### PR TITLE
docs: add bulk award helpers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ curl -H "Authorization: Bearer $ANALYTICS_AUTH_TOKEN" \
   "http://localhost:3000/api/analytics?overtimeThreshold=10"
 ```
 
+## Bulk Award Helpers
+
+Bulk Award Helpers let you award several open shifts in a single action.
+
+- **Select multiple open shifts:** In the schedule view, choose all of the open shifts you want to award.
+- **Apply a shared message and reason:** Enter one message and reason that will be attached to every selected shift.
+- **Validation and overrides:** Each shift is validated for conflicts or eligibility. You can override warnings or remove problematic shifts before finalizing.
+
+### Workflow
+1. Use the checkboxes to select the open shifts.
+2. Click **Award Selected**.
+3. Provide the shared message and reason.
+4. Review validations and override or skip any shifts that fail.
+5. Submit to award the remaining shifts.
+
 ## Responsive design
 
 - `src/styles/responsive.css` defines a tablet breakpoint at **≤900px** where tables collapse and form rows stack, and a phone breakpoint at **≤600px** that further reduces the calendar to a single column.


### PR DESCRIPTION
## Summary
- add Bulk Award Helpers section explaining multi-shift selection and shared messages
- document validation and override behavior with step-by-step workflow

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aca9ee155083278a3a69f6ac68d705