### PR TITLE
feat: require token auth for analytics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ npm run dev
 npm run build
 ```
 
+## Analytics API authentication
+
+The analytics endpoints require a bearer token for access.
+
+1. Set a secret token in the `ANALYTICS_AUTH_TOKEN` environment variable.
+2. Include an `Authorization: Bearer <token>` header on requests to `/api/analytics` and `/api/analytics/export`.
+3. Requests missing or providing an invalid token will receive `401 Unauthorized`.
+
+Example:
+
+```bash
+export ANALYTICS_AUTH_TOKEN=mys3cret
+npm run server
+```
+
 ## Responsive design
 - Mobile breakpoint at **600px** is defined in `src/styles/responsive.css`.
 - Use the `responsive-table` class on tables and `form-row` for grouped form inputs to stack vertically on narrow screens.

--- a/server/index.js
+++ b/server/index.js
@@ -6,12 +6,22 @@ import { aggregateByMonth, sampleVacancies } from './metrics.js';
 const app = express();
 app.use(cors());
 
-app.get('/api/analytics', (req, res) => {
+const AUTH_TOKEN = process.env.ANALYTICS_AUTH_TOKEN;
+
+function requireAuth(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!AUTH_TOKEN || authHeader !== `Bearer ${AUTH_TOKEN}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+}
+
+app.get('/api/analytics', requireAuth, (req, res) => {
   const data = aggregateByMonth(sampleVacancies);
   res.json(data);
 });
 
-app.get('/api/analytics/export', (req, res) => {
+app.get('/api/analytics/export', requireAuth, (req, res) => {
   const format = req.query.format;
   const data = aggregateByMonth(sampleVacancies);
   if (format === 'csv') {


### PR DESCRIPTION
## Summary
- add bearer-token middleware to `/api/analytics` and `/api/analytics/export`
- document `ANALYTICS_AUTH_TOKEN` environment variable for authentication

## Testing
- `npm test`
- `curl -i http://localhost:3000/api/analytics` *(401)*
- `curl -i -H "Authorization: Bearer secret" http://localhost:3000/api/analytics` *(200)*

------
https://chatgpt.com/codex/tasks/task_e_68a8be266b9c832794b84fe78dbe1e07