### PR TITLE
Handle reorder no-op cases

### DIFF
--- a/src/utils/reorder.ts
+++ b/src/utils/reorder.ts
@@ -1,6 +1,12 @@
 export function reorder<T>(arr: T[], from: number, to: number): T[] {
-  if (from < 0 || from >= arr.length || to < 0 || to >= arr.length) {
-    return arr.slice();
+  if (
+    from < 0 ||
+    from >= arr.length ||
+    to < 0 ||
+    to >= arr.length ||
+    from === to
+  ) {
+    return arr;
   }
 
   const copy = arr.slice();

--- a/tests/reorder.test.ts
+++ b/tests/reorder.test.ts
@@ -15,7 +15,13 @@ describe("reorder utility", () => {
   it("returns original array when index is out of range", () => {
     const arr = ["a", "b", "c"];
     const result = reorder(arr, 5, 0);
-    expect(result).toEqual(arr);
+    expect(result).toBe(arr);
+  });
+
+  it("returns original array when from equals to", () => {
+    const arr = ["a", "b", "c"];
+    const result = reorder(arr, 1, 1);
+    expect(result).toBe(arr);
   });
 
   it("does not mutate the input array", () => {


### PR DESCRIPTION
## Summary
- Avoid cloning array when `reorder` is a no-op by returning original reference for invalid indices or unchanged positions
- Test that `reorder` preserves original reference when indexes are out of range or identical

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9d5fbfb48327890a5bce4033ad7c