### PR TITLE
feat: add manual employee entry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,8 @@ export type Employee = {
   classification: Classification;
   status: Status;
   homeWing?: string; // not used for coverage now
+  startDate?: string; // ISO YYYY-MM-DD
+  seniorityHours?: number;
   seniorityRank: number; // 1 = most senior
   active: boolean;
 };
@@ -950,6 +952,8 @@ function EmployeesPage({
                   ? r.status
                   : "FT") as Status,
                 homeWing: String(r.homeWing ?? ""),
+                startDate: String(r.startDate ?? ""),
+                seniorityHours: Number(r.seniorityHours ?? 0),
                 seniorityRank: Number(r.seniorityRank ?? i + 1),
                 active: String(r.active ?? "Yes")
                   .toLowerCase()
@@ -960,8 +964,70 @@ function EmployeesPage({
           />
           <div className="subtitle">
             Columns: id, firstName, lastName, classification (RCA/LPN/RN),
-            status (FT/PT/Casual), homeWing, seniorityRank, active (Yes/No)
+            status (FT/PT/Casual), homeWing, startDate, seniorityHours,
+            seniorityRank, active (Yes/No)
           </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-h">Add Employee</div>
+        <div className="card-c">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const form = e.target as HTMLFormElement;
+              const name = (form.elements.namedItem("name") as HTMLInputElement)
+                .value;
+              const start = (
+                form.elements.namedItem("start") as HTMLInputElement
+              ).value;
+              const hours = Number(
+                (form.elements.namedItem("hours") as HTMLInputElement).value,
+              );
+              if (!name) return;
+              const [first, ...rest] = name.trim().split(" ");
+              const newEmp: Employee = {
+                id: `emp_${Date.now()}`,
+                firstName: first ?? "",
+                lastName: rest.join(" "),
+                classification: "RCA",
+                status: "FT",
+                startDate: start,
+                seniorityHours: hours || 0,
+                seniorityRank: employees.length + 1,
+                active: true,
+              };
+              const sorted = [...employees, newEmp]
+                .sort((a, b) => {
+                  const hDiff =
+                    (b.seniorityHours ?? 0) - (a.seniorityHours ?? 0);
+                  if (hDiff !== 0) return hDiff;
+                  return (a.seniorityRank ?? 99999) - (b.seniorityRank ?? 99999);
+                })
+                .map((e, i) => ({ ...e, seniorityRank: i + 1 }));
+              setEmployees(sorted);
+              form.reset();
+            }}
+          >
+            <div className="row cols3">
+              <div>
+                <label>Name</label>
+                <input name="name" type="text" />
+              </div>
+              <div>
+                <label>Start Date</label>
+                <input name="start" type="date" />
+              </div>
+              <div>
+                <label>Seniority Hours</label>
+                <input name="hours" type="number" />
+              </div>
+            </div>
+            <button type="submit" style={{ marginTop: 8 }}>
+              Add
+            </button>
+          </form>
         </div>
       </div>
 
@@ -973,6 +1039,8 @@ function EmployeesPage({
               <tr>
                 <th>ID</th>
                 <th>Name</th>
+                <th>Start Date</th>
+                <th>Seniority Hrs</th>
                 <th>Class</th>
                 <th>Status</th>
                 <th>Rank</th>
@@ -986,6 +1054,8 @@ function EmployeesPage({
                   <td>
                     {e.firstName} {e.lastName}
                   </td>
+                  <td>{e.startDate}</td>
+                  <td>{e.seniorityHours ?? 0}</td>
                   <td>{e.classification}</td>
                   <td>{e.status}</td>
                   <td>{e.seniorityRank}</td>

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -23,6 +23,7 @@ export interface Bid {
 export interface Employee {
   id: string;
   active: boolean;
+  seniorityHours?: number;
   seniorityRank?: number;
   classification: string;
 }
@@ -47,8 +48,12 @@ export function recommend(
     return { why: ["No eligible bidders"] };
   }
   candidates.sort((a, b) => {
-    // Primary sort by seniority rank. If ranks tie, prefer the earlier bid
-    // determined by timestamp when present, otherwise by bid order.
+    // Primary sort by seniority hours when available, otherwise rank.
+    // If those tie, prefer the earlier bid determined by timestamp when
+    // present, otherwise by bid order.
+    const hoursDiff =
+      (b.emp.seniorityHours ?? 0) - (a.emp.seniorityHours ?? 0);
+    if (hoursDiff !== 0) return hoursDiff;
     const rankDiff =
       (a.emp.seniorityRank ?? 99999) - (b.emp.seniorityRank ?? 99999);
     if (rankDiff !== 0) return rankDiff;
@@ -60,7 +65,9 @@ export function recommend(
   const chosen = candidates[0].emp;
   const why = [
     "Bidder",
-    `Rank ${chosen.seniorityRank ?? "?"}`,
+    chosen.seniorityHours !== undefined
+      ? `Hours ${chosen.seniorityHours}`
+      : `Rank ${chosen.seniorityRank ?? "?"}`,
     `Class ${chosen.classification}`,
   ];
   return { id: chosen.id, why };

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -67,4 +67,19 @@ describe("recommend", () => {
     const rec = recommend(vac, tieBids, employeesWithTie);
     expect(rec.id).toBe("e");
   });
+
+  it("prefers higher seniority hours when present", () => {
+    const vac = { id: "vac1", classification: "RN", offeringTier: "CASUALS" };
+    const employeesWithHours = {
+      x: { id: "x", active: true, seniorityHours: 200, classification: "RN" },
+      y: { id: "y", active: true, seniorityHours: 100, classification: "RN" },
+    };
+    const hourBids = [
+      { vacancyId: "vac1", bidderEmployeeId: "y" },
+      { vacancyId: "vac1", bidderEmployeeId: "x" },
+    ];
+    const rec = recommend(vac, hourBids, employeesWithHours);
+    expect(rec.id).toBe("x");
+    expect(rec.why).toContain("Hours 200");
+  });
 });


### PR DESCRIPTION
## Summary
- allow entering a new employee with name, start date, and seniority hours
- include seniority hours in recommendations and employee table
- cover seniority hour handling with new test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a90245b4e08327a8eb52a60daf79a8