### PR TITLE
feat: add saved vacancy filters

### DIFF
--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,6 +1,3 @@
-
-import React from "react";
-
 type Props = {
   openCount: number;
   awardedToday: number;


### PR DESCRIPTION
## Summary
- add status filter and saved filter views for vacancies
- save views in localStorage and render as chips with Save/Update/Delete controls
- fix unused React import in SummaryCards to satisfy typecheck

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aca7d7a4988327a04396ff3ea8fafa