### PR TITLE
Add dashboard with Maplewood branding for shift overview

### DIFF
--- a/public/maplewood-logo.svg
+++ b/public/maplewood-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="40" viewBox="0 0 120 40">
+  <rect width="120" height="40" fill="#2a7a2a" rx="4"/>
+  <text x="60" y="25" text-anchor="middle" font-size="20" font-family="Arial" fill="white">Maplewood</text>
+</svg>

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from "react";
+import type { Employee, Vacancy } from "./App";
+import "./styles/branding.css";
+
+const LS_KEY = "maplewood-scheduler-v3";
+const loadState = () => {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+};
+
+type State = {
+  employees: Employee[];
+  vacancies: Vacancy[];
+};
+
+export default function Dashboard() {
+  const data: State = loadState() || { employees: [], vacancies: [] };
+  const { employees, vacancies } = data;
+
+  const awarded = useMemo(
+    () => vacancies.filter((v) => v.status === "Awarded"),
+    [vacancies],
+  );
+  const open = useMemo(
+    () => vacancies.filter((v) => v.status !== "Awarded"),
+    [vacancies],
+  );
+
+  const employeeLastAssigned = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const v of awarded) {
+      if (v.awardedTo && v.awardedAt) {
+        const prev = map[v.awardedTo];
+        if (!prev || new Date(v.awardedAt) > new Date(prev)) {
+          map[v.awardedTo] = v.awardedAt;
+        }
+      }
+    }
+    return map;
+  }, [awarded]);
+
+  const employeesWithLast = useMemo(
+    () =>
+      employees
+        .map((e) => ({ ...e, lastAssigned: employeeLastAssigned[e.id] }))
+        .sort((a, b) => {
+          const ad = a.lastAssigned ? new Date(a.lastAssigned).getTime() : 0;
+          const bd = b.lastAssigned ? new Date(b.lastAssigned).getTime() : 0;
+          return bd - ad;
+        }),
+    [employees, employeeLastAssigned],
+  );
+
+  const isRecent = (date?: string) => {
+    if (!date) return false;
+    const d = new Date(date);
+    const diff = Date.now() - d.getTime();
+    return diff < 7 * 24 * 60 * 60 * 1000;
+  };
+
+  return (
+    <div>
+      <header className="maplewood-header">
+        <img src="/maplewood-logo.svg" alt="Maplewood logo" height={40} />
+        <h1>Shift Dashboard</h1>
+      </header>
+
+      <section>
+        <h2>Awarded Shifts</h2>
+        <div className="shift-list">
+          {awarded.map((v) => (
+            <div key={v.id} className="shift-card awarded">
+              {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
+            </div>
+          ))}
+          {awarded.length === 0 && <p>No awarded shifts.</p>}
+        </div>
+      </section>
+
+      <section>
+        <h2>Open Shifts</h2>
+        <div className="shift-list">
+          {open.map((v) => (
+            <div key={v.id} className="shift-card open">
+              {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
+            </div>
+          ))}
+          {open.length === 0 && <p>No open shifts.</p>}
+        </div>
+      </section>
+
+      <section className="employee-list">
+        <h2>Recent Assignments</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Employee</th>
+              <th>Last Assigned</th>
+            </tr>
+          </thead>
+          <tbody>
+            {employeesWithLast.map((e) => (
+              <tr key={e.id} className={isRecent(e.lastAssigned) ? "recent" : undefined}>
+                <td>
+                  {e.firstName} {e.lastName}
+                </td>
+                <td>
+                  {e.lastAssigned
+                    ? new Date(e.lastAssigned).toLocaleDateString()
+                    : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import App from "./App";
 import Analytics from "./Analytics";
 import Agreement from "./Agreement";
+import Dashboard from "./Dashboard";
 import "./styles/responsive.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
@@ -13,6 +14,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <Route path="/" element={<App />} />
         <Route path="/analytics" element={<Analytics />} />
         <Route path="/agreement" element={<Agreement />} />
+        <Route path="/dashboard" element={<Dashboard />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/styles/branding.css
+++ b/src/styles/branding.css
@@ -1,0 +1,49 @@
+.maplewood-header {
+  background-color: #2a7a2a;
+  color: white;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.shift-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 20px 0;
+}
+
+.shift-card {
+  padding: 10px;
+  border-radius: 4px;
+  border-left: 6px solid transparent;
+}
+
+.shift-card.awarded {
+  background-color: #e6f4ea;
+  border-color: #2a7a2a;
+}
+
+.shift-card.open {
+  background-color: #fff8e1;
+  border-color: #ffc107;
+}
+
+.employee-list {
+  margin-top: 20px;
+}
+
+.employee-list table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.employee-list th, .employee-list td {
+  padding: 8px;
+  border-bottom: 1px solid #ddd;
+}
+
+.employee-list tr.recent td {
+  background-color: #fff8e1;
+}


### PR DESCRIPTION
## Summary
- Add React dashboard route highlighting awarded vs open shifts
- Include Maplewood branding with logo, colors, and header
- Show employees' most recent assignments for balancing schedules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9053d87788327ac1db676ce98ab11