### PR TITLE
refactor: inject storage into audit

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,23 @@
+export interface Storage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export function createMemoryStorage(): Storage {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+  };
+}
+
+const storage: Storage = typeof localStorage !== 'undefined'
+  ? {
+      getItem: (key: string) => localStorage.getItem(key),
+      setItem: (key: string, value: string) => localStorage.setItem(key, value),
+    }
+  : createMemoryStorage();
+
+export default storage;

--- a/src/offering/useOfferingRound.ts
+++ b/src/offering/useOfferingRound.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { OfferingTier, nextTier } from './offeringMachine';
 import { logOfferingChange } from '../lib/audit';
+import storage from '../lib/storage';
 
 export interface Vacancy {
   id: string;
@@ -58,7 +59,7 @@ export function createOfferingRound(vac: Vacancy, opts: RoundOptions) {
           to: next,
           actor: 'system',
           reason: 'auto-progress',
-        });
+        }, storage);
         opts.onTick?.(computeMsLeft());
       }
     }
@@ -88,7 +89,7 @@ export function createOfferingRound(vac: Vacancy, opts: RoundOptions) {
         actor: opts.currentUser,
         reason: 'manual',
         note,
-      });
+      }, storage);
       opts.onTick?.(computeMsLeft());
     },
     onToggleAutoProgress(enabled: boolean) {

--- a/tests/offering.test.ts
+++ b/tests/offering.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { nextTier, requiresConfirmation } from '../src/offering/offeringMachine';
 import { createOfferingRound, Vacancy } from '../src/offering/useOfferingRound';
 import { getAuditLogs, clearAuditLogs } from '../src/lib/audit';
+import storage from '../src/lib/storage';
 
 describe('offeringMachine', () => {
   it('nextTier returns correct next/null', () => {
@@ -18,7 +19,7 @@ describe('offeringMachine', () => {
 
 describe('useOfferingRound', () => {
   beforeEach(() => {
-    clearAuditLogs();
+    clearAuditLogs(storage);
     vi.useFakeTimers();
   });
   afterEach(() => {
@@ -41,7 +42,7 @@ describe('useOfferingRound', () => {
     });
     vi.advanceTimersByTime(60000);
     expect(vac.offeringTier).toBe('OT_FULL_TIME');
-    const logs = getAuditLogs();
+    const logs = getAuditLogs(storage);
     expect(logs[0].details.reason).toBe('auto-progress');
     round.dispose();
   });
@@ -60,7 +61,7 @@ describe('useOfferingRound', () => {
       onTick: () => {},
     });
     round.onManualChangeTier('OT_FULL_TIME', 'need coverage');
-    const logs = getAuditLogs();
+    const logs = getAuditLogs(storage);
     expect(logs[0].actor).toBe('manager');
     expect(logs[0].details.from).toBe('CASUALS');
     expect(logs[0].details.to).toBe('OT_FULL_TIME');


### PR DESCRIPTION
## Summary
- add storage module with in-memory fallback
- inject storage into audit utilities and offering round
- update tests for storage-aware audit logging

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2b5e0e88327bbebe0b2f677d47b