### PR TITLE
Refresh interface with modern theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;800&display=swap"
+      rel="stylesheet"
+    />
     <title>Maplewood Scheduler</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -463,10 +463,10 @@ export default function App() {
       <style>{`
         /* Themes */
         :root{ --baseRadius:14px; }
-        .app{min-height:100vh;min-height:100dvh;background:linear-gradient(180deg,var(--bg1),var(--bg2));color:var(--text);font-family:Inter,system-ui,Arial,sans-serif;padding:calc(18px + env(safe-area-inset-top)) 18px calc(18px + env(safe-area-inset-bottom)) 18px}
+        .app{min-height:100vh;min-height:100dvh;background:linear-gradient(180deg,var(--bg1),var(--bg2));color:var(--text);font-family:'Nunito',system-ui,Arial,sans-serif;padding:calc(18px + env(safe-area-inset-top)) 18px calc(18px + env(safe-area-inset-bottom)) 18px}
         @supports(-webkit-touch-callout:none){.app{min-height:-webkit-fill-available}}
-        [data-theme="dark"]{ --bg1:#0a0c12; --bg2:#0d1117; --card:#141a25; --cardAlt:#0f1622; --stroke:#263145; --text:#ffffff; --muted:#d1d5db; --brand:#4ea1ff; --accent:#2dd4bf; --ok:#16a34a; --warn:#f59e0b; --bad:#ef4444; --chipBg:#1d2736; --chipText:#f0f4ff; }
-        [data-theme="light"]{ --bg1:#f5f7fb; --bg2:#ffffff; --card:#ffffff; --cardAlt:#f7f9fc; --stroke:#e1e6ef; --text:#0b1320; --muted:#4a5872; --brand:#0b6bcb; --accent:#0d9488; --ok:#15803d; --warn:#b45309; --bad:#b91c1c; --chipBg:#eef2f9; --chipText:#0b1320; }
+        [data-theme="dark"]{ --bg1:#0f172a; --bg2:#1f2937; --card:#1e293b; --cardAlt:#273446; --stroke:#334155; --text:#f1f5f9; --muted:#cbd5e1; --brand:#0d9488; --accent:#34d399; --ok:#16a34a; --warn:#f59e0b; --bad:#ef4444; --chipBg:#334155; --chipText:#f1f5f9; }
+        [data-theme="light"]{ --bg1:#f0fdf4; --bg2:#ffffff; --card:#ffffff; --cardAlt:#f6fdf9; --stroke:#d1fae5; --text:#064e3b; --muted:#3f7f65; --brand:#047857; --accent:#10b981; --ok:#15803d; --warn:#b45309; --bad:#b91c1c; --chipBg:#dcfce7; --chipText:#064e3b; }
 
         *{box-sizing:border-box}
         body,html,#root{height:100%;margin:0;-webkit-text-size-adjust:100%}
@@ -475,17 +475,18 @@ export default function App() {
         .title{font-size:22px;font-weight:800}
         .subtitle{color:var(--muted);font-size:13px}
         .toolbar{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-        .btn{background:var(--cardAlt);border:1px solid var(--stroke);padding:9px 12px;border-radius:12px;color:var(--text);cursor:pointer;font-weight:600}
-        .btn:hover{border-color:var(--brand)}
+        .btn{background:var(--cardAlt);border:1px solid var(--stroke);padding:9px 12px;border-radius:12px;color:var(--text);cursor:pointer;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s}
+        .btn:hover{border-color:var(--brand);background:var(--brand);color:#fff;box-shadow:0 2px 4px rgba(0,0,0,.1);transform:translateY(-1px)}
         .btn-sm{padding:4px 8px;font-size:12px}
         @media(max-width:900px){.nav{flex-direction:column;align-items:flex-start;gap:8px}.toolbar{width:100%;flex-wrap:wrap}}
         @media(max-width:600px){.toolbar{flex-direction:column;align-items:stretch}}
         .tabs{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0 16px}
         .tab{padding:8px 12px;border-radius:12px;border:1px solid var(--stroke);cursor:pointer;background:var(--cardAlt);font-weight:600;color:var(--text)}
-        .tab.active{border-color:var(--brand);box-shadow:0 0 0 2px rgba(94,155,255,.24) inset}
+        .tab.active{border-color:var(--brand);background:var(--brand);color:#fff;box-shadow:0 0 0 2px var(--brand) inset}
         .grid{display:grid;gap:12px}
         .grid2{grid-template-columns:1fr}
-        .card{background:var(--card);border:1px solid var(--stroke);border-radius:var(--baseRadius);overflow:visible}
+        .card{background:var(--card);border:1px solid var(--stroke);border-radius:var(--baseRadius);overflow:visible;box-shadow:0 4px 6px rgba(0,0,0,.06);transition:box-shadow .2s,transform .2s}
+        .card:hover{box-shadow:0 8px 12px rgba(0,0,0,.1);transform:translateY(-2px)}
         .card-h{padding:10px 14px;border-bottom:1px solid var(--stroke);font-weight:800;display:flex;align-items:center;justify-content:space-between}
         .card-c{padding:14px}
         table{width:100%;border-collapse:separate; border-spacing:0}
@@ -501,7 +502,7 @@ export default function App() {
         .ok{color:var(--ok)} .warn{color:var(--warn)} .bad{color:var(--bad)}
         .dropdown{position:relative}
         .menu{position:absolute;z-index:30;top:100%;left:0;right:0;background:var(--cardAlt);border:1px solid var(--stroke);border-radius:10px;max-height:240px;overflow:auto}
-        .item{padding:8px 10px;cursor:pointer} .item:hover{background:rgba(100,140,220,.12)}
+        .item{padding:8px 10px;cursor:pointer} .item:hover{background:rgba(4,120,87,.12)}
 
         /* Calendar */
         .cal-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:8px;margin-top:8px}

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -63,61 +63,63 @@ export default function Dashboard() {
   };
 
   return (
-    <div>
+    <div className="dashboard">
       <header className="maplewood-header">
         <img src="/maplewood-logo.svg" alt="Maplewood logo" height={40} />
         <h1>Shift Dashboard</h1>
       </header>
 
-      <section>
-        <h2>Awarded Shifts</h2>
-        <div className="shift-list">
-          {awarded.map((v) => (
-            <div key={v.id} className="shift-card awarded">
-              {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
-            </div>
-          ))}
-          {awarded.length === 0 && <p>No awarded shifts.</p>}
-        </div>
-      </section>
-
-      <section>
-        <h2>Open Shifts</h2>
-        <div className="shift-list">
-          {open.map((v) => (
-            <div key={v.id} className="shift-card open">
-              {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
-            </div>
-          ))}
-          {open.length === 0 && <p>No open shifts.</p>}
-        </div>
-      </section>
-
-      <section className="employee-list">
-        <h2>Recent Assignments</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Employee</th>
-              <th>Last Assigned</th>
-            </tr>
-          </thead>
-          <tbody>
-            {employeesWithLast.map((e) => (
-              <tr key={e.id} className={isRecent(e.lastAssigned) ? "recent" : undefined}>
-                <td>
-                  {e.firstName} {e.lastName}
-                </td>
-                <td>
-                  {e.lastAssigned
-                    ? new Date(e.lastAssigned).toLocaleDateString()
-                    : "—"}
-                </td>
-              </tr>
+      <main className="dashboard-content">
+        <section>
+          <h2>Awarded Shifts</h2>
+          <div className="shift-list">
+            {awarded.map((v) => (
+              <div key={v.id} className="shift-card awarded">
+                {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
+              </div>
             ))}
-          </tbody>
-        </table>
-      </section>
+            {awarded.length === 0 && <p>No awarded shifts.</p>}
+          </div>
+        </section>
+
+        <section>
+          <h2>Open Shifts</h2>
+          <div className="shift-list">
+            {open.map((v) => (
+              <div key={v.id} className="shift-card open">
+                {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
+              </div>
+            ))}
+            {open.length === 0 && <p>No open shifts.</p>}
+          </div>
+        </section>
+
+        <section className="employee-list">
+          <h2>Recent Assignments</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Employee</th>
+                <th>Last Assigned</th>
+              </tr>
+            </thead>
+            <tbody>
+              {employeesWithLast.map((e) => (
+                <tr key={e.id} className={isRecent(e.lastAssigned) ? "recent" : undefined}>
+                  <td>
+                    {e.firstName} {e.lastName}
+                  </td>
+                  <td>
+                    {e.lastAssigned
+                      ? new Date(e.lastAssigned).toLocaleDateString()
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </main>
     </div>
   );
 }

--- a/src/styles/branding.css
+++ b/src/styles/branding.css
@@ -1,37 +1,87 @@
+:root {
+  --bg1: #f0fdf4;
+  --bg2: #ffffff;
+  --card: #ffffff;
+  --stroke: #d1fae5;
+  --text: #064e3b;
+  --brand: #047857;
+  --accent: #10b981;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg1: #0f172a;
+    --bg2: #1f2937;
+    --card: #1e293b;
+    --stroke: #334155;
+    --text: #f1f5f9;
+    --brand: #0d9488;
+    --accent: #34d399;
+  }
+}
+
+.dashboard {
+  min-height: 100vh;
+  background: linear-gradient(180deg, var(--bg1), var(--bg2));
+  color: var(--text);
+  font-family: 'Nunito', system-ui, Arial, sans-serif;
+  padding: 20px;
+}
+
 .maplewood-header {
-  background-color: #2a7a2a;
+  background: linear-gradient(90deg, var(--brand), var(--accent));
   color: white;
-  padding: 10px;
+  padding: 16px 20px;
   display: flex;
   align-items: center;
   gap: 10px;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.dashboard-content {
+  max-width: 960px;
+  margin: 20px auto 0;
+  display: grid;
+  gap: 20px;
+}
+
+section {
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+h2 {
+  margin-top: 0;
+  color: var(--brand);
 }
 
 .shift-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin: 20px 0;
+  margin-top: 12px;
 }
 
 .shift-card {
   padding: 10px;
-  border-radius: 4px;
-  border-left: 6px solid transparent;
+  border-radius: 8px;
+  border-left: 6px solid var(--brand);
+  background: var(--card);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .shift-card.awarded {
-  background-color: #e6f4ea;
-  border-color: #2a7a2a;
+  background: #d1fae5;
+  border-left-color: var(--accent);
 }
 
 .shift-card.open {
-  background-color: #fff8e1;
-  border-color: #ffc107;
-}
-
-.employee-list {
-  margin-top: 20px;
+  background: #fef9c3;
+  border-left-color: #f59e0b;
 }
 
 .employee-list table {
@@ -39,11 +89,12 @@
   border-collapse: collapse;
 }
 
-.employee-list th, .employee-list td {
+.employee-list th,
+.employee-list td {
   padding: 8px;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid var(--stroke);
 }
 
 .employee-list tr.recent td {
-  background-color: #fff8e1;
+  background: #fef9c3;
 }


### PR DESCRIPTION
## Summary
- add Nunito font and setup for a friendlier visual style
- introduce green-themed light/dark palettes with animated buttons and cards
- redesign dashboard layout with gradient background and card-based sections

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a908ccc72c832782f84e146b73c63f