### PR TITLE
Add token-based auth utility and Analytics UI

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,27 @@
+export const TOKEN_KEY = 'apiToken';
+
+export function getToken(): string | null {
+  // Prefer token from localStorage if available
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem(TOKEN_KEY);
+    if (stored) return stored;
+  }
+  // Fallback to environment variable
+  const envToken = import.meta.env.VITE_API_TOKEN as string | undefined;
+  return envToken ?? null;
+}
+
+export function setToken(token: string) {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(TOKEN_KEY, token);
+  }
+}
+
+export async function authFetch(input: RequestInfo, init: RequestInit = {}) {
+  const token = getToken();
+  const headers = new Headers(init.headers);
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return fetch(input, { ...init, headers });
+}


### PR DESCRIPTION
## Summary
- add reusable auth helper that reads token from localStorage or env and attaches Authorization header
- secure analytics endpoints by using auth helper, export handler, and token prompt UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f6ea40788327a546ea87e18876fb