### PR TITLE
refactor metrics grouping

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,8 @@
 import express from 'express';
 import cors from 'cors';
 import PDFDocument from 'pdfkit';
-import { aggregateByMonth, sampleVacancies } from './metrics.js';
+import { aggregateByMonth } from './metrics.js';
+import { sampleVacancies } from './sampleData/vacancies.ts';
 import { requireAuth } from './auth.js';
 
 const app = express();

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -1,11 +1,11 @@
 export function aggregateByMonth(vacancies) {
-  const groups = {};
+  const groups = new Map();
   for (const v of vacancies) {
     const month = v.date.slice(0, 7);
-    groups[month] = groups[month] || [];
-    groups[month].push(v);
+    if (!groups.has(month)) groups.set(month, []);
+    groups.get(month).push(v);
   }
-  return Object.entries(groups)
+  return Array.from(groups.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([period, items]) => {
       const posted = items.length;
@@ -18,13 +18,3 @@ export function aggregateByMonth(vacancies) {
       return { period, posted, awarded, cancelled, cancellationRate, overtime };
     });
 }
-
-export const sampleVacancies = [
-  { date: '2024-01-01', status: 'awarded', hours: 10 },
-  { date: '2024-01-05', status: 'cancelled', hours: 8 },
-  { date: '2024-01-07', status: 'posted', hours: 8 },
-  { date: '2024-02-02', status: 'awarded', hours: 9 },
-  { date: '2024-02-04', status: 'awarded', hours: 8 },
-  { date: '2024-02-08', status: 'cancelled', hours: 8 },
-  { date: '2024-03-03', status: 'posted', hours: 8 }
-];

--- a/server/sampleData/vacancies.ts
+++ b/server/sampleData/vacancies.ts
@@ -1,0 +1,9 @@
+export const sampleVacancies = [
+  { date: '2024-01-01', status: 'awarded', hours: 10 },
+  { date: '2024-01-05', status: 'cancelled', hours: 8 },
+  { date: '2024-01-07', status: 'posted', hours: 8 },
+  { date: '2024-02-02', status: 'awarded', hours: 9 },
+  { date: '2024-02-04', status: 'awarded', hours: 8 },
+  { date: '2024-02-08', status: 'cancelled', hours: 8 },
+  { date: '2024-03-03', status: 'posted', hours: 8 }
+];

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { aggregateByMonth, sampleVacancies } from '../server/metrics.js';
+import { aggregateByMonth } from '../server/metrics.js';
+import { sampleVacancies } from '../server/sampleData/vacancies.ts';
 
 describe('aggregateByMonth', () => {
   it('calculates metrics correctly', () => {


### PR DESCRIPTION
## Summary
- move sample vacancy data into `server/sampleData/vacancies.ts`
- refactor `aggregateByMonth` to group using `Map`
- update imports and tests to use new sample data file

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2b3d4e08327a2d37ed95cdc4f25