### PR TITLE
feat: add error boundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+export type ErrorBoundaryProps = {
+  children: ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+};
+
+export type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export function useErrorLogger() {
+  return React.useCallback((error: Error, info: ErrorInfo) => {
+    console.error('Uncaught error:', error, info);
+  }, []);
+}
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert">
+          <h1>Something went wrong.</h1>
+          <p>Please refresh the page or contact support.</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,19 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import './styles/responsive.css'
+import ErrorBoundary, { useErrorLogger } from './components/ErrorBoundary'
+
+function Root() {
+  const logError = useErrorLogger()
+  return (
+    <ErrorBoundary onError={logError}>
+      <App />
+    </ErrorBoundary>
+  )
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>
 )

--- a/tests/errorBoundary.test.tsx
+++ b/tests/errorBoundary.test.tsx
@@ -1,0 +1,24 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ErrorBoundary from '../src/components/ErrorBoundary';
+
+function ProblemChild() {
+  throw new Error('Test error');
+}
+
+describe('ErrorBoundary', () => {
+  it('renders fallback UI when a child throws', () => {
+    const log = vi.fn();
+    const { getByRole } = render(
+      <ErrorBoundary onError={log}>
+        <ProblemChild />
+      </ErrorBoundary>
+    );
+    expect(getByRole('alert').textContent).toContain('Something went wrong.');
+    expect(log).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add React ErrorBoundary with logging hook and fallback UI
- wrap application root with the new ErrorBoundary
- test that ErrorBoundary shows fallback when child throws

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8f6ec99108327b906a63ed42dc331