### PR TITLE
Ensure uploads directory exists before configuring Multer

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,11 +5,15 @@ import { requireAuth } from "./auth.js";
 import { createCsv } from "./analyticsFormats/csv.js";
 import { createPdf } from "./analyticsFormats/pdf.js";
 import multer from "multer";
+import fs from "fs";
+import { fileURLToPath } from "url";
 import { initAgreement, loadAgreement, searchAgreement } from "./collectiveAgreement.js";
 
 const app = express();
 app.use(cors());
-const upload = multer({ dest: new URL("./uploads", import.meta.url).pathname });
+const uploadDir = fileURLToPath(new URL("./uploads", import.meta.url));
+fs.mkdirSync(uploadDir, { recursive: true });
+const upload = multer({ dest: uploadDir });
 
 initAgreement();
 


### PR DESCRIPTION
## Summary
- Safely resolve uploads directory using fileURLToPath and ensure it exists
- Pass the verified directory to Multer for file storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9d59cb6883279c11cc6b13f9f32c