### PR TITLE
feat: allow empty vacancy award

### DIFF
--- a/tests/awardVacancy.test.ts
+++ b/tests/awardVacancy.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { applyAwardVacancy, type Vacancy } from '../src/App';
+
+describe('applyAwardVacancy', () => {
+  it('stores undefined when empId is EMPTY', () => {
+    const vac: Vacancy = {
+      id: 'v1',
+      reason: 'Test',
+      classification: 'RN',
+      shiftDate: '2024-01-01',
+      shiftStart: '08:00',
+      shiftEnd: '16:00',
+      knownAt: '2024-01-01T00:00:00.000Z',
+      offeringTier: 'CASUALS',
+      offeringStep: 'Casuals',
+      status: 'Open',
+    };
+    const updated = applyAwardVacancy([vac], 'v1', { empId: 'EMPTY' });
+    expect(updated[0].status).toBe('Awarded');
+    expect(updated[0].awardedTo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- allow selecting an empty employee in vacancy award dropdown
- permit awarding a vacancy without an employee
- test awarding a vacancy with empty selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e2ee972c8327aa7fd985783e7910