### PR TITLE
chore: align package version with release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maplewood-scheduler",
   "private": true,
-  "version": "0.0.0",
+  "version": "2.3.0",
   "type": "module",
   "engines": {
     "node": "18.20.8"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 /**
- * Maplewood Scheduler — Coverage-first (v2.3)
+ * Maplewood Scheduler — Coverage-first (v2.3.0)
  *
- * New in v2.3 (per your request):
+ * New in v2.3.0 (per your request):
  * ✔ Live countdown timers on each vacancy row (color shifts to yellow/red as deadline nears)
  * ✔ Auto "knownAt" (already existed) + per-row “Reset knownAt” button for re‑announcing
  * ✔ Sticky table header for Open Vacancies + scrollable panel; highlight the row that’s “due next”


### PR DESCRIPTION
## Summary
- set project version to 2.3.0
- update header comment to reflect v2.3.0 release

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: Cannot find name 'parseCSV', const assertions errors, implicit any)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aa97ec848327b4d170c1beb251be