### PR TITLE
Ensure controller cleanup in analytics

### DIFF
--- a/tests/analytics.test.tsx
+++ b/tests/analytics.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen, waitFor } from '@testing-library/react';
 import { vi, expect, test } from 'vitest';
-import Analytics from '../src/Analytics';
+import Analytics, { controllerRef } from '../src/Analytics';
 
 // Mock chart components to avoid canvas requirement
 vi.mock('react-chartjs-2', () => ({
@@ -9,7 +9,24 @@ vi.mock('react-chartjs-2', () => ({
   Line: () => null,
 }));
 
-test('loading indicator disappears after fetch abort', async () => {
+test('controller cleared after successful load', async () => {
+  const mockData = [
+    { period: '2023', posted: 1, awarded: 1, cancelled: 0, cancellationRate: 0, overtime: 0 }
+  ];
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(mockData) })
+  ) as any;
+
+  render(<Analytics />);
+
+  await waitFor(() => {
+    expect(screen.queryByText('Loading...')).toBeNull();
+  });
+
+  expect(controllerRef.current).toBeNull();
+});
+
+test('controller cleared after fetch abort', async () => {
   global.fetch = vi.fn(() =>
     Promise.reject(Object.assign(new Error('Aborted'), { name: 'AbortError' }))
   ) as any;
@@ -19,4 +36,6 @@ test('loading indicator disappears after fetch abort', async () => {
   await waitFor(() => {
     expect(screen.queryByText('Loading...')).toBeNull();
   });
+
+  expect(controllerRef.current).toBeNull();
 });


### PR DESCRIPTION
## Summary
- clear analytics fetch controller in a finally block so loading state always ends
- expose controller ref for tests
- add tests for controller cleanup after successful and aborted loads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f6fbc1f88327a288312e1c330f33