### PR TITLE
Use papaparse for CSV parsing with multiline support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "maplewood-scheduler",
-  "version": "0.0.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maplewood-scheduler",
-      "version": "0.0.0",
+      "version": "2.3.0",
       "dependencies": {
         "chart.js": "^4.4.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
+        "papaparse": "^5.4.1",
         "pdfkit": "^0.13.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.2.0",
@@ -3042,6 +3043,12 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==",
       "license": "MIT"
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "chart.js": "^4.4.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "papaparse": "^5.4.1",
     "pdfkit": "^0.13.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
@@ -27,8 +28,8 @@
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.0",
-    "vitest": "^1.6.0",
     "typescript": "^5.4.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,48 +1,12 @@
+import Papa from 'papaparse';
+
 // Parses a CSV string into an array of objects keyed by header names.
 export function parseCSV(input: string): Record<string, string>[] {
-  const lines = input.trim().split(/\r?\n/);
-  if (lines.length === 0) return [];
-  const headers = splitLine(lines[0]);
-  const rows: Record<string, string>[] = [];
-  for (const line of lines.slice(1)) {
-    if (!line.trim()) continue;
-    const values = splitLine(line);
-    const row: Record<string, string> = {};
-    headers.forEach((h, i) => {
-      row[h] = values[i] ?? "";
-    });
-    rows.push(row);
-  }
-  return rows;
+  const { data } = Papa.parse<Record<string, string>>(input, {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  return data as Record<string, string>[];
 }
 
-// Splits a single CSV line accounting for quoted values and escapes.
-function splitLine(line: string): string[] {
-  const result: string[] = [];
-  let current = "";
-  let inQuotes = false;
-  let wasQuoted = false;
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-    if (char === '"') {
-      if (inQuotes && line[i + 1] === '"') {
-        current += '"';
-        i++; // skip escaped quote
-      } else {
-        inQuotes = !inQuotes;
-        if (inQuotes && current === "") {
-          // entering quotes at start of field
-          wasQuoted = true;
-        }
-      }
-    } else if (char === ',' && !inQuotes) {
-      result.push(wasQuoted ? current : current.trim());
-      current = "";
-      wasQuoted = false;
-    } else {
-      current += char;
-    }
-  }
-  result.push(wasQuoted ? current : current.trim());
-  return result;
-}

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -26,4 +26,21 @@ describe('parseCSV', () => {
       { id: '1', name: '  John  ' }
     ]);
   });
+
+  it('handles embedded quotes', () => {
+    const input = 'id,quote\n1,"She said ""Hello"""';
+    const rows = parseCSV(input);
+    expect(rows).toEqual([
+      { id: '1', quote: 'She said "Hello"' }
+    ]);
+  });
+
+  it('handles newlines within quoted fields', () => {
+    const input = 'id,notes\n1,"Line1\nLine2"';
+    const rows = parseCSV(input);
+    expect(rows).toEqual([
+      { id: '1', notes: 'Line1\nLine2' }
+    ]);
+  });
 });
+


### PR DESCRIPTION
## Summary
- replace custom CSV splitter with papaparse-based `parseCSV`
- add tests for embedded quotes and newline handling
- include papaparse as project dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2b4e8ec8327923d857a55e41198