### PR TITLE
Filter awarded vacancies from bids dropdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -678,7 +678,7 @@ function SettingsPage({settings,setSettings}:{settings:Settings; setSettings:(u:
   );
 }
 
-function BidsPage({bids,setBids,vacancies,vacations,employees,employeesById}:{bids:Bid[];setBids:(u:any)=>void;vacancies:Vacancy[];vacations:Vacation[];employees:Employee[];employeesById:Record<string,Employee>}){
+export function BidsPage({bids,setBids,vacancies,vacations,employees,employeesById}:{bids:Bid[];setBids:(u:any)=>void;vacancies:Vacancy[];vacations:Vacation[];employees:Employee[];employeesById:Record<string,Employee>}){
   const [newBid, setNewBid] = useState<Partial<Bid & {bidDate:string; bidTime:string}>>({});
 
   const vacWithCoveredName = (v: Vacancy) => {
@@ -686,6 +686,8 @@ function BidsPage({bids,setBids,vacancies,vacations,employees,employeesById}:{bi
     const covered = vac ? vac.employeeName : "";
     return `${displayVacancyLabel(v)} — covering ${covered}`.trim();
   };
+
+  const openVacancies = vacancies.filter(v => v.status !== "Awarded");
 
   const setNow = () => {
     const now = new Date();
@@ -702,7 +704,10 @@ function BidsPage({bids,setBids,vacancies,vacations,employees,employeesById}:{bi
             <label>Vacancy</label>
             <select onChange={e=> setNewBid(b=>({...b, vacancyId:e.target.value}))} value={newBid.vacancyId ?? ""}>
               <option value="" disabled>Pick vacancy</option>
-              {vacancies.map(v=> <option key={v.id} value={v.id}>{vacWithCoveredName(v)}</option>)}
+              {openVacancies.length
+                ? openVacancies.map(v=> <option key={v.id} value={v.id}>{vacWithCoveredName(v)}</option>)
+                : <option disabled>No open vacancies</option>
+              }
             </select>
           </div>
           <div>

--- a/tests/bidsPage.test.tsx
+++ b/tests/bidsPage.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { BidsPage, applyAwardVacancy, type Vacancy } from '../src/App';
+
+// test verifying that awarded vacancies are excluded from the dropdown
+
+describe('BidsPage vacancy dropdown', () => {
+  it('does not list awarded vacancies', () => {
+    const vac: Vacancy = {
+      id: 'v1',
+      reason: 'Test',
+      classification: 'RN',
+      shiftDate: '2024-01-01',
+      shiftStart: '08:00',
+      shiftEnd: '16:00',
+      knownAt: '2024-01-01T00:00:00.000Z',
+      offeringTier: 'CASUALS',
+      offeringStep: 'Casuals',
+      status: 'Open',
+    };
+
+    const beforeHtml = renderToStaticMarkup(
+      <BidsPage bids={[]} setBids={() => {}} vacancies={[vac]} vacations={[]} employees={[]} employeesById={{}} />
+    );
+    expect(beforeHtml).toContain('value="v1"');
+
+    const awarded = applyAwardVacancy([vac], 'v1', { empId: 'e1' });
+    const afterHtml = renderToStaticMarkup(
+      <BidsPage bids={[]} setBids={() => {}} vacancies={awarded} vacations={[]} employees={[]} employeesById={{}} />
+    );
+    expect(afterHtml).not.toContain('value="v1"');
+    expect(afterHtml).toContain('No open vacancies');
+  });
+});
+


### PR DESCRIPTION
## Summary
- filter out awarded vacancies from bids dropdown
- show a placeholder when no open vacancies remain
- test that awarding removes a vacancy from the dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e8674d648327b4fd1ded071cd079