### PR TITLE
Clamp offering round minutes and validate input

### DIFF
--- a/src/components/OfferingControls.tsx
+++ b/src/components/OfferingControls.tsx
@@ -35,6 +35,12 @@ export default function OfferingControls({ vacancy, round }: Props) {
     }
   };
 
+  const handleMinutesChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    if (Number.isNaN(value)) return;
+    round.setRoundMinutes(value);
+  };
+
   const mins = Math.max(0, Math.floor(round.timeLeftMs / 60000));
   const secs = Math.max(0, Math.floor((round.timeLeftMs % 60000) / 1000));
 
@@ -72,8 +78,11 @@ export default function OfferingControls({ vacancy, round }: Props) {
         Round length (min)
         <input
           type="number"
+          min={1}
+          max={1440}
+          step={1}
           value={vacancy.offeringRoundMinutes ?? 120}
-          onChange={(e) => round.setRoundMinutes(Number(e.target.value))}
+          onChange={handleMinutesChange}
         />
       </label>
       {pendingTier && (

--- a/src/offering/useOfferingRound.ts
+++ b/src/offering/useOfferingRound.ts
@@ -97,8 +97,10 @@ export function createOfferingRound(vac: Vacancy, opts: RoundOptions) {
       opts.updateVacancy({ offeringAutoProgress: enabled });
     },
     setRoundMinutes(mins: number) {
-      vac.offeringRoundMinutes = mins;
-      opts.updateVacancy({ offeringRoundMinutes: mins });
+      if (!Number.isFinite(mins)) return;
+      const clamped = Math.min(1440, Math.max(1, Math.round(mins)));
+      vac.offeringRoundMinutes = clamped;
+      opts.updateVacancy({ offeringRoundMinutes: clamped });
       opts.onTick?.(computeMsLeft());
     },
     dispose() {

--- a/tests/offering.test.ts
+++ b/tests/offering.test.ts
@@ -92,4 +92,24 @@ describe('useOfferingRound', () => {
     expect(vac.offeringTier).toBe('OT_FULL_TIME');
     round.dispose();
   });
+
+  it('clamps round minutes to 1-1440 and ignores non-numeric', () => {
+    const vac: Vacancy = { id: '1', offeringTier: 'CASUALS', offeringRoundMinutes: 120 };
+    const updateVacancy = vi.fn();
+    const round = createOfferingRound(vac, {
+      updateVacancy,
+      currentUser: 'manager',
+      onTick: () => {},
+    });
+    round.setRoundMinutes(-5);
+    expect(vac.offeringRoundMinutes).toBe(1);
+    expect(updateVacancy).toHaveBeenLastCalledWith({ offeringRoundMinutes: 1 });
+    round.setRoundMinutes(2000);
+    expect(vac.offeringRoundMinutes).toBe(1440);
+    expect(updateVacancy).toHaveBeenLastCalledWith({ offeringRoundMinutes: 1440 });
+    round.setRoundMinutes(NaN as any);
+    expect(vac.offeringRoundMinutes).toBe(1440);
+    expect(updateVacancy).toHaveBeenCalledTimes(2);
+    round.dispose();
+  });
 });


### PR DESCRIPTION
## Summary
- Clamp offering round duration within 1–1440 minutes
- Add UI restrictions and sanitization for round length input
- Test invalid minute inputs for clamping and non-numeric handling

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8f6f953748327bdde245a4bc182e8