### PR TITLE
Fix employee search field not clearing on reset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -773,6 +773,7 @@ function SelectEmployee({employees, value, onChange}:{employees:Employee[]; valu
   const list = useMemo(()=> employees.filter(e=> matchText(q, `${e.firstName} ${e.lastName} ${e.id}`)).slice(0,50), [q,employees]);
   const curr = employees.find(e=>e.id===value);
   useEffect(()=>{ const onDoc=(e:MouseEvent)=>{ if(!ref.current) return; if(!ref.current.contains(e.target as Node)) setOpen(false); }; document.addEventListener("mousedown", onDoc); return ()=> document.removeEventListener("mousedown", onDoc); },[]);
+  useEffect(()=>{ if(!value) setQ(""); },[value]);
   return (
     <div className="dropdown" ref={ref}>
       <input placeholder={curr? `${curr.firstName} ${curr.lastName} (${curr.id})`:"Type name or ID…"} value={q} onChange={e=>{ setQ(e.target.value); setOpen(true); }} onFocus={()=> setOpen(true)} />


### PR DESCRIPTION
## Summary
- Clear employee search dropdown when selection is reset to avoid stale text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TS2304 Cannot find name 'parseCSV' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a47ac750832796da19df1341551f