### PR TITLE
feat: improve employee selectors accessibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import SelectEmployee from "./components/SelectEmployee";
+import EmployeeCombo from "./components/EmployeeCombo";
 
 /**
  * Maplewood Scheduler — Coverage-first (v2.3)
@@ -104,7 +106,6 @@ const isoDate = (d: Date) => `${d.getFullYear()}-${String(d.getMonth()+1).padSta
 const combineDateTime = (dateISO: string, timeHHmm: string) => new Date(`${dateISO}T${timeHHmm}:00`);
 const formatDateLong = (iso: string) => new Date(iso+"T00:00:00").toLocaleDateString(undefined, { month: "long", day: "2-digit", year: "numeric" });
 const formatDowShort = (iso: string) => new Date(iso+"T00:00:00").toLocaleDateString(undefined, { weekday: "short" });
-const matchText = (q: string, label: string) => q.trim().toLowerCase().split(/\s+/).filter(Boolean).every(p => label.toLowerCase().includes(p));
 
 const buildCalendar = (year:number, month:number) => {
   const first = new Date(year, month, 1);
@@ -765,49 +766,6 @@ function VacancyRow({v, recId, recName, employees, countdownLabel, countdownClas
         <button className="btn" onClick={handleAward} disabled={!choice}>Award</button>
       </td>
     </tr>
-  );
-}
-
-function SelectEmployee({employees, value, onChange}:{employees:Employee[]; value:string; onChange:(v:string)=>void}){
-  const [open,setOpen]=useState(false); const [q,setQ]=useState(""); const ref=useRef<HTMLDivElement>(null);
-  const list = useMemo(()=> employees.filter(e=> matchText(q, `${e.firstName} ${e.lastName} ${e.id}`)).slice(0,50), [q,employees]);
-  const curr = employees.find(e=>e.id===value);
-  useEffect(()=>{ const onDoc=(e:MouseEvent)=>{ if(!ref.current) return; if(!ref.current.contains(e.target as Node)) setOpen(false); }; document.addEventListener("mousedown", onDoc); return ()=> document.removeEventListener("mousedown", onDoc); },[]);
-  return (
-    <div className="dropdown" ref={ref}>
-      <input placeholder={curr? `${curr.firstName} ${curr.lastName} (${curr.id})`:"Type name or ID…"} value={q} onChange={e=>{ setQ(e.target.value); setOpen(true); }} onFocus={()=> setOpen(true)} />
-      {open && (
-        <div className="menu">
-          {list.map(e=> (
-            <div key={e.id} className="item" onClick={()=>{ onChange(e.id); setQ(`${e.firstName} ${e.lastName} (${e.id})`); setOpen(false); }}>
-              {e.firstName} {e.lastName} <span className="pill" style={{marginLeft:6}}>{e.classification} {e.status}</span>
-            </div>
-          ))}
-          {!list.length && <div className="item" style={{opacity:.7}}>No matches</div>}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function EmployeeCombo({ employees, onSelect }:{ employees:Employee[]; onSelect:(id:string)=>void }){
-  const [open,setOpen]=useState(false); const [q,setQ]=useState(""); const ref=useRef<HTMLDivElement>(null);
-  const list = useMemo(()=> employees.filter(e=> matchText(q, `${e.firstName} ${e.lastName} ${e.id}`)).slice(0,50), [q,employees]);
-  useEffect(()=>{ const onDoc=(e:MouseEvent)=>{ if(!ref.current) return; if(!ref.current.contains(e.target as Node)) setOpen(false); }; document.addEventListener("mousedown", onDoc); return ()=> document.removeEventListener("mousedown", onDoc); },[]);
-  return (
-    <div className="dropdown" ref={ref}>
-      <input placeholder="Type name or ID…" value={q} onChange={e=>{ setQ(e.target.value); setOpen(true); }} onFocus={()=> setOpen(true)} />
-      {open && (
-        <div className="menu">
-          {list.map(e=> (
-            <div key={e.id} className="item" onClick={()=>{ onSelect(e.id); setQ(`${e.firstName} ${e.lastName} (${e.id})`); setOpen(false); }}>
-              {e.firstName} {e.lastName} <span className="pill" style={{marginLeft:6}}>{e.classification} {e.status}</span>
-            </div>
-          ))}
-          {!list.length && <div className="item" style={{opacity:.7}}>No matches</div>}
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/src/components/EmployeeCombo.tsx
+++ b/src/components/EmployeeCombo.tsx
@@ -1,0 +1,150 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useId,
+  KeyboardEvent,
+} from "react";
+import type { Employee } from "../App";
+
+function matchText(q: string, label: string) {
+  return q
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((p) => label.toLowerCase().includes(p));
+}
+
+export default function EmployeeCombo({
+  employees,
+  onSelect,
+}: {
+  employees: Employee[];
+  onSelect: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listId = useId();
+
+  const list = useMemo(
+    () =>
+      employees
+        .filter((e) =>
+          matchText(q, `${e.firstName} ${e.lastName} ${e.id}`)
+        )
+        .slice(0, 50),
+    [q, employees]
+  );
+
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!wrapperRef.current) return;
+      if (!wrapperRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  useEffect(() => {
+    if (highlight >= list.length) {
+      setHighlight(Math.max(0, list.length - 1));
+    }
+  }, [list.length, highlight]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!open) {
+        setOpen(true);
+        setHighlight(0);
+      } else {
+        setHighlight((h) => Math.min(h + 1, list.length - 1));
+      }
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!open) {
+        setOpen(true);
+        setHighlight(list.length - 1);
+      } else {
+        setHighlight((h) => Math.max(h - 1, 0));
+      }
+    } else if (e.key === "Enter") {
+      if (!open) return;
+      e.preventDefault();
+      const item = list[highlight];
+      if (item) {
+        onSelect(item.id);
+        setQ(`${item.firstName} ${item.lastName} (${item.id})`);
+        setOpen(false);
+        inputRef.current?.focus();
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setOpen(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  return (
+    <div className="dropdown" ref={wrapperRef}>
+      <input
+        ref={inputRef}
+        role="combobox"
+        aria-controls={`${listId}-listbox`}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && list[highlight]
+            ? `${listId}-option-${list[highlight].id}`
+            : undefined
+        }
+        placeholder="Type name or ID…"
+        value={q}
+        onChange={(e) => {
+          setQ(e.target.value);
+          setOpen(true);
+          setHighlight(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+      />
+      {open && (
+        <div className="menu" role="listbox" id={`${listId}-listbox`}>
+          {list.map((e, idx) => (
+            <div
+              key={e.id}
+              role="option"
+              id={`${listId}-option-${e.id}`}
+              className={`item${idx === highlight ? " active" : ""}`}
+              aria-selected={idx === highlight}
+              onMouseDown={(ev) => {
+                ev.preventDefault();
+                onSelect(e.id);
+                setQ(`${e.firstName} ${e.lastName} (${e.id})`);
+                setOpen(false);
+                inputRef.current?.focus();
+              }}
+            >
+              {e.firstName} {e.lastName}{" "}
+              <span className="pill" style={{ marginLeft: 6 }}>
+                {e.classification} {e.status}
+              </span>
+            </div>
+          ))}
+          {!list.length && (
+            <div className="item" style={{ opacity: 0.7 }}>
+              No matches
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/SelectEmployee.tsx
+++ b/src/components/SelectEmployee.tsx
@@ -1,0 +1,158 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useId,
+  KeyboardEvent,
+} from "react";
+import type { Employee } from "../App";
+
+function matchText(q: string, label: string) {
+  return q
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((p) => label.toLowerCase().includes(p));
+}
+
+export default function SelectEmployee({
+  employees,
+  value,
+  onChange,
+}: {
+  employees: Employee[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listId = useId();
+
+  const list = useMemo(
+    () =>
+      employees
+        .filter((e) =>
+          matchText(q, `${e.firstName} ${e.lastName} ${e.id}`)
+        )
+        .slice(0, 50),
+    [q, employees]
+  );
+
+  const curr = employees.find((e) => e.id === value);
+
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!wrapperRef.current) return;
+      if (!wrapperRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  useEffect(() => {
+    if (highlight >= list.length) {
+      setHighlight(Math.max(0, list.length - 1));
+    }
+  }, [list.length, highlight]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!open) {
+        setOpen(true);
+        setHighlight(0);
+      } else {
+        setHighlight((h) => Math.min(h + 1, list.length - 1));
+      }
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!open) {
+        setOpen(true);
+        setHighlight(list.length - 1);
+      } else {
+        setHighlight((h) => Math.max(h - 1, 0));
+      }
+    } else if (e.key === "Enter") {
+      if (!open) return;
+      e.preventDefault();
+      const item = list[highlight];
+      if (item) {
+        onChange(item.id);
+        setQ(`${item.firstName} ${item.lastName} (${item.id})`);
+        setOpen(false);
+        inputRef.current?.focus();
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      setOpen(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  return (
+    <div className="dropdown" ref={wrapperRef}>
+      <input
+        ref={inputRef}
+        role="combobox"
+        aria-controls={`${listId}-listbox`}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-autocomplete="list"
+        aria-activedescendant={
+          open && list[highlight]
+            ? `${listId}-option-${list[highlight].id}`
+            : undefined
+        }
+        placeholder={
+          curr
+            ? `${curr.firstName} ${curr.lastName} (${curr.id})`
+            : "Type name or ID…"
+        }
+        value={q}
+        onChange={(e) => {
+          setQ(e.target.value);
+          setOpen(true);
+          setHighlight(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+      />
+      {open && (
+        <div className="menu" role="listbox" id={`${listId}-listbox`}>
+          {list.map((e, idx) => (
+            <div
+              key={e.id}
+              role="option"
+              id={`${listId}-option-${e.id}`}
+              className={`item${idx === highlight ? " active" : ""}`}
+              aria-selected={idx === highlight}
+              onMouseDown={(ev) => {
+                ev.preventDefault();
+                onChange(e.id);
+                setQ(`${e.firstName} ${e.lastName} (${e.id})`);
+                setOpen(false);
+                inputRef.current?.focus();
+              }}
+            >
+              {e.firstName} {e.lastName}{" "}
+              <span className="pill" style={{ marginLeft: 6 }}>
+                {e.classification} {e.status}
+              </span>
+            </div>
+          ))}
+          {!list.length && (
+            <div className="item" style={{ opacity: 0.7 }}>
+              No matches
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract SelectEmployee and EmployeeCombo components
- add ARIA combobox, listbox and option roles with keyboard navigation
- return focus to input after selecting or closing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find name 'parseCSV', const assertions errors, implicit any)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a74cf01c8327882bbd1cb300b033