### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Maplewood Scheduler (Vite + React + TS)
 
+[![CI](https://github.com/OWNER/maplewood-scheduler/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/maplewood-scheduler/actions/workflows/ci.yml)
+
 ## Run locally
 ```bash
 npm install
@@ -14,3 +16,7 @@ npm run build
 ### Deploy options
 - **Netlify Drop**: drag the `dist/` folder to https://app.netlify.com/drop
 - **Connect Git**: push this folder to GitHub and connect it in Netlify. Build command: `npm run build`, Publish dir: `dist`.
+
+## Continuous Integration
+
+This project uses [GitHub Actions](.github/workflows/ci.yml) to run `npm run typecheck` and `npm test` on pushes to and pull requests targeting `main`.


### PR DESCRIPTION
## Summary
- add CI workflow that installs dependencies, runs typecheck and tests
- document CI with badge and description in README

## Testing
- `npm run typecheck` *(fails: Cannot find name 'parseCSV'; parameter 'prev' implicitly has an 'any' type)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8a758f04083278faf7d5d2242db42