### PR TITLE
Add bulk award workflow

### DIFF
--- a/src/components/BulkAwardDialog.tsx
+++ b/src/components/BulkAwardDialog.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import type { Employee } from "../App";
+import { OVERRIDE_REASONS } from "../App";
+
+type Props = {
+  open: boolean;
+  employees: Employee[];
+  onConfirm: (payload: { empId?: string; reason?: string; overrideUsed?: boolean; message?: string }) => void;
+  onClose: () => void;
+};
+
+export default function BulkAwardDialog({ open, employees, onConfirm, onClose }: Props) {
+  const [empId, setEmpId] = useState("");
+  const [message, setMessage] = useState("");
+  const [reason, setReason] = useState("");
+
+  if (!open) return null;
+
+  const confirm = () => {
+    onConfirm({
+      empId: empId || undefined,
+      reason: reason || undefined,
+      overrideUsed: !!reason,
+      message: message || undefined,
+    });
+    setEmpId("");
+    setMessage("");
+    setReason("");
+  };
+
+  return (
+    <div role="alertdialog" aria-modal="true" className="modal">
+      <h3>Bulk Award Vacancies</h3>
+      <label>
+        Employee
+        <select value={empId} onChange={(e) => setEmpId(e.target.value)}>
+          <option value="">Select employee…</option>
+          {employees.map((e) => (
+            <option key={e.id} value={e.id}>
+              {e.firstName} {e.lastName}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Message (optional)
+        <textarea value={message} onChange={(e) => setMessage(e.target.value)} />
+      </label>
+      <label>
+        Override reason
+        <select value={reason} onChange={(e) => setReason(e.target.value)}>
+          <option value="">None</option>
+          {OVERRIDE_REASONS.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </label>
+      <div style={{ marginTop: 12, display: "flex", gap: 8, justifyContent: "flex-end" }}>
+        <button className="btn" onClick={onClose}>
+          Cancel
+        </button>
+        <button className="btn" onClick={confirm} disabled={!empId}>
+          Confirm
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,6 +1,4 @@
 
-import React from "react";
-
 type Props = {
   openCount: number;
   awardedToday: number;

--- a/tests/bulkAwardVacancies.test.ts
+++ b/tests/bulkAwardVacancies.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { applyAwardVacancies, type Vacancy } from "../src/App";
+
+describe("applyAwardVacancies", () => {
+  it("awards multiple vacancies", () => {
+    const vac1: Vacancy = {
+      id: "v1",
+      reason: "Test",
+      classification: "RN",
+      shiftDate: "2024-01-01",
+      shiftStart: "08:00",
+      shiftEnd: "16:00",
+      knownAt: "2024-01-01T00:00:00.000Z",
+      offeringTier: "CASUALS",
+      offeringStep: "Casuals",
+      status: "Open",
+    };
+    const vac2: Vacancy = { ...vac1, id: "v2" };
+    const updated = applyAwardVacancies([vac1, vac2], ["v1", "v2"], { empId: "e1" });
+    expect(updated[0].status).toBe("Awarded");
+    expect(updated[1].status).toBe("Awarded");
+    expect(updated[0].awardedTo).toBe("e1");
+    expect(updated[1].awardedTo).toBe("e1");
+  });
+});


### PR DESCRIPTION
## Summary
- support awarding multiple vacancies at once via new `applyAwardVacancies`
- allow selecting vacancies and show a Bulk Award dialog
- new tests covering bulk awarding logic

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca792828883278ce9a0d815123a33