### PR TITLE
Fix quoted field whitespace handling in CSV parser

### DIFF
--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -21,6 +21,7 @@ function splitLine(line: string): string[] {
   const result: string[] = [];
   let current = "";
   let inQuotes = false;
+  let wasQuoted = false;
   for (let i = 0; i < line.length; i++) {
     const char = line[i];
     if (char === '"') {
@@ -29,14 +30,19 @@ function splitLine(line: string): string[] {
         i++; // skip escaped quote
       } else {
         inQuotes = !inQuotes;
+        if (inQuotes && current === "") {
+          // entering quotes at start of field
+          wasQuoted = true;
+        }
       }
     } else if (char === ',' && !inQuotes) {
-      result.push(current.trim());
+      result.push(wasQuoted ? current : current.trim());
       current = "";
+      wasQuoted = false;
     } else {
       current += char;
     }
   }
-  result.push(current.trim());
+  result.push(wasQuoted ? current : current.trim());
   return result;
 }

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -18,4 +18,12 @@ describe('parseCSV', () => {
       { id: '1', name: 'Doe, John' }
     ]);
   });
+
+  it('preserves whitespace inside quoted fields', () => {
+    const input = 'id,name\n1,"  John  "';
+    const rows = parseCSV(input);
+    expect(rows).toEqual([
+      { id: '1', name: '  John  ' }
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- preserve whitespace inside quoted CSV fields by tracking quote state
- add regression test ensuring quoted whitespace is retained

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8da23ab5c8327b049cc7c0222b558