### PR TITLE
Handle unknown vacancy statuses in metrics aggregation

### DIFF
--- a/server/metrics.js
+++ b/server/metrics.js
@@ -1,7 +1,13 @@
+const ALLOWED_STATUSES = new Set(["awarded", "cancelled", "posted"]);
+
 export function aggregateByMonth(vacancies, options = {}) {
   const { overtimeThreshold = 8 } = options;
   const groups = {};
   for (const v of vacancies) {
+    if (!ALLOWED_STATUSES.has(v.status)) {
+      console.warn(`Unknown status: ${v.status}`);
+      continue;
+    }
     const month = v.date.slice(0, 7);
     groups[month] = groups[month] || [];
     groups[month].push(v);

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -27,4 +27,17 @@ describe("aggregateByMonth", () => {
     expect(jan?.overtime).toBe(0);
     expect(feb?.overtime).toBe(0);
   });
+
+  it("ignores vacancies with unknown status", () => {
+    const extra = {
+      date: "2024-01-10",
+      status: "pending",
+      hours: 5,
+    };
+    const result = aggregateByMonth([...sampleVacancies, extra]);
+    const jan = result.find((r) => r.period === "2024-01");
+    expect(jan?.posted).toBe(3);
+    expect(jan?.awarded).toBe(1);
+    expect(jan?.cancelled).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- whitelist `awarded`, `cancelled`, and `posted` statuses in vacancy metrics
- log and skip vacancies with unknown statuses
- test that unknown statuses do not affect monthly aggregates

## Testing
- `npm test tests/metrics.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a91242ed288327970ba4b3e4658db3