### PR TITLE
test: expand reorder utility coverage

### DIFF
--- a/src/utils/reorder.ts
+++ b/src/utils/reorder.ts
@@ -1,4 +1,8 @@
 export function reorder<T>(arr: T[], from: number, to: number): T[] {
+  if (from < 0 || from >= arr.length || to < 0 || to >= arr.length) {
+    return arr.slice();
+  }
+
   const copy = arr.slice();
   const [item] = copy.splice(from, 1);
   copy.splice(to, 0, item);

--- a/tests/reorder.test.ts
+++ b/tests/reorder.test.ts
@@ -6,4 +6,22 @@ describe("reorder utility", () => {
     const result = reorder(["a", "b", "c"], 0, 2);
     expect(result).toEqual(["b", "c", "a"]);
   });
+
+  it("moves item backward in array", () => {
+    const result = reorder(["a", "b", "c"], 2, 0);
+    expect(result).toEqual(["c", "a", "b"]);
+  });
+
+  it("returns original array when index is out of range", () => {
+    const arr = ["a", "b", "c"];
+    const result = reorder(arr, 5, 0);
+    expect(result).toEqual(arr);
+  });
+
+  it("does not mutate the input array", () => {
+    const arr = ["a", "b", "c"];
+    const copy = [...arr];
+    reorder(arr, 0, 2);
+    expect(arr).toEqual(copy);
+  });
 });


### PR DESCRIPTION
## Summary
- add bounds check to `reorder` to return original list when indices are out of range
- extend reorder tests for backward movement, out-of-range inputs, and immutability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a91692e808832786f0d72e74fbd54f