### PR TITLE
Refine agreement search results rendering

### DIFF
--- a/src/Agreement.tsx
+++ b/src/Agreement.tsx
@@ -4,7 +4,12 @@ import { authFetch } from "./utils/api";
 export default function Agreement() {
   const [uploaded, setUploaded] = useState(false);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<string[]>([]);
+  interface Match {
+    line: string;
+    lineNumber: number;
+    context: string;
+  }
+  const [results, setResults] = useState<Match[]>([]);
 
   const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -23,7 +28,8 @@ export default function Agreement() {
       `/api/collective-agreement/search?q=${encodeURIComponent(query)}`,
     );
     const data = await res.json();
-    setResults(data.matches || []);
+    const matches = (data.matches ?? []) as Match[];
+    setResults(matches);
   };
 
   return (
@@ -51,7 +57,12 @@ export default function Agreement() {
             </button>
             <ul>
               {results.map((r, i) => (
-                <li key={i}>{r}</li>
+                <li key={i}>
+                  <div>{r.line}</div>
+                  <small>
+                    Line {r.lineNumber}: {r.context}
+                  </small>
+                </li>
               ))}
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- represent agreement search results as objects containing line, line number and context
- display each match with its line plus line number and context in results list

## Testing
- `npm test`
- `npm run typecheck` *(fails: src/components/SummaryCards.tsx(2,1): error TS6133: 'React' is declared but its value is never read.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9d37f8948327a4e50b9f1be2414f