### PR TITLE
Stop ticking when final offering tier expires

### DIFF
--- a/tests/offering.test.ts
+++ b/tests/offering.test.ts
@@ -92,6 +92,29 @@ describe("useOfferingRound", () => {
     round.dispose();
   });
 
+  it("stops ticking after final tier expires", () => {
+    const vac: Vacancy = {
+      id: "1",
+      offeringTier: "LAST_RESORT_RN",
+      offeringRoundStartedAt: new Date().toISOString(),
+      offeringRoundMinutes: 1,
+      offeringAutoProgress: true,
+    };
+    const onTick = vi.fn();
+    const round = createOfferingRound(vac, {
+      updateVacancy: () => {},
+      currentUser: "system",
+      onTick,
+    });
+    expect(round.isRunning()).toBe(true);
+    vi.advanceTimersByTime(60000);
+    expect(round.isRunning()).toBe(false);
+    const calls = onTick.mock.calls.length;
+    vi.advanceTimersByTime(2000);
+    expect(onTick).toHaveBeenCalledTimes(calls);
+    round.dispose();
+  });
+
   it("manual change writes AuditLog with actor, from, to, reason", () => {
     const vac: Vacancy = {
       id: "1",


### PR DESCRIPTION
## Summary
- halt interval when a round expires with no next tier or auto-progress disabled
- expose `isRunning` and reuse `dispose` to manage the timer, restarting on manual reset
- test that ticking stops after the final tier expires

## Testing
- `npm test tests/offering.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a91241102083279b4c6e4d1ae1ea44