### PR TITLE
feat: add vacancy offering tier progression

### DIFF
--- a/docs/offering.md
+++ b/docs/offering.md
@@ -1,0 +1,16 @@
+# Offering Workflow
+
+Vacancies progress through a sequence of offering tiers. Each tier represents a
+pool of employees eligible to cover the vacancy.
+
+1. **Casuals** – default tier when a vacancy is created.
+2. **OT – Full-Time**
+3. **OT – Casuals**
+4. **Last Resort – RN** – requires confirmation before activation.
+
+When a vacancy is created, the offering round starts immediately and lasts 120
+minutes by default. A countdown timer tracks the remaining time. When the timer
+expires and auto‑advance is enabled, the system automatically moves to the next
+tier and logs the change to the audit log. Managers can adjust the round length,
+turn auto‑advance on or off, or manually change tiers at any time. Manual
+changes also log to the audit trail and optionally capture a free‑text note.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Analytics from "./Analytics";
 import { recommend, Recommendation } from "./recommend";
+import type { OfferingTier } from "./offering/offeringMachine";
 
 /**
  * Maplewood Scheduler — Coverage-first (v2.3.0)
@@ -53,6 +54,10 @@ export type Vacancy = {
   shiftStart: string; // HH:mm
   shiftEnd: string;   // HH:mm
   knownAt: string;    // ISO datetime
+  offeringTier: OfferingTier;
+  offeringRoundStartedAt?: string;
+  offeringRoundMinutes?: number;
+  offeringAutoProgress?: boolean;
   offeringStep: "Casuals" | "OT-Regular" | "OT-Casuals";
   status: "Open" | "Pending Award" | "Awarded";
   awardedTo?: string;        // employeeId
@@ -168,7 +173,15 @@ export default function App(){
 
   const [employees, setEmployees] = useState<Employee[]>(persisted?.employees ?? []);
   const [vacations, setVacations] = useState<Vacation[]>(persisted?.vacations ?? []);
-  const [vacancies, setVacancies] = useState<Vacancy[]>(persisted?.vacancies ?? []);
+  const [vacancies, setVacancies] = useState<Vacancy[]>(
+    (persisted?.vacancies ?? []).map((v: any) => ({
+      offeringTier: 'CASUALS',
+      offeringRoundStartedAt: v.offeringRoundStartedAt ?? new Date().toISOString(),
+      offeringRoundMinutes: v.offeringRoundMinutes ?? 120,
+      offeringAutoProgress: v.offeringAutoProgress ?? true,
+      ...v,
+    }))
+  );
   const [bids, setBids] = useState<Bid[]>(persisted?.bids ?? []);
   const [settings, setSettings] = useState<Settings>({ ...defaultSettings, ...(persisted?.settings ?? {}) });
 
@@ -250,6 +263,10 @@ export default function App(){
       shiftStart: v.shiftStart ?? SHIFT_PRESETS[0].start,
       shiftEnd: v.shiftEnd ?? SHIFT_PRESETS[0].end,
       knownAt: nowISO,
+      offeringTier: 'CASUALS',
+      offeringRoundStartedAt: nowISO,
+      offeringRoundMinutes: 120,
+      offeringAutoProgress: true,
       offeringStep: "Casuals",
       status: "Open",
     }));

--- a/src/components/OfferingControls.tsx
+++ b/src/components/OfferingControls.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { TIERS, tierLabel, OfferingTier, requiresConfirmation } from '../offering/offeringMachine';
+import { UseOfferingRound } from '../offering/useOfferingRound';
+
+interface Props {
+  vacancy: {
+    offeringTier: OfferingTier;
+    offeringAutoProgress?: boolean;
+    offeringRoundMinutes?: number;
+  };
+  round: UseOfferingRound;
+}
+
+/**
+ * UI controls for managing the offering tier on a vacancy.
+ * Simplified for demo/testing purposes.
+ */
+export default function OfferingControls({ vacancy, round }: Props) {
+  const [pendingTier, setPendingTier] = useState<OfferingTier | null>(null);
+  const [note, setNote] = useState('');
+
+  const onSelect = (tier: OfferingTier) => {
+    if (requiresConfirmation(tier)) {
+      setPendingTier(tier);
+    } else {
+      round.onManualChangeTier(tier);
+    }
+  };
+
+  const confirm = () => {
+    if (pendingTier) {
+      round.onManualChangeTier(pendingTier, note || undefined);
+      setPendingTier(null);
+      setNote('');
+    }
+  };
+
+  const mins = Math.max(0, Math.floor(round.timeLeftMs / 60000));
+  const secs = Math.max(0, Math.floor((round.timeLeftMs % 60000) / 1000));
+
+  let countdownClass = '';
+  if (round.timeLeftMs <= 5 * 60000) countdownClass = 'red';
+  else if (round.timeLeftMs <= 30 * 60000) countdownClass = 'yellow';
+
+  return (
+    <div className="offering-controls">
+      <div role="radiogroup" aria-label="Offering Tier">
+        {TIERS.map((t) => (
+          <label key={t} style={{ marginRight: '0.5rem' }}>
+            <input
+              type="radio"
+              name="tier"
+              checked={vacancy.offeringTier === t}
+              onChange={() => onSelect(t)}
+            />
+            {tierLabel(t)}
+          </label>
+        ))}
+      </div>
+      <div className={`countdown ${countdownClass}`} aria-live="polite">
+        {String(mins).padStart(2, '0')}:{String(secs).padStart(2, '0')}
+      </div>
+      <label>
+        <input
+          type="checkbox"
+          checked={vacancy.offeringAutoProgress !== false}
+          onChange={(e) => round.onToggleAutoProgress(e.target.checked)}
+        />{' '}
+        Auto-advance
+      </label>
+      <label>
+        Round length (min)
+        <input
+          type="number"
+          value={vacancy.offeringRoundMinutes ?? 120}
+          onChange={(e) => round.setRoundMinutes(Number(e.target.value))}
+        />
+      </label>
+      {pendingTier && (
+        <div role="alertdialog" aria-modal="true" className="modal">
+          <p>Confirm Last Resort RN</p>
+          <p>This tier is intended only when all other options are exhausted. Proceed?</p>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Reason / notes"
+          />
+          <div>
+            <button onClick={() => setPendingTier(null)}>Cancel</button>
+            <button onClick={confirm}>Confirm</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/VacancyDetail.tsx
+++ b/src/components/VacancyDetail.tsx
@@ -1,0 +1,21 @@
+import OfferingControls from './OfferingControls';
+import { useOfferingRound, Vacancy } from '../offering/useOfferingRound';
+
+// Dummy store placeholder for demo/testing
+function useVacancyStore() {
+  return {
+    updateVacancy: (_id: string, _patch: Partial<Vacancy>) => {},
+    currentUser: 'demo-user',
+  };
+}
+
+export default function VacancyDetail({ vacancy }: { vacancy: Vacancy }) {
+  const { updateVacancy, currentUser } = useVacancyStore();
+  const round = useOfferingRound(vacancy, (patch) => updateVacancy(vacancy.id, patch), currentUser);
+  return (
+    <div>
+      <h2>Vacancy Detail</h2>
+      <OfferingControls vacancy={vacancy} round={round} />
+    </div>
+  );
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,78 @@
+import { OfferingTier } from '../offering/offeringMachine';
+
+export interface AuditLog {
+  id: string;
+  ts: string;
+  actor: string; // 'system' or user id
+  action: 'OFFERING_TIER_CHANGED';
+  targetType: 'Vacancy';
+  targetId: string;
+  details: {
+    from: OfferingTier;
+    to: OfferingTier;
+    reason: 'auto-progress' | 'manual';
+    note?: string;
+  };
+}
+
+const KEY = 'auditLogs';
+
+function read(): AuditLog[] {
+  if (typeof localStorage !== 'undefined') {
+    try {
+      const raw = localStorage.getItem(KEY);
+      return raw ? (JSON.parse(raw) as AuditLog[]) : [];
+    } catch {
+      return [];
+    }
+  }
+  // Node/test environment fallback
+  (globalThis as any).__AUDIT__ = (globalThis as any).__AUDIT__ || [];
+  return (globalThis as any).__AUDIT__;
+}
+
+function write(logs: AuditLog[]) {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(KEY, JSON.stringify(logs));
+  } else {
+    (globalThis as any).__AUDIT__ = logs;
+  }
+}
+
+export function logOfferingChange({
+  vacancyId,
+  from,
+  to,
+  actor,
+  reason,
+  note,
+}: {
+  vacancyId: string;
+  from: OfferingTier;
+  to: OfferingTier;
+  actor: string;
+  reason: 'auto-progress' | 'manual';
+  note?: string;
+}): AuditLog {
+  const log: AuditLog = {
+    id: typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2),
+    ts: new Date().toISOString(),
+    actor,
+    action: 'OFFERING_TIER_CHANGED',
+    targetType: 'Vacancy',
+    targetId: vacancyId,
+    details: { from, to, reason, note },
+  };
+  const logs = read();
+  logs.push(log);
+  write(logs);
+  return log;
+}
+
+export function getAuditLogs(): AuditLog[] {
+  return read();
+}
+
+export function clearAuditLogs() {
+  write([]);
+}

--- a/src/offering/offeringMachine.ts
+++ b/src/offering/offeringMachine.ts
@@ -1,0 +1,36 @@
+export type OfferingTier = 'CASUALS' | 'OT_FULL_TIME' | 'OT_CASUALS' | 'LAST_RESORT_RN';
+
+export const TIERS: OfferingTier[] = ['CASUALS', 'OT_FULL_TIME', 'OT_CASUALS', 'LAST_RESORT_RN'];
+
+/**
+ * Return the next tier in the offering sequence or null if at the end.
+ */
+export function nextTier(tier: OfferingTier): OfferingTier | null {
+  const idx = TIERS.indexOf(tier);
+  return idx >= 0 && idx < TIERS.length - 1 ? TIERS[idx + 1] : null;
+}
+
+/**
+ * Human readable labels for each tier.
+ */
+export function tierLabel(tier: OfferingTier): string {
+  switch (tier) {
+    case 'CASUALS':
+      return 'Casuals';
+    case 'OT_FULL_TIME':
+      return 'OT – Full-Time';
+    case 'OT_CASUALS':
+      return 'OT – Casuals';
+    case 'LAST_RESORT_RN':
+      return 'Last Resort – RN';
+    default:
+      return tier;
+  }
+}
+
+/**
+ * Whether switching to the given tier requires a confirmation modal.
+ */
+export function requiresConfirmation(tier: OfferingTier): boolean {
+  return tier === 'LAST_RESORT_RN';
+}

--- a/src/offering/useOfferingRound.ts
+++ b/src/offering/useOfferingRound.ts
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from 'react';
+import { OfferingTier, nextTier } from './offeringMachine';
+import { logOfferingChange } from '../lib/audit';
+
+export interface Vacancy {
+  id: string;
+  offeringTier: OfferingTier;
+  offeringRoundStartedAt?: string;
+  offeringRoundMinutes?: number;
+  offeringAutoProgress?: boolean;
+}
+
+export interface UseOfferingRound {
+  timeLeftMs: number;
+  isExpired: boolean;
+  onResetRound: () => void;
+  onManualChangeTier: (next: OfferingTier, note?: string) => void;
+  onToggleAutoProgress: (enabled: boolean) => void;
+  setRoundMinutes: (mins: number) => void;
+}
+
+interface RoundOptions {
+  updateVacancy: (patch: Partial<Vacancy>) => void;
+  currentUser: string;
+  onTick?: (msLeft: number) => void;
+}
+
+/**
+ * Internal non-react implementation for easier testing.
+ */
+export function createOfferingRound(vac: Vacancy, opts: RoundOptions) {
+  let interval: any;
+  const getRoundMinutes = () => vac.offeringRoundMinutes ?? 120;
+
+  const computeMsLeft = () => {
+    const started = vac.offeringRoundStartedAt
+      ? new Date(vac.offeringRoundStartedAt).getTime()
+      : Date.now();
+    return started + getRoundMinutes() * 60000 - Date.now();
+  };
+
+  const tick = () => {
+    const msLeft = computeMsLeft();
+    opts.onTick?.(msLeft);
+    if (msLeft <= 0 && vac.offeringAutoProgress !== false) {
+      const next = nextTier(vac.offeringTier);
+      if (next) {
+        const from = vac.offeringTier;
+        vac.offeringTier = next;
+        vac.offeringRoundStartedAt = new Date().toISOString();
+        opts.updateVacancy({
+          offeringTier: next,
+          offeringRoundStartedAt: vac.offeringRoundStartedAt,
+        });
+        logOfferingChange({
+          vacancyId: vac.id,
+          from,
+          to: next,
+          actor: 'system',
+          reason: 'auto-progress',
+        });
+        opts.onTick?.(computeMsLeft());
+      }
+    }
+  };
+
+  interval = setInterval(tick, 60000);
+  tick();
+
+  return {
+    onResetRound() {
+      vac.offeringRoundStartedAt = new Date().toISOString();
+      opts.updateVacancy({ offeringRoundStartedAt: vac.offeringRoundStartedAt });
+      opts.onTick?.(computeMsLeft());
+    },
+    onManualChangeTier(next: OfferingTier, note?: string) {
+      const from = vac.offeringTier;
+      vac.offeringTier = next;
+      vac.offeringRoundStartedAt = new Date().toISOString();
+      opts.updateVacancy({
+        offeringTier: next,
+        offeringRoundStartedAt: vac.offeringRoundStartedAt,
+      });
+      logOfferingChange({
+        vacancyId: vac.id,
+        from,
+        to: next,
+        actor: opts.currentUser,
+        reason: 'manual',
+        note,
+      });
+      opts.onTick?.(computeMsLeft());
+    },
+    onToggleAutoProgress(enabled: boolean) {
+      vac.offeringAutoProgress = enabled;
+      opts.updateVacancy({ offeringAutoProgress: enabled });
+    },
+    setRoundMinutes(mins: number) {
+      vac.offeringRoundMinutes = mins;
+      opts.updateVacancy({ offeringRoundMinutes: mins });
+      opts.onTick?.(computeMsLeft());
+    },
+    dispose() {
+      clearInterval(interval);
+    },
+  };
+}
+
+export function useOfferingRound(
+  vac: Vacancy,
+  updateVacancy: (patch: Partial<Vacancy>) => void,
+  currentUser: string
+): UseOfferingRound {
+  const roundRef = useRef<ReturnType<typeof createOfferingRound>>();
+  const [timeLeftMs, setTimeLeftMs] = useState(0);
+
+  useEffect(() => {
+    roundRef.current?.dispose();
+    roundRef.current = createOfferingRound(vac, {
+      updateVacancy,
+      currentUser,
+      onTick: setTimeLeftMs,
+    });
+    return () => roundRef.current?.dispose();
+  }, [vac, updateVacancy, currentUser]);
+
+  return {
+    timeLeftMs,
+    isExpired: timeLeftMs <= 0,
+    onResetRound: () => roundRef.current?.onResetRound(),
+    onManualChangeTier: (n, note) => roundRef.current?.onManualChangeTier(n, note),
+    onToggleAutoProgress: (e) => roundRef.current?.onToggleAutoProgress(e),
+    setRoundMinutes: (m) => roundRef.current?.setRoundMinutes(m),
+  };
+}

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -1,3 +1,5 @@
+import type { OfferingTier } from './offering/offeringMachine';
+
 export type Recommendation = {
   id?: string;
   why: string[];
@@ -6,6 +8,10 @@ export type Recommendation = {
 export interface Vacancy {
   id: string;
   classification: string;
+  offeringTier: OfferingTier;
+  offeringRoundStartedAt?: string;
+  offeringRoundMinutes?: number;
+  offeringAutoProgress?: boolean;
 }
 
 export interface Bid {

--- a/tests/offering.test.ts
+++ b/tests/offering.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { nextTier, requiresConfirmation } from '../src/offering/offeringMachine';
+import { createOfferingRound, Vacancy } from '../src/offering/useOfferingRound';
+import { getAuditLogs, clearAuditLogs } from '../src/lib/audit';
+
+describe('offeringMachine', () => {
+  it('nextTier returns correct next/null', () => {
+    expect(nextTier('CASUALS')).toBe('OT_FULL_TIME');
+    expect(nextTier('OT_CASUALS')).toBe('LAST_RESORT_RN');
+    expect(nextTier('LAST_RESORT_RN')).toBeNull();
+  });
+
+  it('requires confirmation for last resort', () => {
+    expect(requiresConfirmation('LAST_RESORT_RN')).toBe(true);
+    expect(requiresConfirmation('CASUALS')).toBe(false);
+  });
+});
+
+describe('useOfferingRound', () => {
+  beforeEach(() => {
+    clearAuditLogs();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('auto-advance triggers after round length', () => {
+    const vac: Vacancy = {
+      id: '1',
+      offeringTier: 'CASUALS',
+      offeringRoundStartedAt: new Date().toISOString(),
+      offeringRoundMinutes: 1,
+      offeringAutoProgress: true,
+    };
+    const round = createOfferingRound(vac, {
+      updateVacancy: () => {},
+      currentUser: 'system',
+      onTick: () => {},
+    });
+    vi.advanceTimersByTime(60000);
+    expect(vac.offeringTier).toBe('OT_FULL_TIME');
+    const logs = getAuditLogs();
+    expect(logs[0].details.reason).toBe('auto-progress');
+    round.dispose();
+  });
+
+  it('manual change writes AuditLog with actor, from, to, reason', () => {
+    const vac: Vacancy = {
+      id: '1',
+      offeringTier: 'CASUALS',
+      offeringRoundStartedAt: new Date().toISOString(),
+      offeringRoundMinutes: 5,
+      offeringAutoProgress: true,
+    };
+    const round = createOfferingRound(vac, {
+      updateVacancy: () => {},
+      currentUser: 'manager',
+      onTick: () => {},
+    });
+    round.onManualChangeTier('OT_FULL_TIME', 'need coverage');
+    const logs = getAuditLogs();
+    expect(logs[0].actor).toBe('manager');
+    expect(logs[0].details.from).toBe('CASUALS');
+    expect(logs[0].details.to).toBe('OT_FULL_TIME');
+    expect(logs[0].details.reason).toBe('manual');
+    expect(logs[0].details.note).toBe('need coverage');
+    round.dispose();
+  });
+
+  it('toggling auto-progress stops/starts auto advance', () => {
+    const vac: Vacancy = {
+      id: '1',
+      offeringTier: 'CASUALS',
+      offeringRoundStartedAt: new Date().toISOString(),
+      offeringRoundMinutes: 1,
+      offeringAutoProgress: true,
+    };
+    const round = createOfferingRound(vac, {
+      updateVacancy: () => {},
+      currentUser: 'manager',
+      onTick: () => {},
+    });
+    round.onToggleAutoProgress(false);
+    vi.advanceTimersByTime(60000);
+    expect(vac.offeringTier).toBe('CASUALS');
+    round.onToggleAutoProgress(true);
+    round.onResetRound();
+    vi.advanceTimersByTime(60000);
+    expect(vac.offeringTier).toBe('OT_FULL_TIME');
+    round.dispose();
+  });
+});

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -17,7 +17,7 @@ const bids = [
 
 describe('recommend', () => {
   it('returns highest seniority matching class', () => {
-    const vac = { id: 'vac1', classification: 'RN' };
+    const vac = { id: 'vac1', classification: 'RN', offeringTier: 'CASUALS' };
     const rec = recommend(vac, bids, employees);
     expect(rec.id).toBe('b');
     expect(rec.why).toContain('Bidder');
@@ -26,7 +26,7 @@ describe('recommend', () => {
   });
 
   it('reports when there are no eligible bidders', () => {
-    const vac = { id: 'vac2', classification: 'RN' };
+    const vac = { id: 'vac2', classification: 'RN', offeringTier: 'CASUALS' };
     const rec = recommend(vac, bids, employees);
     expect(rec.id).toBeUndefined();
     expect(rec.why[0]).toBe('No eligible bidders');


### PR DESCRIPTION
## Summary
- control offering tiers via new `OfferingControls` and timer hook
- auto-advance tiers with strict audit logging
- document offering workflow

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8d7d6c3848327a03dd1915f0329e3