### PR TITLE
Add bulk award audit logger hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1016,6 +1016,7 @@ export default function App() {
         <BulkAwardDialog
           open={bulkAwardOpen}
           employees={employees}
+          vacancyIds={selectedVacancyIds}
           onClose={() => setBulkAwardOpen(false)}
           onConfirm={(payload) => {
             setVacancies((prev) =>

--- a/src/components/BulkAwardDialog.tsx
+++ b/src/components/BulkAwardDialog.tsx
@@ -1,15 +1,17 @@
 import { useState } from "react";
 import type { Employee } from "../App";
 import { OVERRIDE_REASONS } from "../App";
+import { logBulkAward } from "../utils/logger";
 
 type Props = {
   open: boolean;
   employees: Employee[];
+  vacancyIds: string[];
   onConfirm: (payload: { empId?: string; reason?: string; overrideUsed?: boolean; message?: string }) => void;
   onClose: () => void;
 };
 
-export default function BulkAwardDialog({ open, employees, onConfirm, onClose }: Props) {
+export default function BulkAwardDialog({ open, employees, vacancyIds, onConfirm, onClose }: Props) {
   const [empId, setEmpId] = useState("");
   const [message, setMessage] = useState("");
   const [reason, setReason] = useState("");
@@ -17,11 +19,17 @@ export default function BulkAwardDialog({ open, employees, onConfirm, onClose }:
   if (!open) return null;
 
   const confirm = () => {
-    onConfirm({
+    const payload = {
       empId: empId || undefined,
       reason: reason || undefined,
       overrideUsed: !!reason,
       message: message || undefined,
+    };
+    onConfirm(payload);
+    logBulkAward({
+      vacancyIds,
+      employeeId: payload.empId,
+      reason: payload.reason,
     });
     setEmpId("");
     setMessage("");

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,34 @@
+import { authFetch } from "./api";
+
+export async function logBulkAward({
+  vacancyIds,
+  employeeId,
+  reason,
+  user,
+}: {
+  vacancyIds: string[];
+  employeeId?: string;
+  reason?: string;
+  user?: string;
+}) {
+  const payload = {
+    vacancyIds,
+    employeeId,
+    reason,
+    user:
+      user ??
+      (typeof window !== "undefined"
+        ? window.localStorage.getItem("currentUser") || undefined
+        : undefined),
+    timestamp: new Date().toISOString(),
+  };
+  try {
+    await authFetch("/api/logs/bulk-award", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.error("Failed to log bulk award", err);
+  }
+}


### PR DESCRIPTION
## Summary
- add logger utility to send bulk award events with acting user and timestamp
- trigger logging from BulkAwardDialog confirmation with selected vacancy IDs
- pass vacancy IDs into BulkAwardDialog from App

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68aca9f2d47883278f59768591c32248