### PR TITLE
Refactor analytics export formatters

### DIFF
--- a/server/analyticsFormats/csv.ts
+++ b/server/analyticsFormats/csv.ts
@@ -1,0 +1,16 @@
+export interface AnalyticsRow {
+  period: string;
+  posted: number;
+  awarded: number;
+  cancelled: number;
+  cancellationRate: number;
+  overtime: number;
+}
+
+export function createCsv(data: AnalyticsRow[]): string {
+  const header = 'period,posted,awarded,cancelled,cancellationRate,overtime\n';
+  const rows = data
+    .map(d => `${d.period},${d.posted},${d.awarded},${d.cancelled},${d.cancellationRate},${d.overtime}`)
+    .join('\n');
+  return header + rows;
+}

--- a/server/analyticsFormats/pdf.ts
+++ b/server/analyticsFormats/pdf.ts
@@ -1,0 +1,24 @@
+import PDFDocument from 'pdfkit';
+
+export interface AnalyticsRow {
+  period: string;
+  posted: number;
+  awarded: number;
+  cancelled: number;
+  cancellationRate: number;
+  overtime: number;
+}
+
+export function createPdf(data: AnalyticsRow[]) {
+  const doc = new PDFDocument();
+  doc.fontSize(16).text('Analytics');
+  data.forEach(row => {
+    doc
+      .fontSize(12)
+      .text(
+        `${row.period}: posted ${row.posted}, awarded ${row.awarded}, cancelled ${row.cancelled}, ` +
+          `cancellationRate ${(row.cancellationRate * 100).toFixed(2)}%, overtime ${row.overtime}`
+      );
+  });
+  return doc;
+}


### PR DESCRIPTION
## Summary
- Move CSV and PDF generation into dedicated `server/analyticsFormats` modules
- Dispatch analytics export formatting based on query parameter with 400 on unknown formats

## Testing
- `npm test`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a8e2b2e32c8327b4afb5715f6d4340