### PR TITLE
test: restore global fetch in analytics test

### DIFF
--- a/tests/analytics.test.tsx
+++ b/tests/analytics.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { render, screen, waitFor } from "@testing-library/react";
-import { vi, expect, test } from "vitest";
+import { vi, expect, test, afterEach } from "vitest";
 import Analytics from "../src/Analytics";
 
 // Mock chart components to avoid canvas requirement
@@ -8,6 +8,12 @@ vi.mock("react-chartjs-2", () => ({
   Bar: () => null,
   Line: () => null,
 }));
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
 
 test("loading indicator disappears after fetch abort", async () => {
   global.fetch = vi.fn(() =>


### PR DESCRIPTION
## Summary
- preserve original `global.fetch` in analytics tests by saving and restoring it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a913b65748832796b25326bd8b6e90