### PR TITLE
Handle upload errors in Agreement

### DIFF
--- a/src/Agreement.tsx
+++ b/src/Agreement.tsx
@@ -5,17 +5,25 @@ export default function Agreement() {
   const [uploaded, setUploaded] = useState(false);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     const form = new FormData();
     form.append("file", file);
-    await authFetch("/api/collective-agreement/upload", {
+    const res = await authFetch("/api/collective-agreement/upload", {
       method: "POST",
       body: form,
     });
-    setUploaded(true);
+    if (res.ok) {
+      setUploaded(true);
+      setError(null);
+    } else {
+      const msg = await res.text();
+      setError(msg || "Upload failed");
+      setUploaded(false);
+    }
   };
 
   const search = async () => {
@@ -37,6 +45,9 @@ export default function Agreement() {
         {!uploaded && (
           <div>
             <input type="file" onChange={onUpload} />
+            {error && (
+              <div style={{ color: "red" }}>{error}</div>
+            )}
           </div>
         )}
         {uploaded && (

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,6 +1,3 @@
-
-import React from "react";
-
 type Props = {
   openCount: number;
   awardedToday: number;


### PR DESCRIPTION
## Summary
- Capture upload response and only set uploaded flag when request succeeds
- Display a red error message when upload fails
- Remove unused React import from SummaryCards to satisfy typecheck

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac9d47cab48327acb617938f3063b3