### PR TITLE
Use JavaScript analytics format modules in server

### DIFF
--- a/server/analyticsFormats/csv.js
+++ b/server/analyticsFormats/csv.js
@@ -1,13 +1,4 @@
-export interface AnalyticsRow {
-  period: string;
-  posted: number;
-  awarded: number;
-  cancelled: number;
-  cancellationRate: number;
-  overtime: number;
-}
-
-export function createCsv(data: AnalyticsRow[]): string {
+export function createCsv(data) {
   const header = 'period,posted,awarded,cancelled,cancellationRate,overtime\n';
   const rows = data
     .map(d => `${d.period},${d.posted},${d.awarded},${d.cancelled},${d.cancellationRate},${d.overtime}`)

--- a/server/analyticsFormats/pdf.js
+++ b/server/analyticsFormats/pdf.js
@@ -1,15 +1,6 @@
 import PDFDocument from 'pdfkit';
 
-export interface AnalyticsRow {
-  period: string;
-  posted: number;
-  awarded: number;
-  cancelled: number;
-  cancellationRate: number;
-  overtime: number;
-}
-
-export function createPdf(data: AnalyticsRow[]) {
+export function createPdf(data) {
   const doc = new PDFDocument();
   doc.fontSize(16).text('Analytics');
   data.forEach(row => {

--- a/server/index.js
+++ b/server/index.js
@@ -2,8 +2,8 @@ import express from 'express';
 import cors from 'cors';
 import { aggregateByMonth, sampleVacancies } from './metrics.js';
 import { requireAuth } from './auth.js';
-import { createCsv } from './analyticsFormats/csv.ts';
-import { createPdf } from './analyticsFormats/pdf.ts';
+import { createCsv } from './analyticsFormats/csv.js';
+import { createPdf } from './analyticsFormats/pdf.js';
 
 const app = express();
 app.use(cors());


### PR DESCRIPTION
## Summary
- rewrite analytics CSV/PDF helpers in plain JavaScript
- update server to load compiled helpers

## Testing
- `npm test`
- `npm run server`

------
https://chatgpt.com/codex/tasks/task_e_68a8ef819bf08327a2e88f16bc0794b0