### PR TITLE
refactor: modularize app with utilities and hooks

### DIFF
--- a/src/components/EmployeeCombo.tsx
+++ b/src/components/EmployeeCombo.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Employee } from "../App";
+import { matchText } from "../utils/format";
+
+export default function EmployeeCombo({
+  employees,
+  onSelect,
+}: {
+  employees: Employee[];
+  onSelect: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const ref = useRef<HTMLDivElement>(null);
+  const list = useMemo(
+    () => employees.filter((e) => matchText(q, `${e.firstName} ${e.lastName} ${e.id}`)).slice(0, 50),
+    [q, employees]
+  );
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+  return (
+    <div className="dropdown" ref={ref}>
+      <input
+        placeholder="Type name or ID…"
+        value={q}
+        onChange={(e) => {
+          setQ(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+      />
+      {open && (
+        <div className="menu">
+          {list.map((e) => (
+            <div
+              key={e.id}
+              className="item"
+              onClick={() => {
+                onSelect(e.id);
+                setQ(`${e.firstName} ${e.lastName} (${e.id})`);
+                setOpen(false);
+              }}
+            >
+              {e.firstName} {e.lastName}{" "}
+              <span className="pill" style={{ marginLeft: 6 }}>
+                {e.classification} {e.status}
+              </span>
+            </div>
+          ))}
+          {!list.length && <div className="item" style={{ opacity: 0.7 }}>No matches</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+export function usePersistedState<T>(
+  key: string,
+  initial: T,
+  revive?: (value: any) => T
+): [T, React.Dispatch<React.SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      const parsed = raw ? JSON.parse(raw) : initial;
+      return revive ? revive(parsed) : parsed;
+    } catch {
+      return initial;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // ignore
+    }
+  }, [key, state]);
+
+  return [state, setState];
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,68 @@
+export const isoDate = (d: Date) => `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+
+export const combineDateTime = (dateISO: string, timeHHmm: string) => new Date(`${dateISO}T${timeHHmm}:00`);
+
+export const buildCalendar = (year: number, month: number) => {
+  const first = new Date(year, month, 1);
+  const start = new Date(first);
+  start.setDate(first.getDate() - first.getDay());
+  const days: { date: Date; inMonth: boolean }[] = [];
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    days.push({ date: d, inMonth: d.getMonth() === month });
+  }
+  return days;
+};
+
+export const prevMonth = (setY: (n: number) => void, setM: (n: number) => void, y: number, m: number) => {
+  if (m === 0) {
+    setY(y - 1);
+    setM(11);
+  } else setM(m - 1);
+};
+
+export const nextMonth = (setY: (n: number) => void, setM: (n: number) => void, y: number, m: number) => {
+  if (m === 11) {
+    setY(y + 1);
+    setM(0);
+  } else setM(m + 1);
+};
+
+export function minutesBetween(a: Date, b: Date) {
+  return Math.round((a.getTime() - b.getTime()) / 60000);
+}
+
+interface SettingsLike {
+  responseWindows: { lt2h: number; h2to4: number; h4to24: number; h24to72: number; gt72: number };
+}
+
+interface VacancyLike {
+  knownAt: string;
+  shiftDate: string;
+  shiftStart: string;
+}
+
+export function pickWindowMinutes(v: VacancyLike, settings: SettingsLike) {
+  const known = new Date(v.knownAt);
+  const shiftStart = combineDateTime(v.shiftDate, v.shiftStart);
+  const hrsUntilShift = (shiftStart.getTime() - known.getTime()) / 3_600_000;
+  if (hrsUntilShift < 2) return settings.responseWindows.lt2h;
+  if (hrsUntilShift < 4) return settings.responseWindows.h2to4;
+  if (hrsUntilShift < 24) return settings.responseWindows.h4to24;
+  if (hrsUntilShift < 72) return settings.responseWindows.h24to72;
+  return settings.responseWindows.gt72;
+}
+
+export function deadlineFor(v: VacancyLike, settings: SettingsLike) {
+  const winMin = pickWindowMinutes(v, settings);
+  return new Date(new Date(v.knownAt).getTime() + winMin * 60000);
+}
+
+export function dateRangeInclusive(startISO: string, endISO: string) {
+  const out: string[] = [];
+  const s = new Date(startISO + "T00:00:00");
+  const e = new Date(endISO + "T00:00:00");
+  for (let d = new Date(s); d <= e; d.setDate(d.getDate() + 1)) out.push(isoDate(d));
+  return out;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,43 @@
+export const formatDateLong = (iso: string) =>
+  new Date(iso + "T00:00:00").toLocaleDateString(undefined, {
+    month: "long",
+    day: "2-digit",
+    year: "numeric",
+  });
+
+export const formatDowShort = (iso: string) =>
+  new Date(iso + "T00:00:00").toLocaleDateString(undefined, {
+    weekday: "short",
+  });
+
+export const matchText = (q: string, label: string) =>
+  q
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .every((p) => label.toLowerCase().includes(p));
+
+export function fmtCountdown(msLeft: number) {
+  const neg = msLeft < 0;
+  const abs = Math.abs(msLeft);
+  const totalSec = Math.floor(abs / 1000);
+  const d = Math.floor(totalSec / 86400);
+  const h = Math.floor((totalSec % 86400) / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  const core =
+    d > 0 ? `${d}d ${h}h` : h > 0 ? `${h}h ${m}m` : `${m}m ${s}s`;
+  return neg ? `Due ${core} ago` : core;
+}
+
+export const displayVacancyLabel = (v: {
+  shiftDate: string;
+  shiftStart: string;
+  shiftEnd: string;
+  wing?: string;
+  classification: string;
+}) => {
+  const d = formatDateLong(v.shiftDate);
+  return `${d} • ${v.shiftStart}–${v.shiftEnd} • ${v.wing ?? ""} • ${v.classification}`.replace(/\s+•\s+$/, "");
+};

--- a/src/views/BidsView.tsx
+++ b/src/views/BidsView.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import type { Bid, Vacancy, Vacation, Employee } from "../App";
+import EmployeeCombo from "../components/EmployeeCombo";
+import { isoDate } from "../utils/date";
+import { displayVacancyLabel } from "../utils/format";
+
+export default function BidsView({
+  bids,
+  setBids,
+  vacancies,
+  vacations,
+  employees,
+  employeesById,
+}: {
+  bids: Bid[];
+  setBids: (u: any) => void;
+  vacancies: Vacancy[];
+  vacations: Vacation[];
+  employees: Employee[];
+  employeesById: Record<string, Employee>;
+}) {
+  const [newBid, setNewBid] = useState<
+    Partial<Bid & { bidDate: string; bidTime: string }>
+  >({});
+
+  const vacWithCoveredName = (v: Vacancy) => {
+    const vac = vacations.find((x) => x.id === v.vacationId);
+    const covered = vac ? vac.employeeName : "";
+    return `${displayVacancyLabel(v)} — covering ${covered}`.trim();
+  };
+
+  const setNow = () => {
+    const now = new Date();
+    const d = isoDate(now);
+    const t = `${String(now.getHours()).padStart(2, "0")}:${String(
+      now.getMinutes()
+    ).padStart(2, "0")}`;
+    setNewBid((b) => ({ ...b, bidDate: d, bidTime: t }));
+  };
+
+  return (
+    <div className="grid">
+      <div className="card">
+        <div className="card-h">Add Bid</div>
+        <div className="card-c">
+          <div className="row cols2">
+            <div>
+              <label>Vacancy</label>
+              <select
+                onChange={(e) =>
+                  setNewBid((b) => ({ ...b, vacancyId: e.target.value }))
+                }
+                value={newBid.vacancyId ?? ""}
+              >
+                <option value="" disabled>
+                  Pick vacancy
+                </option>
+                {vacancies.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {vacWithCoveredName(v)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label>Employee</label>
+              <EmployeeCombo
+                employees={employees}
+                onSelect={(id) => {
+                  const e = employeesById[id];
+                  setNewBid((b) => ({
+                    ...b,
+                    bidderEmployeeId: id,
+                    bidderName: e ? `${e.firstName} ${e.lastName}` : "",
+                    bidderStatus: e?.status,
+                    bidderClassification: e?.classification,
+                  }));
+                }}
+              />
+            </div>
+            <div>
+              <label>Bid Date</label>
+              <input
+                type="date"
+                value={newBid.bidDate ?? ""}
+                onChange={(e) =>
+                  setNewBid((b) => ({ ...b, bidDate: e.target.value }))
+                }
+              />
+            </div>
+            <div>
+              <label>Bid Time</label>
+              <div className="form-row">
+                <input
+                  type="time"
+                  value={newBid.bidTime ?? ""}
+                  onChange={(e) =>
+                    setNewBid((b) => ({ ...b, bidTime: e.target.value }))
+                  }
+                />
+                <button className="btn" onClick={setNow}>
+                  Now
+                </button>
+              </div>
+            </div>
+            <div style={{ gridColumn: "1 / -1" }}>
+              <label>Notes</label>
+              <input
+                placeholder={'e.g., "available for 06:30-14:30"'}
+                onChange={(e) =>
+                  setNewBid((b) => ({ ...b, notes: e.target.value }))
+                }
+              />
+            </div>
+            <div style={{ gridColumn: "1 / -1" }}>
+              <button
+                className="btn"
+                onClick={() => {
+                  if (!newBid.vacancyId || !newBid.bidderEmployeeId)
+                    return alert("Vacancy and employee required");
+                  const ts =
+                    newBid.bidDate && newBid.bidTime
+                      ? new Date(
+                          `${newBid.bidDate}T${newBid.bidTime}:00`
+                        ).toISOString()
+                      : new Date().toISOString();
+                  setBids((prev: Bid[]) => [
+                    ...prev,
+                    {
+                      vacancyId: newBid.vacancyId!,
+                      bidderEmployeeId: newBid.bidderEmployeeId!,
+                      bidderName: newBid.bidderName!,
+                      bidderStatus: newBid.bidderStatus!,
+                      bidderClassification: newBid.bidderClassification!,
+                      bidTimestamp: ts,
+                      notes: newBid.notes ?? "",
+                    },
+                  ]);
+                  setNewBid({});
+                }}
+              >
+                Add Bid
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-h">All Bids</div>
+        <div className="card-c">
+          <table className="responsive-table">
+            <thead>
+              <tr>
+                <th>Vacancy</th>
+                <th>Employee</th>
+                <th>Class</th>
+                <th>Status</th>
+                <th>Timestamp</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bids.map((b, i) => {
+                const v = vacancies.find((x) => x.id === b.vacancyId);
+                return (
+                  <tr key={i}>
+                    <td>{v ? displayVacancyLabel(v) : b.vacancyId}</td>
+                    <td>{b.bidderName}</td>
+                    <td>{b.bidderClassification}</td>
+                    <td>{b.bidderStatus}</td>
+                    <td>{new Date(b.bidTimestamp).toLocaleString()}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/views/CoverageView.tsx
+++ b/src/views/CoverageView.tsx
@@ -1,0 +1,614 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import EmployeeCombo from "../components/EmployeeCombo";
+import { recommend, Recommendation } from "../recommend";
+import type {
+  Employee,
+  Vacation,
+  Vacancy,
+  Bid,
+  Settings,
+  Classification,
+} from "../App";
+import { dateRangeInclusive, deadlineFor } from "../utils/date";
+import {
+  fmtCountdown,
+  formatDateLong,
+  formatDowShort,
+  matchText,
+} from "../utils/format";
+
+const WINGS = [
+  "Shamrock",
+  "Bluebell",
+  "Rosewood",
+  "Front",
+  "Receptionist",
+] as const;
+
+const SHIFT_PRESETS = [
+  { label: "Day", start: "06:30", end: "14:30" },
+  { label: "Evening", start: "14:30", end: "22:30" },
+  { label: "Night", start: "22:30", end: "06:30" },
+] as const;
+
+const OVERRIDE_REASONS = [
+  "Earlier bidder within step",
+  "Availability mismatch / declined",
+  "Single Site Order / conflict",
+  "Scope of practice / skill mix",
+  "Fatigue risk (back‑to‑back)",
+  "Unit familiarity / continuity",
+  "Manager discretion",
+] as const;
+
+export default function CoverageView({
+  employees,
+  vacancies,
+  bids,
+  settings,
+  setVacations,
+  setVacancies,
+}: {
+  employees: Employee[];
+  vacancies: Vacancy[];
+  bids: Bid[];
+  settings: Settings;
+  setVacations: (u: any) => void;
+  setVacancies: (u: any) => void;
+}) {
+  const [newVacay, setNewVacay] = useState<
+    Partial<Vacation & { shiftStart: string; shiftEnd: string; shiftPreset: string }>
+  >({
+    wing: WINGS[0],
+    shiftStart: SHIFT_PRESETS[0].start,
+    shiftEnd: SHIFT_PRESETS[0].end,
+    shiftPreset: SHIFT_PRESETS[0].label,
+  });
+
+  const [filterWing, setFilterWing] = useState<string>("");
+  const [filterClass, setFilterClass] = useState<Classification | "">("");
+  const [filterStart, setFilterStart] = useState<string>("");
+  const [filterEnd, setFilterEnd] = useState<string>("");
+
+  const [now, setNow] = useState<number>(Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const employeesById = useMemo(
+    () => Object.fromEntries(employees.map((e) => [e.id, e])),
+    [employees]
+  );
+
+  const recommendations = useMemo<Record<string, Recommendation>>(() => {
+    const m: Record<string, Recommendation> = {};
+    vacancies.forEach((v) => {
+      m[v.id] = recommend(v, bids, employeesById);
+    });
+    return m;
+  }, [vacancies, bids, employeesById]);
+
+  useEffect(() => {
+    const byVacation = new Map<string, Vacancy[]>();
+    vacancies.forEach((v) => {
+      if (v.vacationId) {
+        const a = byVacation.get(v.vacationId) || [];
+        a.push(v);
+        byVacation.set(v.vacationId, a);
+      }
+    });
+    setVacations((prev: Vacation[]) =>
+      prev.map((vac) => {
+        const list = byVacation.get(vac.id) || [];
+        const allAwarded = list.length > 0 && list.every((x) => x.status === "Awarded");
+        if (allAwarded && !vac.archived)
+          return { ...vac, archived: true, archivedAt: new Date().toISOString() };
+        return vac;
+      })
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vacancies]);
+
+  const addVacationAndGenerate = (
+    v: Partial<Vacation & { shiftStart: string; shiftEnd: string; shiftPreset: string }>
+  ) => {
+    if (!v.employeeId || !v.employeeName || !v.classification || !v.startDate || !v.endDate || !v.wing) {
+      alert("Employee, wing, start & end are required.");
+      return;
+    }
+    const vac: Vacation = {
+      id: `vac_${Date.now().toString(36)}`,
+      employeeId: v.employeeId!,
+      employeeName: v.employeeName!,
+      classification: v.classification!,
+      wing: v.wing!,
+      startDate: v.startDate!,
+      endDate: v.endDate!,
+      notes: v.notes ?? "",
+      archived: false,
+    };
+    setVacations((prev: Vacation[]) => [vac, ...prev]);
+
+    const days = dateRangeInclusive(v.startDate!, v.endDate!);
+    const nowISO = new Date().toISOString();
+    const vxs: Vacancy[] = days.map((d) => ({
+      id: `VAC-${Math.random().toString(36).slice(2, 7).toUpperCase()}`,
+      vacationId: vac.id,
+      reason: "Vacation Backfill",
+      classification: vac.classification,
+      wing: vac.wing,
+      shiftDate: d,
+      shiftStart: v.shiftStart ?? SHIFT_PRESETS[0].start,
+      shiftEnd: v.shiftEnd ?? SHIFT_PRESETS[0].end,
+      knownAt: nowISO,
+      offeringTier: "CASUALS",
+      offeringRoundStartedAt: nowISO,
+      offeringRoundMinutes: 120,
+      offeringAutoProgress: true,
+      offeringStep: "Casuals",
+      status: "Open",
+    }));
+    setVacancies((prev: Vacancy[]) => [...vxs, ...prev]);
+
+    setNewVacay({
+      wing: WINGS[0],
+      shiftStart: SHIFT_PRESETS[0].start,
+      shiftEnd: SHIFT_PRESETS[0].end,
+      shiftPreset: SHIFT_PRESETS[0].label,
+    });
+  };
+
+  const awardVacancy = (
+    vacId: string,
+    payload: { empId?: string; reason?: string; overrideUsed?: boolean }
+  ) => {
+    if (!payload.empId) {
+      alert("Pick an employee to award.");
+      return;
+    }
+    setVacancies((prev: Vacancy[]) =>
+      prev.map((v) =>
+        v.id === vacId
+          ? {
+              ...v,
+              status: "Awarded",
+              awardedTo: payload.empId,
+              awardedAt: new Date().toISOString(),
+              awardReason: payload.reason ?? "",
+              overrideUsed: !!payload.overrideUsed,
+            }
+          : v
+      )
+    );
+  };
+
+  const resetKnownAt = (vacId: string) => {
+    setVacancies((prev: Vacancy[]) =>
+      prev.map((v) =>
+        v.id === vacId ? { ...v, knownAt: new Date().toISOString() } : v
+      )
+    );
+  };
+
+  const dueNextId = useMemo(() => {
+    let min = Infinity;
+    let id: string | null = null;
+    for (const v of vacancies) {
+      if (v.status === "Awarded") continue;
+      const dl = deadlineFor(v, settings).getTime() - now;
+      if (dl > 0 && dl < min) {
+        min = dl;
+        id = v.id;
+      }
+    }
+    return id;
+  }, [vacancies, now, settings]);
+
+  const filteredVacancies = useMemo(() => {
+    return vacancies.filter((v) => {
+      if (v.status === "Awarded") return false;
+      if (filterWing && v.wing !== filterWing) return false;
+      if (filterClass && v.classification !== filterClass) return false;
+      if (filterStart && v.shiftDate < filterStart) return false;
+      if (filterEnd && v.shiftDate > filterEnd) return false;
+      return true;
+    });
+  }, [vacancies, filterWing, filterClass, filterStart, filterEnd]);
+
+  return (
+    <div className="grid grid2">
+      <div className="card">
+        <div className="card-h">Add Vacation (auto-creates daily vacancies)</div>
+        <div className="card-c">
+          <div className="row cols2">
+            <div>
+              <label>Employee</label>
+              <EmployeeCombo
+                employees={employees}
+                onSelect={(id) => {
+                  const e = employees.find((x) => x.id === id);
+                  setNewVacay((v) => ({
+                    ...v,
+                    employeeId: id,
+                    employeeName: e ? `${e.firstName} ${e.lastName}` : "",
+                    classification: (e?.classification ?? v.classification ?? "RCA") as Classification,
+                  }));
+                }}
+              />
+            </div>
+            <div>
+              <label>Wing / Unit</label>
+              <select
+                value={newVacay.wing ?? WINGS[0]}
+                onChange={(e) => setNewVacay((v) => ({ ...v, wing: e.target.value }))}
+              >
+                {WINGS.map((w) => (
+                  <option key={w} value={w}>
+                    {w}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label>Start Date</label>
+              <input
+                type="date"
+                onChange={(e) => setNewVacay((v) => ({ ...v, startDate: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label>End Date</label>
+              <input
+                type="date"
+                onChange={(e) => setNewVacay((v) => ({ ...v, endDate: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label>Shift</label>
+              <select
+                value={newVacay.shiftPreset ?? SHIFT_PRESETS[0].label}
+                onChange={(e) => {
+                  const preset = SHIFT_PRESETS.find((p) => p.label === e.target.value);
+                  if (preset) {
+                    setNewVacay((v) => ({
+                      ...v,
+                      shiftPreset: preset.label,
+                      shiftStart: preset.start,
+                      shiftEnd: preset.end,
+                    }));
+                  } else {
+                    setNewVacay((v) => ({ ...v, shiftPreset: "Custom" }));
+                  }
+                }}
+              >
+                {SHIFT_PRESETS.map((p) => (
+                  <option key={p.label} value={p.label}>
+                    {p.label} ({p.start}–{p.end})
+                  </option>
+                ))}
+                <option value="Custom">Custom</option>
+              </select>
+            </div>
+            {newVacay.shiftPreset === "Custom" && (
+              <>
+                <div>
+                  <label>Shift Start</label>
+                  <input
+                    type="time"
+                    value={newVacay.shiftStart ?? ""}
+                    onChange={(e) =>
+                      setNewVacay((v) => ({ ...v, shiftStart: e.target.value }))
+                    }
+                  />
+                </div>
+                <div>
+                  <label>Shift End</label>
+                  <input
+                    type="time"
+                    value={newVacay.shiftEnd ?? ""}
+                    onChange={(e) =>
+                      setNewVacay((v) => ({ ...v, shiftEnd: e.target.value }))
+                    }
+                  />
+                </div>
+              </>
+            )}
+            <div style={{ gridColumn: "1 / -1" }}>
+              <label>Notes</label>
+              <textarea
+                placeholder="Optional"
+                onChange={(e) => setNewVacay((v) => ({ ...v, notes: e.target.value }))}
+              />
+            </div>
+            <div style={{ gridColumn: "1 / -1" }}>
+              <button
+                className="btn"
+                onClick={() => addVacationAndGenerate(newVacay)}
+              >
+                Add & Generate
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-h">Open Vacancies</div>
+        <div className="card-c">
+          <div className="toolbar" style={{ marginBottom: 8 }}>
+            <select value={filterWing} onChange={(e) => setFilterWing(e.target.value)}>
+              <option value="">All Wings</option>
+              {WINGS.map((w) => (
+                <option key={w} value={w}>
+                  {w}
+                </option>
+              ))}
+            </select>
+            <select
+              value={filterClass}
+              onChange={(e) => setFilterClass(e.target.value as Classification | "")}
+            >
+              <option value="">All Classes</option>
+              {["RCA", "LPN", "RN"].map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <input
+              type="date"
+              value={filterStart}
+              onChange={(e) => setFilterStart(e.target.value)}
+            />
+            <input
+              type="date"
+              value={filterEnd}
+              onChange={(e) => setFilterEnd(e.target.value)}
+            />
+            <button
+              className="btn"
+              onClick={() => {
+                setFilterWing("");
+                setFilterClass("");
+                setFilterStart("");
+                setFilterEnd("");
+              }}
+            >
+              Clear
+            </button>
+          </div>
+          <table className="vac-table responsive-table">
+            <thead>
+              <tr>
+                <th>Shift</th>
+                <th>Wing</th>
+                <th>Class</th>
+                <th>Tier</th>
+                <th>Recommendation</th>
+                <th>Deadline</th>
+                <th>Employee</th>
+                <th>Override</th>
+                <th>Reason</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredVacancies.map((v) => {
+                const rec = recommendations[v.id];
+                const recId = rec?.id;
+                const recName = recId
+                  ? `${employeesById[recId]?.firstName ?? ""} ${employeesById[recId]?.lastName ?? ""}`.trim()
+                  : "";
+                const recWhy = rec?.why ?? [];
+                const dl = deadlineFor(v, settings);
+                const msLeft = dl.getTime() - now;
+                let countdownClass = "cd-green";
+                if (msLeft < 2 * 60 * 1000) countdownClass = "cd-red";
+                else if (msLeft < 10 * 60 * 1000) countdownClass = "cd-yellow";
+                return (
+                  <VacancyRow
+                    key={v.id}
+                    v={v}
+                    recId={recId}
+                    recName={recName}
+                    recWhy={recWhy}
+                    employees={employees}
+                    countdownLabel={fmtCountdown(msLeft)}
+                    countdownClass={countdownClass}
+                    isDueNext={v.id === dueNextId}
+                    onAward={(payload) => awardVacancy(v.id, payload)}
+                    onResetKnownAt={() => resetKnownAt(v.id)}
+                  />
+                );
+              })}
+            </tbody>
+          </table>
+          {filteredVacancies.length === 0 && (
+            <div className="subtitle" style={{ marginTop: 8 }}>
+              No open vacancies 🎉
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function VacancyRow({
+  v,
+  recId,
+  recName,
+  recWhy,
+  employees,
+  countdownLabel,
+  countdownClass,
+  isDueNext,
+  onAward,
+  onResetKnownAt,
+}: {
+  v: Vacancy;
+  recId?: string;
+  recName: string;
+  recWhy: string[];
+  employees: Employee[];
+  countdownLabel: string;
+  countdownClass: string;
+  isDueNext: boolean;
+  onAward: (payload: { empId?: string; reason?: string; overrideUsed?: boolean }) => void;
+  onResetKnownAt: () => void;
+}) {
+  const [choice, setChoice] = useState<string>("");
+  const [overrideClass, setOverrideClass] = useState<boolean>(false);
+  const [reason, setReason] = useState<string>("");
+
+  const chosen = employees.find((e) => e.id === choice);
+  const classMismatch = chosen && chosen.classification !== v.classification;
+  const needReason = (!!recId && choice && choice !== recId) || (classMismatch && overrideClass);
+
+  function handleAward() {
+    if (classMismatch && !overrideClass) {
+      alert(
+        `Selected employee is ${chosen?.classification}; vacancy requires ${v.classification}. Check "Allow class override" to proceed.`
+      );
+      return;
+    }
+    if (needReason && !reason) {
+      alert("Please select a reason for this override.");
+      return;
+    }
+    onAward({ empId: choice || undefined, reason: reason || undefined, overrideUsed: overrideClass });
+    setChoice("");
+    setReason("");
+    setOverrideClass(false);
+  }
+
+  return (
+    <tr className={isDueNext ? "due-next" : ""}>
+      <td>
+        <span className="pill">{formatDowShort(v.shiftDate)}</span> {formatDateLong(v.shiftDate)} • {v.shiftStart}-{v.shiftEnd}
+      </td>
+      <td>{v.wing ?? ""}</td>
+      <td>{v.classification}</td>
+      <td>{v.offeringStep}</td>
+      <td>
+        <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 4 }}>
+          <span>{recName}</span>
+          {recWhy.map((w, i) => (
+            <span key={i} className="pill">
+              {w}
+            </span>
+          ))}
+        </div>
+      </td>
+      <td>
+        <span className={`cd-chip ${countdownClass}`}>{countdownLabel}</span>
+      </td>
+      <td style={{ minWidth: 220 }}>
+        <SelectEmployee employees={employees} value={choice} onChange={setChoice} />
+      </td>
+      <td style={{ whiteSpace: "nowrap" }}>
+        <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <input
+            type="checkbox"
+            checked={overrideClass}
+            onChange={(e) => setOverrideClass(e.target.checked)}
+          />
+          <span className="subtitle">Allow class override</span>
+        </label>
+      </td>
+      <td style={{ minWidth: 230 }}>
+        {needReason || overrideClass || (recId && choice && choice !== recId) ? (
+          <select value={reason} onChange={(e) => setReason(e.target.value)}>
+            <option value="">Select reason…</option>
+            {OVERRIDE_REASONS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="subtitle">—</span>
+        )}
+      </td>
+      <td style={{ display: "flex", gap: 6 }}>
+        <button className="btn" onClick={onResetKnownAt}>
+          Reset knownAt
+        </button>
+        <button className="btn" onClick={handleAward} disabled={!choice}>
+          Award
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function SelectEmployee({
+  employees,
+  value,
+  onChange,
+}: {
+  employees: Employee[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const ref = useRef<HTMLDivElement>(null);
+  const list = useMemo(
+    () => employees.filter((e) => matchText(q, `${e.firstName} ${e.lastName} ${e.id}`)).slice(0, 50),
+    [q, employees]
+  );
+  const curr = employees.find((e) => e.id === value);
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+  useEffect(() => {
+    if (!value) setQ("");
+  }, [value]);
+  return (
+    <div className="dropdown" ref={ref}>
+      <input
+        placeholder={
+          curr ? `${curr.firstName} ${curr.lastName} (${curr.id})` : "Type name or ID…"
+        }
+        value={q}
+        onChange={(e) => {
+          setQ(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+      />
+      {open && (
+        <div className="menu">
+          {list.map((e) => (
+            <div
+              key={e.id}
+              className="item"
+              onClick={() => {
+                onChange(e.id);
+                setQ(`${e.firstName} ${e.lastName} (${e.id})`);
+                setOpen(false);
+              }}
+            >
+              {e.firstName} {e.lastName}{" "}
+              <span className="pill" style={{ marginLeft: 6 }}>
+                {e.classification} {e.status}
+              </span>
+            </div>
+          ))}
+          {!list.length && (
+            <div className="item" style={{ opacity: 0.7 }}>
+              No matches
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/views/EmployeesView.tsx
+++ b/src/views/EmployeesView.tsx
@@ -1,0 +1,80 @@
+import type { Employee, Classification, Status } from "../App";
+
+export default function EmployeesView({
+  employees,
+  setEmployees,
+}: {
+  employees: Employee[];
+  setEmployees: (u: any) => void;
+}) {
+  return (
+    <div className="grid">
+      <div className="card">
+        <div className="card-h">Import Staff (CSV)</div>
+        <div className="card-c">
+          <input
+            type="file"
+            accept=".csv"
+            onChange={async (e) => {
+              const f = e.target.files?.[0];
+              if (!f) return;
+              const text = await f.text();
+              const { parseCSV } = await import("../utils/csv");
+              const rows = parseCSV(text);
+              const out: Employee[] = rows.map((r: any, i: number) => ({
+                id: String(r.id ?? r.EmployeeID ?? `emp_${i}`),
+                firstName: String(r.firstName ?? r.name ?? ""),
+                lastName: String(r.lastName ?? ""),
+                classification: (["RCA", "LPN", "RN"].includes(String(r.classification))
+                  ? r.classification
+                  : "RCA") as Classification,
+                status: (["FT", "PT", "Casual"].includes(String(r.status))
+                  ? r.status
+                  : "FT") as Status,
+                homeWing: String(r.homeWing ?? ""),
+                seniorityRank: Number(r.seniorityRank ?? i + 1),
+                active: String(r.active ?? "Yes").toLowerCase().startsWith("y"),
+              }));
+              setEmployees(out.filter((e) => !!e.id));
+            }}
+          />
+          <div className="subtitle">
+            Columns: id, firstName, lastName, classification (RCA/LPN/RN), status (FT/PT/Casual), homeWing, seniorityRank, active (Yes/No)
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-h">Employees</div>
+        <div className="card-c">
+          <table className="responsive-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Class</th>
+                <th>Status</th>
+                <th>Rank</th>
+                <th>Active</th>
+              </tr>
+            </thead>
+            <tbody>
+              {employees.map((e) => (
+                <tr key={e.id}>
+                  <td>{e.id}</td>
+                  <td>
+                    {e.firstName} {e.lastName}
+                  </td>
+                  <td>{e.classification}</td>
+                  <td>{e.status}</td>
+                  <td>{e.seniorityRank}</td>
+                  <td>{e.active ? "Yes" : "No"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/views/SettingsView.tsx
+++ b/src/views/SettingsView.tsx
@@ -1,0 +1,47 @@
+import type { Settings } from "../App";
+
+export default function SettingsView({
+  settings,
+  setSettings,
+}: {
+  settings: Settings;
+  setSettings: (u: any) => void;
+}) {
+  return (
+    <div className="grid">
+      <div className="card">
+        <div className="card-h">Response Windows (minutes)</div>
+        <div className="card-c">
+          <div className="row cols2">
+            {(
+              [
+                ["<2h", "lt2h"],
+                ["2–4h", "h2to4"],
+                ["4–24h", "h4to24"],
+                ["24–72h", "h24to72"],
+                [">72h", "gt72"],
+              ] as const
+            ).map(([label, key]) => (
+              <div key={key}>
+                <label>{label}</label>
+                <input
+                  type="number"
+                  value={(settings.responseWindows as any)[key]}
+                  onChange={(e) =>
+                    setSettings((s: any) => ({
+                      ...s,
+                      responseWindows: {
+                        ...s.responseWindows,
+                        [key]: Number(e.target.value),
+                      },
+                    }))
+                  }
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract date and format helpers into reusable utils
- move persistent state logic into `usePersistedState` hook
- split major UI areas into dedicated view components

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2b865808327ba065c1049253c57