### PR TITLE
Clear end date when enabling multi-day vacations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -670,12 +670,10 @@ export default function App() {
                         onChange={(e) => {
                           const checked = e.target.checked;
                           setMultiDay(checked);
-                          if (!checked) {
-                            setNewVacay((v) => ({
-                              ...v,
-                              endDate: v.startDate,
-                            }));
-                          }
+                          setNewVacay((v) => ({
+                            ...v,
+                            endDate: checked ? "" : v.startDate,
+                          }));
                         }}
                       />{" "}
                       {multiDay ? ">1 day" : "1 day"}

--- a/tests/multiDayCheckbox.test.tsx
+++ b/tests/multiDayCheckbox.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { expect, test } from "vitest";
+import App from "../src/App";
+
+test("multi-day checkbox clears endDate and inputs can set it", () => {
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>,
+  );
+  const dateInput = screen.getByLabelText("Date") as HTMLInputElement;
+  fireEvent.change(dateInput, { target: { value: "2024-08-01" } });
+
+  const checkbox = screen.getByLabelText("1 day");
+  fireEvent.click(checkbox);
+
+  const startInput = screen.getByLabelText("Start Date") as HTMLInputElement;
+  const endInput = screen.getByLabelText("End Date") as HTMLInputElement;
+  expect(endInput.value).toBe("");
+
+  fireEvent.change(startInput, { target: { value: "2024-08-02" } });
+  fireEvent.change(endInput, { target: { value: "2024-08-03" } });
+  expect(endInput.value).toBe("2024-08-03");
+});


### PR DESCRIPTION
## Summary
- reset vacation end date when multi-day option is enabled
- add regression test ensuring end date is cleared and can be overwritten

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a913939a64832786cc5e62a3e25343