### PR TITLE
Handle optional analytics auth token

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,8 @@
+export function requireAuth(req, res, next) {
+  const token = process.env.ANALYTICS_AUTH_TOKEN;
+  const authHeader = req.headers.authorization;
+  if (token && authHeader !== `Bearer ${token}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+}

--- a/server/index.js
+++ b/server/index.js
@@ -2,19 +2,10 @@ import express from 'express';
 import cors from 'cors';
 import PDFDocument from 'pdfkit';
 import { aggregateByMonth, sampleVacancies } from './metrics.js';
+import { requireAuth } from './auth.js';
 
 const app = express();
 app.use(cors());
-
-const AUTH_TOKEN = process.env.ANALYTICS_AUTH_TOKEN;
-
-function requireAuth(req, res, next) {
-  const authHeader = req.headers.authorization;
-  if (!AUTH_TOKEN || authHeader !== `Bearer ${AUTH_TOKEN}`) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
-  next();
-}
 
 app.get('/api/analytics', requireAuth, (req, res) => {
   const data = aggregateByMonth(sampleVacancies);

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { requireAuth } from '../server/auth.js';
+
+describe('requireAuth', () => {
+  beforeEach(() => {
+    delete process.env.ANALYTICS_AUTH_TOKEN;
+  });
+
+  it('allows requests when no token is configured', () => {
+    const req: any = { headers: {} };
+    const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('rejects requests with invalid token', () => {
+    process.env.ANALYTICS_AUTH_TOKEN = 'secret';
+    const req: any = { headers: { authorization: 'Bearer wrong' } };
+    const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+    requireAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows requests with valid token', () => {
+    process.env.ANALYTICS_AUTH_TOKEN = 'secret';
+    const req: any = { headers: { authorization: 'Bearer secret' } };
+    const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- export requireAuth middleware that only checks for a token when configured
- update server to import new middleware
- add tests for middleware behavior

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8cd7403c88327b95799e091359d12