### PR TITLE
Add audit log viewer with filtering and export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -554,6 +554,9 @@ export default function App() {
             <Link to="/agreement" className="btn">
               Agreement
             </Link>
+            <Link to="/audit-log" className="btn">
+              Audit Log
+            </Link>
             <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
               <span className="subtitle">Text size</span>
               <input

--- a/src/AuditLog.tsx
+++ b/src/AuditLog.tsx
@@ -1,0 +1,112 @@
+import { useState, useMemo } from "react";
+import {
+  filterAuditLogs,
+  clearAuditLogs,
+} from "./lib/audit";
+import storage from "./lib/storage";
+
+export default function AuditLog() {
+  const [date, setDate] = useState("");
+  const [vacancyId, setVacancyId] = useState("");
+  const [refresh, setRefresh] = useState(0);
+
+  const logs = useMemo(
+    () =>
+      filterAuditLogs(storage, {
+        date: date || undefined,
+        vacancyId: vacancyId || undefined,
+      }),
+    [date, vacancyId, refresh],
+  );
+
+  const clear = () => {
+    clearAuditLogs(storage);
+    setRefresh((r) => r + 1);
+  };
+
+  const exportCsv = () => {
+    const rows = [
+      ["ts", "actor", "vacancyId", "from", "to", "reason", "note"],
+      ...logs.map((l) => [
+        l.ts,
+        l.actor,
+        l.targetId,
+        l.details.from,
+        l.details.to,
+        l.details.reason,
+        l.details.note ?? "",
+      ]),
+    ];
+    const csv = rows
+      .map((r) => r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(","))
+      .join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "audit-log.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="grid">
+      <div className="card">
+        <div className="card-h">Audit Log</div>
+        <div className="card-c">
+          <div className="row" style={{ gap: 8, marginBottom: 8 }}>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+            <input
+              placeholder="Vacancy ID"
+              value={vacancyId}
+              onChange={(e) => setVacancyId(e.target.value)}
+            />
+            <button className="btn" onClick={exportCsv}>
+              Export CSV
+            </button>
+            <button className="btn" onClick={clear}>
+              Clear Logs
+            </button>
+          </div>
+          <table className="responsive-table">
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Vacancy</th>
+                <th>Actor</th>
+                <th>From</th>
+                <th>To</th>
+                <th>Reason</th>
+                <th>Note</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((l) => (
+                <tr key={l.id}>
+                  <td>{new Date(l.ts).toLocaleString()}</td>
+                  <td>{l.targetId}</td>
+                  <td>{l.actor}</td>
+                  <td>{l.details.from}</td>
+                  <td>{l.details.to}</td>
+                  <td>{l.details.reason}</td>
+                  <td>{l.details.note}</td>
+                </tr>
+              ))}
+              {!logs.length && (
+                <tr>
+                  <td colSpan={7} style={{ textAlign: "center" }}>
+                    No logs
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -73,6 +73,16 @@ export function getAuditLogs(storage: Storage): AuditLog[] {
   return read(storage);
 }
 
+export function filterAuditLogs(
+  storage: Storage,
+  { date, vacancyId }: { date?: string; vacancyId?: string },
+): AuditLog[] {
+  let logs = getAuditLogs(storage);
+  if (date) logs = logs.filter((l) => l.ts.startsWith(date));
+  if (vacancyId) logs = logs.filter((l) => l.targetId === vacancyId);
+  return logs;
+}
+
 export function clearAuditLogs(storage: Storage) {
   write([], storage);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./App";
 import Analytics from "./Analytics";
 import Agreement from "./Agreement";
 import Dashboard from "./Dashboard";
+import AuditLog from "./AuditLog";
 import "./styles/responsive.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
@@ -15,6 +16,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <Route path="/analytics" element={<Analytics />} />
         <Route path="/agreement" element={<Agreement />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/audit-log" element={<AuditLog />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>,

--- a/tests/audit.test.ts
+++ b/tests/audit.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { logOfferingChange, filterAuditLogs, clearAuditLogs } from "../src/lib/audit";
+import { createMemoryStorage } from "../src/lib/storage";
+
+describe("filterAuditLogs", () => {
+  it("filters by date and vacancy id", () => {
+    const storage = createMemoryStorage();
+    const today = new Date().toISOString().slice(0, 10);
+    logOfferingChange(
+      {
+        vacancyId: "1",
+        from: "CASUALS",
+        to: "OT_FULL_TIME",
+        actor: "system",
+        reason: "manual",
+      },
+      storage,
+    );
+    const byDate = filterAuditLogs(storage, { date: today });
+    expect(byDate).toHaveLength(1);
+    const none = filterAuditLogs(storage, { vacancyId: "2" });
+    expect(none).toHaveLength(0);
+    clearAuditLogs(storage);
+  });
+});


### PR DESCRIPTION
## Summary
- add audit log filtering by date or vacancy ID
- create AuditLog page with search, CSV export and clear action
- link AuditLog route from navigation

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a910b17f988327a1dab43f084dc671