### PR TITLE
Limit SelectEmployee menu height

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -931,7 +931,18 @@ function SelectEmployee({employees, value, onChange, allowEmpty=false}:{employee
     <div className="dropdown" ref={ref}>
       <input placeholder={curr? `${curr.firstName} ${curr.lastName} (${curr.id})`:"Type name or ID…"} value={q} onChange={e=>{ setQ(e.target.value); setOpen(true); }} onFocus={()=> setOpen(true)} />
       {open && (
-        <div className="menu" ref={menuRef} style={{top:dropUp?'auto':'100%',bottom:dropUp?'100%':'auto',maxHeight:rect?window.innerHeight-rect.top-20:undefined,overflow:'auto'}}>
+        <div
+          className="menu"
+          ref={menuRef}
+          style={{
+            top: dropUp ? 'auto' : '100%',
+            bottom: dropUp ? '100%' : 'auto',
+            maxHeight: rect
+              ? Math.min(320, dropUp ? rect.top - 20 : window.innerHeight - rect.top - 20)
+              : 320,
+            overflow: 'auto',
+          }}
+        >
           {allowEmpty && (
             <div className="item" onClick={()=>{ onChange("EMPTY"); setQ(""); setOpen(false); }}>Empty</div>
           )}


### PR DESCRIPTION
## Summary
- cap SelectEmployee dropdown height to 320px and adjust for drop-up placement

## Testing
- `npm test`
- `npm run typecheck` *(fails: Argument of type '(prev: Vacancy[]) => ...' is not assignable to parameter of type 'SetStateAction<Vacancy[]>' and missing papaparse types)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f39693dc8327aafd25f8dcda9ef9