### PR TITLE
Rename OT-Regular step to OT-Full-Time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,7 @@ export type Vacancy = {
   offeringRoundStartedAt?: string;
   offeringRoundMinutes?: number;
   offeringAutoProgress?: boolean;
-  offeringStep: "Casuals" | "OT-Regular" | "OT-Casuals";
+  offeringStep: "Casuals" | "OT-Full-Time" | "OT-Casuals";
   status: "Open" | "Pending Award" | "Awarded";
   awardedTo?: string; // employeeId
   awardedAt?: string; // ISO datetime


### PR DESCRIPTION
## Summary
- rename vacancy offering step value from "OT-Regular" to "OT-Full-Time"
- ensure naming is consistent across the codebase

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9169493b883279288fee162aec445