### PR TITLE
Handle invalid bid timestamps in recommendation logic

### DIFF
--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -35,11 +35,15 @@ export function recommend(
 ): Recommendation {
   const relevant = bids.filter((b) => b.vacancyId === vac.id);
   const candidates = relevant
-    .map((b, idx) => ({
-      emp: employeesById[b.bidderEmployeeId],
-      order: idx,
-      time: b.placedAt ? Date.parse(b.placedAt) : undefined,
-    }))
+    .map((b, idx) => {
+      const parsed = b.placedAt ? Date.parse(b.placedAt) : undefined;
+      return {
+        emp: employeesById[b.bidderEmployeeId],
+        order: idx,
+        time:
+          parsed !== undefined && !Number.isNaN(parsed) ? parsed : undefined,
+      };
+    })
     .filter(
       (c): c is { emp: Employee; order: number; time: number | undefined } =>
         !!c.emp && c.emp.active && c.emp.classification === vac.classification,
@@ -57,7 +61,13 @@ export function recommend(
     const rankDiff =
       (a.emp.seniorityRank ?? 99999) - (b.emp.seniorityRank ?? 99999);
     if (rankDiff !== 0) return rankDiff;
-    if (a.time !== undefined && b.time !== undefined && a.time !== b.time) {
+    if (
+      a.time !== undefined &&
+      b.time !== undefined &&
+      !Number.isNaN(a.time) &&
+      !Number.isNaN(b.time) &&
+      a.time !== b.time
+    ) {
       return a.time - b.time;
     }
     return a.order - b.order;

--- a/tests/recommend.test.ts
+++ b/tests/recommend.test.ts
@@ -68,6 +68,28 @@ describe("recommend", () => {
     expect(rec.id).toBe("e");
   });
 
+  it("falls back to bid order when timestamp is invalid", () => {
+    const vac = { id: "vac1", classification: "RN", offeringTier: "CASUALS" };
+    const employeesWithTie = {
+      ...employees,
+      e: { id: "e", active: true, seniorityRank: 1, classification: "RN" },
+    };
+    const tieBids = [
+      {
+        vacancyId: "vac1",
+        bidderEmployeeId: "e",
+        placedAt: "not-a-date",
+      },
+      {
+        vacancyId: "vac1",
+        bidderEmployeeId: "b",
+        placedAt: "2024-01-01T09:00:00Z",
+      },
+    ];
+    const rec = recommend(vac, tieBids, employeesWithTie);
+    expect(rec.id).toBe("e");
+  });
+
   it("prefers higher seniority hours when present", () => {
     const vac = { id: "vac1", classification: "RN", offeringTier: "CASUALS" };
     const employeesWithHours = {


### PR DESCRIPTION
## Summary
- Ignore invalid bid timestamps when parsing bid times
- Skip timestamp comparison if either bid lacks a valid timestamp
- Test recommendation behavior with invalid timestamps

## Testing
- `npm test tests/recommend.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a9123ec8e48327aeb936395a8043ce