### PR TITLE
Make minutesBetween argument order-independent

### DIFF
--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -54,5 +54,5 @@ export const nextMonth = (
 };
 
 export const minutesBetween = (a: Date, b: Date) =>
-  Math.round((a.getTime() - b.getTime()) / 60000);
+  Math.round(Math.abs(a.getTime() - b.getTime()) / 60000);
 

--- a/tests/analytics.test.tsx
+++ b/tests/analytics.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { vi, expect, test, afterEach } from "vitest";
 import Analytics from "../src/Analytics";
+import { minutesBetween } from "../src/lib/dates";
 
 // Mock chart components to avoid canvas requirement
 vi.mock("react-chartjs-2", () => ({
@@ -25,4 +26,11 @@ test("loading indicator disappears after fetch abort", async () => {
   await waitFor(() => {
     expect(screen.queryByText("Loading...")).toBeNull();
   });
+});
+
+test("minutesBetween returns 60 regardless of argument order", () => {
+  const earlier = new Date("2024-01-01T00:00");
+  const later = new Date("2024-01-01T01:00");
+  expect(minutesBetween(earlier, later)).toBe(60);
+  expect(minutesBetween(later, earlier)).toBe(60);
 });


### PR DESCRIPTION
## Summary
- use absolute millisecond difference to compute minutesBetween
- test minutesBetween returns 60 regardless of argument order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac9e62770083279c4f0cda024f19e9