### PR TITLE
Refactor offering round state management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maplewood-scheduler",
-  "version": "0.0.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplewood-scheduler",
-      "version": "0.0.0",
+      "version": "2.3.0",
       "dependencies": {
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
@@ -17,6 +17,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
+        "@types/node": "^18.19.123",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@vitejs/plugin-react": "^4.2.0",
@@ -1127,6 +1128,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.123",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
+      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -3798,6 +3809,13 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/node": "^18.19.123",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.0",
-    "vitest": "^1.6.0",
     "typescript": "^5.4.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/components/VacancyDetail.tsx
+++ b/src/components/VacancyDetail.tsx
@@ -15,7 +15,7 @@ export default function VacancyDetail({ vacancy }: { vacancy: Vacancy }) {
   return (
     <div>
       <h2>Vacancy Detail</h2>
-      <OfferingControls vacancy={vacancy} round={round} />
+      <OfferingControls vacancy={round.vacancy} round={round} />
     </div>
   );
 }

--- a/tests/offering.test.ts
+++ b/tests/offering.test.ts
@@ -35,12 +35,11 @@ describe('useOfferingRound', () => {
       offeringAutoProgress: true,
     };
     const round = createOfferingRound(vac, {
-      updateVacancy: () => {},
       currentUser: 'system',
       onTick: () => {},
     });
     vi.advanceTimersByTime(60000);
-    expect(vac.offeringTier).toBe('OT_FULL_TIME');
+    expect(round.getVacancy().offeringTier).toBe('OT_FULL_TIME');
     const logs = getAuditLogs();
     expect(logs[0].details.reason).toBe('auto-progress');
     round.dispose();
@@ -55,11 +54,11 @@ describe('useOfferingRound', () => {
       offeringAutoProgress: true,
     };
     const round = createOfferingRound(vac, {
-      updateVacancy: () => {},
       currentUser: 'manager',
       onTick: () => {},
     });
-    round.onManualChangeTier('OT_FULL_TIME', 'need coverage');
+    const result = round.onManualChangeTier('OT_FULL_TIME', 'need coverage');
+    expect(result.offeringTier).toBe('OT_FULL_TIME');
     const logs = getAuditLogs();
     expect(logs[0].actor).toBe('manager');
     expect(logs[0].details.from).toBe('CASUALS');
@@ -78,17 +77,16 @@ describe('useOfferingRound', () => {
       offeringAutoProgress: true,
     };
     const round = createOfferingRound(vac, {
-      updateVacancy: () => {},
       currentUser: 'manager',
       onTick: () => {},
     });
     round.onToggleAutoProgress(false);
     vi.advanceTimersByTime(60000);
-    expect(vac.offeringTier).toBe('CASUALS');
+    expect(round.getVacancy().offeringTier).toBe('CASUALS');
     round.onToggleAutoProgress(true);
     round.onResetRound();
     vi.advanceTimersByTime(60000);
-    expect(vac.offeringTier).toBe('OT_FULL_TIME');
+    expect(round.getVacancy().offeringTier).toBe('OT_FULL_TIME');
     round.dispose();
   });
 });


### PR DESCRIPTION
## Summary
- manage offering round vacancy data with a local `useReducer` state
- encapsulate timer logic with a typed `NodeJS.Timeout`
- expose reset and tier-change events that return vacancy patches

## Testing
- `npm run -s typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e2b70d3c8327825314a10c9c6700