### PR TITLE
feat: add calendar view for vacancies

### DIFF
--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { Employee, Vacancy } from "./App";
+import CalendarView from "./components/CalendarView";
 import "./styles/branding.css";
 
 const LS_KEY = "maplewood-scheduler-v3";
@@ -20,6 +21,8 @@ type State = {
 export default function Dashboard() {
   const data: State = loadState() || { employees: [], vacancies: [] };
   const { employees, vacancies } = data;
+
+  const [view, setView] = useState<"list" | "calendar">("list");
 
   const awarded = useMemo(
     () => vacancies.filter((v) => v.status === "Awarded"),
@@ -69,56 +72,77 @@ export default function Dashboard() {
         <h1>Shift Dashboard</h1>
       </header>
 
+      <nav className="dashboard-nav">
+        <button onClick={() => setView("list")} disabled={view === "list"}>
+          List View
+        </button>
+        <button
+          onClick={() => setView("calendar")}
+          disabled={view === "calendar"}
+        >
+          Calendar View
+        </button>
+      </nav>
+
       <main className="dashboard-content">
-        <section>
-          <h2>Awarded Shifts</h2>
-          <div className="shift-list">
-            {awarded.map((v) => (
-              <div key={v.id} className="shift-card awarded">
-                {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
+        {view === "calendar" ? (
+          <CalendarView vacancies={vacancies} />
+        ) : (
+          <>
+            <section>
+              <h2>Awarded Shifts</h2>
+              <div className="shift-list">
+                {awarded.map((v) => (
+                  <div key={v.id} className="shift-card awarded">
+                    {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
+                  </div>
+                ))}
+                {awarded.length === 0 && <p>No awarded shifts.</p>}
               </div>
-            ))}
-            {awarded.length === 0 && <p>No awarded shifts.</p>}
-          </div>
-        </section>
+            </section>
 
-        <section>
-          <h2>Open Shifts</h2>
-          <div className="shift-list">
-            {open.map((v) => (
-              <div key={v.id} className="shift-card open">
-                {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
+            <section>
+              <h2>Open Shifts</h2>
+              <div className="shift-list">
+                {open.map((v) => (
+                  <div key={v.id} className="shift-card open">
+                    {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
+                  </div>
+                ))}
+                {open.length === 0 && <p>No open shifts.</p>}
               </div>
-            ))}
-            {open.length === 0 && <p>No open shifts.</p>}
-          </div>
-        </section>
+            </section>
 
-        <section className="employee-list">
-          <h2>Recent Assignments</h2>
-          <table>
-            <thead>
-              <tr>
-                <th>Employee</th>
-                <th>Last Assigned</th>
-              </tr>
-            </thead>
-            <tbody>
-              {employeesWithLast.map((e) => (
-                <tr key={e.id} className={isRecent(e.lastAssigned) ? "recent" : undefined}>
-                  <td>
-                    {e.firstName} {e.lastName}
-                  </td>
-                  <td>
-                    {e.lastAssigned
-                      ? new Date(e.lastAssigned).toLocaleDateString()
-                      : "—"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </section>
+            <section className="employee-list">
+              <h2>Recent Assignments</h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Employee</th>
+                    <th>Last Assigned</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {employeesWithLast.map((e) => (
+                    <tr
+                      key={e.id}
+                      className={isRecent(e.lastAssigned) ? "recent" : undefined}
+                    >
+                      <td>
+                        {e.firstName} {e.lastName}
+                      </td>
+                      <td>
+                        {e.lastAssigned
+                          ? new Date(e.lastAssigned).toLocaleDateString()
+                          : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          </>
+        )}
       </main>
     </div>
   );

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useState } from "react";
+import type { Vacancy } from "../App";
+import type { CalendarVacancy } from "../types/vacancy";
+import {
+  buildCalendar,
+  isoDate,
+  combineDateTime,
+  prevMonth,
+  nextMonth,
+} from "../lib/dates";
+
+export default function CalendarView({
+  vacancies,
+}: {
+  vacancies: Vacancy[];
+}) {
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth());
+
+  const days = useMemo(() => buildCalendar(year, month), [year, month]);
+
+  const eventsByDate = useMemo(() => {
+    const map: Record<string, CalendarVacancy[]> = {};
+    for (const v of vacancies) {
+      const start = combineDateTime(v.shiftDate, v.shiftStart).toISOString();
+      const end = combineDateTime(v.shiftDate, v.shiftEnd).toISOString();
+      const cv: CalendarVacancy = { ...v, start, end };
+      (map[v.shiftDate] ??= []).push(cv);
+    }
+    return map;
+  }, [vacancies]);
+
+  const monthLabel = new Date(year, month, 1).toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <div className="calendar-view">
+      <div className="calendar-header">
+        <button onClick={() => prevMonth(setYear, setMonth, year, month)}>
+          &lt;
+        </button>
+        <span>{monthLabel}</span>
+        <button onClick={() => nextMonth(setYear, setMonth, year, month)}>
+          &gt;
+        </button>
+      </div>
+      <div className="calendar-grid">
+        {days.map(({ date, inMonth }) => {
+          const iso = isoDate(date);
+          const events = eventsByDate[iso] || [];
+          return (
+            <div
+              key={iso}
+              className={`calendar-cell${inMonth ? "" : " dim"}`}
+            >
+              <div className="date-label">{date.getDate()}</div>
+              {events.map((e) => (
+                <div
+                  key={e.id}
+                  className={`vacancy-block ${
+                    e.status === "Awarded" ? "awarded" : "open"
+                  }`}
+                >
+                  {e.shiftStart}–{e.shiftEnd} {e.wing ?? ""} {e.classification}
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -4,6 +4,38 @@
   gap: 8px;
 }
 
+/* calendar layout */
+.calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+
+.calendar-cell {
+  border: 1px solid var(--stroke);
+  min-height: 80px;
+  padding: 4px;
+}
+
+.calendar-cell .date-label {
+  font-size: 0.8rem;
+  font-weight: bold;
+}
+
+.vacancy-block {
+  margin-top: 2px;
+  padding: 2px;
+  font-size: 0.75rem;
+  border-radius: 2px;
+}
+
 /* Collapse tables and stack form rows on tablets and phones */
 @media (max-width: 900px) {
   .responsive-table thead {
@@ -29,5 +61,15 @@
 
   .form-row {
     flex-direction: column;
+  }
+
+  .calendar-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .calendar-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/types/vacancy.ts
+++ b/src/types/vacancy.ts
@@ -1,0 +1,12 @@
+import type { Vacancy as BaseVacancy } from "../App";
+
+/**
+ * Vacancy information augmented with ISO start/end timestamps
+ * for use in calendar-based views.
+ */
+export interface CalendarVacancy extends BaseVacancy {
+  /** ISO datetime representing the start of the shift */
+  start: string;
+  /** ISO datetime representing the end of the shift */
+  end: string;
+}


### PR DESCRIPTION
## Summary
- add CalendarView component for monthly shift display
- extend vacancy types with start/end timestamps
- toggle between list and calendar views on dashboard
- responsive styles for calendar layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a910a2a7848327a55748a6933af0da