### PR TITLE
Fix collective agreement PDF detection

### DIFF
--- a/server/collectiveAgreement.js
+++ b/server/collectiveAgreement.js
@@ -18,7 +18,11 @@ export async function initAgreement() {
 
 export async function loadAgreement(filePath) {
   const buffer = fs.readFileSync(filePath);
-  if (filePath.toLowerCase().endsWith(".pdf")) {
+  // Detect PDFs by signature rather than relying on the file extension so
+  // previously uploaded agreements without an extension can still be parsed
+  // correctly on startup.
+  const isPdf = buffer.slice(0, 4).toString() === "%PDF";
+  if (isPdf) {
     const data = await pdfParse(buffer);
     agreementText = data.text;
   } else {

--- a/tests/collectiveAgreement.test.ts
+++ b/tests/collectiveAgreement.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+
+// Mock pdf-parse so we don't rely on the actual library which expects
+// additional assets when bundled for tests.
+vi.mock("pdf-parse", () => ({
+  default: async () => ({ text: "Hello Agreement" }),
+}));
+
+describe("collectiveAgreement", () => {
+  it("parses PDFs without relying on file extension", async () => {
+    // Import after mocking pdf-parse so the mock is applied.
+    const { loadAgreement, searchAgreement } = await import(
+      "../server/collectiveAgreement.js"
+    );
+    // Create a buffer with a PDF signature but no file extension.
+    const pdfBuffer = Buffer.concat([
+      Buffer.from("%PDF"),
+      Buffer.from(" test"),
+    ]);
+    const tmpPath = path.join(process.cwd(), "temp-agreement");
+    fs.writeFileSync(tmpPath, pdfBuffer);
+    try {
+      await loadAgreement(tmpPath);
+      const matches = searchAgreement("Hello");
+      expect(matches[0]).toContain("Hello Agreement");
+    } finally {
+      fs.unlinkSync(tmpPath);
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- detect PDFs via file signature instead of file extension so stored agreements are parsed properly after restart
- add test covering PDF agreement handling without relying on the real pdf-parse library

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9090db3e8832795a85c78f1c538d1