### PR TITLE
Preserve whitespace in quoted CSV fields

### DIFF
--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -21,6 +21,7 @@ function splitLine(line: string): string[] {
   const result: string[] = [];
   let current = "";
   let inQuotes = false;
+  let fieldWasQuoted = false;
   for (let i = 0; i < line.length; i++) {
     const char = line[i];
     if (char === '"') {
@@ -29,14 +30,19 @@ function splitLine(line: string): string[] {
         i++; // skip escaped quote
       } else {
         inQuotes = !inQuotes;
+        if (inQuotes) fieldWasQuoted = true;
       }
     } else if (char === ',' && !inQuotes) {
-      result.push(current.trim());
+      result.push(fieldWasQuoted ? current : current.trim());
       current = "";
+      fieldWasQuoted = false;
     } else {
+      if (!inQuotes && fieldWasQuoted && (char === ' ' || char === '\t')) {
+        continue;
+      }
       current += char;
     }
   }
-  result.push(current.trim());
+  result.push(fieldWasQuoted ? current : current.trim());
   return result;
 }

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -18,4 +18,12 @@ describe('parseCSV', () => {
       { id: '1', name: 'Doe, John' }
     ]);
   });
+
+  it('preserves spaces inside quoted fields', () => {
+    const input = 'id,name\n1," John "';
+    const rows = parseCSV(input);
+    expect(rows).toEqual([
+      { id: '1', name: ' John ' }
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- Track whether CSV fields were quoted and trim only unquoted ones
- Keep surrounding spaces for quoted fields
- Add unit test for whitespace preservation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8daec3df88327b29174c8ed18b4a0