### PR TITLE
Harden analytics auth and fix offering state updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
+        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^4.2.0",
         "jsdom": "^26.1.0",
         "typescript": "^5.4.0",
@@ -1359,6 +1360,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1385,6 +1393,29 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@testing-library/react": "^16.3.0",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.2.0",
     "jsdom": "^26.1.0",
     "typescript": "^5.4.0",

--- a/server/auth.js
+++ b/server/auth.js
@@ -3,7 +3,9 @@ import { timingSafeEqual } from 'crypto';
 export function requireAuth(req, res, next) {
   const token = process.env.ANALYTICS_AUTH_TOKEN;
   if (!token) {
-    return next();
+    return res
+      .status(401)
+      .json({ error: 'Analytics auth token not configured' });
   }
 
   const authHeader = req.headers.authorization;

--- a/src/components/OfferingControls.tsx
+++ b/src/components/OfferingControls.tsx
@@ -1,13 +1,9 @@
 import { useState } from 'react';
 import { TIERS, tierLabel, OfferingTier, requiresConfirmation } from '../offering/offeringMachine';
-import { UseOfferingRound } from '../offering/useOfferingRound';
+import { UseOfferingRound, Vacancy } from '../offering/useOfferingRound';
 
 interface Props {
-  vacancy: {
-    offeringTier: OfferingTier;
-    offeringAutoProgress?: boolean;
-    offeringRoundMinutes?: number;
-  };
+  vacancy: Vacancy;
   round: UseOfferingRound;
 }
 
@@ -18,6 +14,7 @@ interface Props {
 export default function OfferingControls({ vacancy, round }: Props) {
   const [pendingTier, setPendingTier] = useState<OfferingTier | null>(null);
   const [note, setNote] = useState('');
+  const tierName = `tier-${vacancy.id}`;
 
   const onSelect = (tier: OfferingTier) => {
     if (requiresConfirmation(tier)) {
@@ -49,7 +46,7 @@ export default function OfferingControls({ vacancy, round }: Props) {
           <label key={t} style={{ marginRight: '0.5rem' }}>
             <input
               type="radio"
-              name="tier"
+              name={tierName}
               checked={vacancy.offeringTier === t}
               onChange={() => onSelect(t)}
             />

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -6,12 +6,14 @@ describe('requireAuth', () => {
     delete process.env.ANALYTICS_AUTH_TOKEN;
   });
 
-  it('allows requests when no token is configured', () => {
+  it('rejects requests when no token is configured', () => {
     const req: any = { headers: {} };
     const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
     const next = vi.fn();
     requireAuth(req, res, next);
-    expect(next).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Analytics auth token not configured' });
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('rejects requests with invalid token', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "strict": true
+    "strict": true,
+    "types": ["vite/client"]
   },
   "include": [
     "src"


### PR DESCRIPTION
## Summary
- block analytics access when auth token missing
- use unique radio group names per vacancy
- avoid mutating vacancy objects in offering rounds

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8f92fab3483278851573bec35234c