### PR TITLE
Style multi-day toggle with custom indicator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -663,9 +663,12 @@ export default function App() {
                     </select>
                   </div>
                   <div style={{ gridColumn: "1 / -1" }}>
-                    <label>
+                    <label
+                      className={`toggle-box${multiDay ? " checked" : ""}`}
+                    >
                       <input
                         type="checkbox"
+                        className="toggle-input"
                         checked={multiDay}
                         onChange={(e) => {
                           const checked = e.target.checked;
@@ -675,7 +678,8 @@ export default function App() {
                             endDate: checked ? "" : v.startDate,
                           }));
                         }}
-                      />{" "}
+                      />
+                      <span className="toggle-indicator" />
                       {multiDay ? ">1 day" : "1 day"}
                     </label>
                   </div>

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -78,6 +78,7 @@
 .toggle-input {
   position: absolute;
   opacity: 0;
+  pointer-events: none;
 }
 
 .toggle-box {
@@ -88,11 +89,9 @@
   border: 1px solid var(--stroke);
   border-radius: 4px;
   cursor: pointer;
-  position: relative;
 }
 
-.toggle-box::before {
-  content: "";
+.toggle-indicator {
   width: 16px;
   height: 16px;
   border: 1px solid var(--stroke);
@@ -100,24 +99,7 @@
   background: var(--bg2);
 }
 
-.toggle-box::after {
-  content: "";
-  position: absolute;
-  left: 9px;
-  top: 5px;
-  width: 5px;
-  height: 10px;
-  border: solid var(--bg1);
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
-  opacity: 0;
-}
-
-.toggle-input:checked + .toggle-box {
+.toggle-box.checked .toggle-indicator {
   background: var(--brand);
   border-color: var(--brand);
-}
-
-.toggle-input:checked + .toggle-box::after {
-  opacity: 1;
 }

--- a/tests/multiDayCheckbox.test.tsx
+++ b/tests/multiDayCheckbox.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { expect, test } from "vitest";
 import App from "../src/App";
 
-test("multi-day checkbox clears endDate and inputs can set it", () => {
+test("multi-day toggle switches between single and range date fields", () => {
   render(
     <MemoryRouter>
       <App />
@@ -16,6 +16,7 @@ test("multi-day checkbox clears endDate and inputs can set it", () => {
   const checkbox = screen.getByLabelText("1 day");
   fireEvent.click(checkbox);
 
+  expect(screen.queryByLabelText("Date")).toBeNull();
   const startInput = screen.getByLabelText("Start Date") as HTMLInputElement;
   const endInput = screen.getByLabelText("End Date") as HTMLInputElement;
   expect(endInput.value).toBe("");
@@ -23,4 +24,9 @@ test("multi-day checkbox clears endDate and inputs can set it", () => {
   fireEvent.change(startInput, { target: { value: "2024-08-02" } });
   fireEvent.change(endInput, { target: { value: "2024-08-03" } });
   expect(endInput.value).toBe("2024-08-03");
+
+  fireEvent.click(checkbox);
+  expect(screen.getByLabelText("Date")).toBeTruthy();
+  expect(screen.queryByLabelText("Start Date")).toBeNull();
+  expect(screen.queryByLabelText("End Date")).toBeNull();
 });


### PR DESCRIPTION
## Summary
- hide the raw checkbox input and drive toggle styling via `toggle-box` and `toggle-indicator`
- add test ensuring multi-day toggle shows the right date fields

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a917e10f688327933fe704037cf9fe