### PR TITLE
Clarify analytics export format error message

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -41,7 +41,7 @@ app.get("/api/analytics/export", requireAuth, (req, res) => {
       break;
     }
     default:
-      res.status(400).json({ error: "format query param required (csv|pdf)" });
+      res.status(400).json({ error: "format query parameter required (csv|pdf)" });
   }
 });
 


### PR DESCRIPTION
## Summary
- Reword analytics export route error message for missing format parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a913b3384c8327aabfafbe8e05e88c