### PR TITLE
Document tablet and phone responsive breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ curl -H "Authorization: Bearer $ANALYTICS_AUTH_TOKEN" \
 
 ## Responsive design
 
-- Mobile breakpoint at **600px** is defined in `src/styles/responsive.css`.
+- `src/styles/responsive.css` defines a tablet breakpoint at **≤900px** where tables collapse and form rows stack, and a phone breakpoint at **≤600px** that further reduces the calendar to a single column.
 - Use the `responsive-table` class on tables and `form-row` for grouped form inputs to stack vertically on narrow screens.
 
 ### Deploy options


### PR DESCRIPTION
## Summary
- clarify responsive breakpoints in README for tablets (≤900px) and phones (≤600px)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a916920ed483279345bfcd3ff3cc0e