### PR TITLE
Style override checkbox with custom toggle UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1736,12 +1736,14 @@ function VacancyRow({
         />
       </td>
       <td style={{ whiteSpace: "nowrap" }}>
-        <label style={{ display: "flex", gap: 6, alignItems: "center" }}>
-          <input
-            type="checkbox"
-            checked={overrideClass}
-            onChange={(e) => setOverrideClass(e.target.checked)}
-          />
+        <input
+          id="override-toggle"
+          className="toggle-input"
+          type="checkbox"
+          checked={overrideClass}
+          onChange={(e) => setOverrideClass(e.target.checked)}
+        />
+        <label htmlFor="override-toggle" className="toggle-box">
           <span className="subtitle">Allow class override</span>
         </label>
       </td>

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -73,3 +73,51 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* custom checkbox toggle */
+.toggle-input {
+  position: absolute;
+  opacity: 0;
+}
+
+.toggle-box {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+  border: 1px solid var(--stroke);
+  border-radius: 4px;
+  cursor: pointer;
+  position: relative;
+}
+
+.toggle-box::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--stroke);
+  border-radius: 2px;
+  background: var(--bg2);
+}
+
+.toggle-box::after {
+  content: "";
+  position: absolute;
+  left: 9px;
+  top: 5px;
+  width: 5px;
+  height: 10px;
+  border: solid var(--bg1);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+  opacity: 0;
+}
+
+.toggle-input:checked + .toggle-box {
+  background: var(--brand);
+  border-color: var(--brand);
+}
+
+.toggle-input:checked + .toggle-box::after {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- hide native checkbox and add labelled toggle for class override option
- style toggle box and checkmark via responsive.css using pseudo-elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a913926ea88327b0caba3ea94e7e46