### PR TITLE
feat: configurable overtime and average metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ export ANALYTICS_AUTH_TOKEN=mys3cret
 npm run server
 ```
 
+## Analytics API options
+
+Analytics endpoints accept an optional `overtimeThreshold` query parameter to
+control how overtime hours are calculated. The default threshold is **8** hours.
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer $ANALYTICS_AUTH_TOKEN" \
+  "http://localhost:3000/api/analytics?overtimeThreshold=10"
+```
+
 ## Responsive design
 - Mobile breakpoint at **600px** is defined in `src/styles/responsive.css`.
 - Use the `responsive-table` class on tables and `form-row` for grouped form inputs to stack vertically on narrow screens.

--- a/server/analyticsFormats/csv.js
+++ b/server/analyticsFormats/csv.js
@@ -1,7 +1,11 @@
 export function createCsv(data) {
-  const header = 'period,posted,awarded,cancelled,cancellationRate,overtime\n';
+  const header =
+    'period,posted,awarded,cancelled,cancellationRate,overtime,averageHours\n';
   const rows = data
-    .map(d => `${d.period},${d.posted},${d.awarded},${d.cancelled},${d.cancellationRate},${d.overtime}`)
+    .map(
+      d =>
+        `${d.period},${d.posted},${d.awarded},${d.cancelled},${d.cancellationRate},${d.overtime},${d.averageHours}`,
+    )
     .join('\n');
   return header + rows;
 }

--- a/server/analyticsFormats/pdf.js
+++ b/server/analyticsFormats/pdf.js
@@ -8,7 +8,8 @@ export function createPdf(data) {
       .fontSize(12)
       .text(
         `${row.period}: posted ${row.posted}, awarded ${row.awarded}, cancelled ${row.cancelled}, ` +
-          `cancellationRate ${(row.cancellationRate * 100).toFixed(2)}%, overtime ${row.overtime}`
+          `cancellationRate ${(row.cancellationRate * 100).toFixed(2)}%, overtime ${row.overtime}, ` +
+          `average hours ${row.averageHours.toFixed(2)}`
       );
   });
   return doc;

--- a/server/index.js
+++ b/server/index.js
@@ -9,13 +9,19 @@ const app = express();
 app.use(cors());
 
 app.get('/api/analytics', requireAuth, (req, res) => {
-  const data = aggregateByMonth(sampleVacancies);
+  const threshold = parseFloat(req.query.overtimeThreshold);
+  const data = aggregateByMonth(sampleVacancies, {
+    overtimeThreshold: isNaN(threshold) ? undefined : threshold,
+  });
   res.json(data);
 });
 
 app.get('/api/analytics/export', requireAuth, (req, res) => {
   const format = req.query.format;
-  const data = aggregateByMonth(sampleVacancies);
+  const threshold = parseFloat(req.query.overtimeThreshold);
+  const data = aggregateByMonth(sampleVacancies, {
+    overtimeThreshold: isNaN(threshold) ? undefined : threshold,
+  });
   switch (format) {
     case 'csv': {
       res.setHeader('Content-Type', 'text/csv');

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -1,4 +1,5 @@
-export function aggregateByMonth(vacancies) {
+export function aggregateByMonth(vacancies, options = {}) {
+  const { overtimeThreshold = 8 } = options;
   const groups = {};
   for (const v of vacancies) {
     const month = v.date.slice(0, 7);
@@ -14,8 +15,22 @@ export function aggregateByMonth(vacancies) {
       const cancellationRate = posted ? cancelled / posted : 0;
       const overtime = items
         .filter(i => i.status === 'awarded')
-        .reduce((sum, i) => sum + Math.max(0, i.hours - 8), 0);
-      return { period, posted, awarded, cancelled, cancellationRate, overtime };
+        .reduce(
+          (sum, i) => sum + Math.max(0, i.hours - overtimeThreshold),
+          0,
+        );
+      const avgHours = items.length
+        ? items.reduce((sum, i) => sum + i.hours, 0) / items.length
+        : 0;
+      return {
+        period,
+        posted,
+        awarded,
+        cancelled,
+        cancellationRate,
+        overtime,
+        averageHours: avgHours,
+      };
     });
 }
 

--- a/tests/analyticsFormats.test.ts
+++ b/tests/analyticsFormats.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { createCsv } from '../server/analyticsFormats/csv.js';
+
+describe('createCsv', () => {
+  it('includes averageHours column', () => {
+    const data = [
+      {
+        period: '2024-01',
+        posted: 1,
+        awarded: 1,
+        cancelled: 0,
+        cancellationRate: 0,
+        overtime: 2,
+        averageHours: 10,
+      },
+    ];
+    const csv = createCsv(data);
+    expect(csv).toContain('averageHours');
+    expect(csv.trim().split('\n')[1].split(',').pop()).toBe('10');
+  });
+});

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -11,10 +11,20 @@ describe('aggregateByMonth', () => {
     expect(jan?.cancelled).toBe(1);
     expect(jan?.cancellationRate).toBeCloseTo(1 / 3);
     expect(jan?.overtime).toBe(2);
+    expect(jan?.averageHours).toBeCloseTo(26 / 3);
     expect(feb?.posted).toBe(3);
     expect(feb?.awarded).toBe(2);
     expect(feb?.cancelled).toBe(1);
     expect(feb?.cancellationRate).toBeCloseTo(1 / 3);
     expect(feb?.overtime).toBe(1);
+    expect(feb?.averageHours).toBeCloseTo(25 / 3);
+  });
+
+  it('supports custom overtime threshold', () => {
+    const result = aggregateByMonth(sampleVacancies, { overtimeThreshold: 10 });
+    const jan = result.find(r => r.period === '2024-01');
+    const feb = result.find(r => r.period === '2024-02');
+    expect(jan?.overtime).toBe(0);
+    expect(feb?.overtime).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- support configurable overtime threshold when aggregating vacancy metrics
- track average hours per month and include in CSV/PDF exports
- document analytics API query parameter and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8fba5536483278ec9638a5fd26add