### PR TITLE
Handle CSV parsing errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -619,7 +619,18 @@ function EmployeesPage({employees, setEmployees}:{employees:Employee[]; setEmplo
     <div className="grid">
       <div className="card"><div className="card-h">Import Staff (CSV)</div><div className="card-c">
         <input type="file" accept=".csv" onChange={async e=>{
-          const f=e.target.files?.[0]; if(!f) return; const text=await f.text(); const { parseCSV } = await import("./utils/csv"); const rows=parseCSV(text);
+          const f=e.target.files?.[0];
+          if(!f) return;
+          const text=await f.text();
+          const { parseCSV } = await import("./utils/csv");
+          let rows:Record<string,string>[] = [];
+          try {
+            rows = parseCSV(text);
+          } catch(err) {
+            console.error(err);
+            alert('Failed to parse CSV');
+            return;
+          }
           const out:Employee[]=rows.map((r:any,i:number)=>({
             id:String(r.id??r.EmployeeID??`emp_${i}`),
             firstName:String(r.firstName ?? r.name ?? ""),

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -2,11 +2,16 @@ import Papa from 'papaparse';
 
 // Parses a CSV string into an array of objects keyed by header names.
 export function parseCSV(input: string): Record<string, string>[] {
-  const { data } = Papa.parse<Record<string, string>>(input, {
+  const results = Papa.parse<Record<string, string>>(input, {
     header: true,
     skipEmptyLines: true,
   });
 
-  return data as Record<string, string>[];
+  if (results.errors.length > 0) {
+    const firstError = results.errors[0];
+    throw new Error(`CSV parsing error on row ${firstError.row}: ${firstError.message}`);
+  }
+
+  return results.data as Record<string, string>[];
 }
 

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -42,5 +42,10 @@ describe('parseCSV', () => {
       { id: '1', notes: 'Line1\nLine2' }
     ]);
   });
+
+  it('throws on malformed CSV input', () => {
+    const input = 'id,name\n1,"Unclosed';
+    expect(() => parseCSV(input)).toThrowError(/CSV parsing error/);
+  });
 });
 


### PR DESCRIPTION
## Summary
- validate PapaParse results and throw on CSV parsing errors
- catch and display failures when importing staff CSV
- add test coverage for malformed CSV input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8ef8312e483279fc09697ebe1c375