### PR TITLE
Fix cancellationRate string in analytics PDF export

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -27,7 +27,12 @@ app.get('/api/analytics/export', (req, res) => {
     doc.pipe(res);
     doc.fontSize(16).text('Analytics');
     data.forEach(row => {
-      doc.fontSize(12).text(`${row.period}: posted ${row.posted}, awarded ${row.awarded}, cancelled ${row.cancelled}, cancellationRate ${(row.cancellationRate * 100).toFixed(2)}%, overtime ${row.overtime}`);
+      doc
+        .fontSize(12)
+        .text(
+          `${row.period}: posted ${row.posted}, awarded ${row.awarded}, cancelled ${row.cancelled}, ` +
+            `cancellationRate ${(row.cancellationRate * 100).toFixed(2)}%, overtime ${row.overtime}`
+        );
     });
     doc.end();
   } else {


### PR DESCRIPTION
## Summary
- format analytics PDF export string without breaking `cancellationRate`

## Testing
- `npm test`
- `pdftotext /tmp/analytics.pdf /tmp/analytics.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a8be2c2e448327afaf75ce13074000