### PR TITLE
Handle auth bearer scheme case-insensitively and compare tokens securely

### DIFF
--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -33,4 +33,25 @@ describe('requireAuth', () => {
     requireAuth(req, res, next);
     expect(next).toHaveBeenCalled();
   });
+
+  it('allows requests with varied bearer casing', () => {
+    process.env.ANALYTICS_AUTH_TOKEN = 'secret';
+    const variants = ['bearer secret', 'BEARER secret', 'BeArEr secret'];
+    for (const authorization of variants) {
+      const req: any = { headers: { authorization } };
+      const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+      const next = vi.fn();
+      requireAuth(req, res, next);
+      expect(next).toHaveBeenCalled();
+    }
+  });
+
+  it('allows requests with trailing spaces after token', () => {
+    process.env.ANALYTICS_AUTH_TOKEN = 'secret';
+    const req: any = { headers: { authorization: 'Bearer secret   ' } };
+    const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+    const next = vi.fn();
+    requireAuth(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- parse Authorization header case-insensitively and trim token before comparing
- use `crypto.timingSafeEqual` for token comparison
- add tests for varied header casing and trailing spaces

## Testing
- `npm test` *(fails: Failed to load url papaparse in csv.ts)*
- `npx vitest run tests/auth.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8ef85039c8327befca9881005232e