### PR TITLE
Clamp offering timer to zero

### DIFF
--- a/src/offering/useOfferingRound.ts
+++ b/src/offering/useOfferingRound.ts
@@ -57,7 +57,7 @@ export function createOfferingRound(vac: Vacancy, opts: RoundOptions) {
   };
 
   const tick = () => {
-    const msLeft = computeMsLeft();
+    const msLeft = Math.max(0, computeMsLeft());
     opts.onTick?.(msLeft);
     if (msLeft <= 0) {
       const next = nextTier(current.offeringTier);
@@ -78,7 +78,7 @@ export function createOfferingRound(vac: Vacancy, opts: RoundOptions) {
           },
           storage,
         );
-        opts.onTick?.(computeMsLeft());
+        opts.onTick?.(Math.max(0, computeMsLeft()));
       } else {
         dispose();
       }

--- a/tests/offering.test.ts
+++ b/tests/offering.test.ts
@@ -67,6 +67,9 @@ describe("useOfferingRound", () => {
     expect(logs[0].details.reason).toBe("auto-progress");
     // final tick calls onTick twice: once when expiring and once after advancing
     expect(onTick).toHaveBeenCalledTimes(62);
+    // the expired tick should clamp the remaining time to zero
+    const expiringCall = onTick.mock.calls[onTick.mock.calls.length - 2];
+    expect(expiringCall[0]).toBe(0);
     round.dispose();
   });
 


### PR DESCRIPTION
## Summary
- Prevent offering round timer from reporting negative values and clamp to zero after auto progress
- Test that expired ticks emit zero remaining time

## Testing
- `npm test tests/offering.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a91690ce588327a152bff3ce6d7935