### PR TITLE
Add bid deletion button with test

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1396,6 +1396,10 @@ export function BidsPage({
 
   const openVacancies = vacancies.filter((v) => v.status !== "Awarded");
 
+  const removeBid = (index: number) => {
+    setBids((prev: Bid[]) => prev.filter((_, idx) => idx !== index));
+  };
+
   const setNow = () => {
     const now = new Date();
     const d = isoDate(now);
@@ -1527,6 +1531,7 @@ export function BidsPage({
                 <th>Class</th>
                 <th>Status</th>
                 <th>Bid at</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -1539,6 +1544,15 @@ export function BidsPage({
                     <td>{b.bidderClassification}</td>
                     <td>{b.bidderStatus}</td>
                     <td>{new Date(b.bidTimestamp).toLocaleString()}</td>
+                    <td>
+                      <button
+                        className="btn"
+                        style={{ background: "var(--bad)", color: "#fff" }}
+                        onClick={() => removeBid(i)}
+                      >
+                        Delete
+                      </button>
+                    </td>
                   </tr>
                 );
               })}

--- a/tests/bidsPage.test.tsx
+++ b/tests/bidsPage.test.tsx
@@ -1,7 +1,14 @@
+// @vitest-environment jsdom
 import React from "react";
 import { describe, it, expect } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { BidsPage, applyAwardVacancy, type Vacancy } from "../src/App";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  BidsPage,
+  applyAwardVacancy,
+  type Vacancy,
+  type Bid,
+} from "../src/App";
 
 // test verifying that awarded vacancies are excluded from the dropdown
 
@@ -45,5 +52,38 @@ describe("BidsPage vacancy dropdown", () => {
     );
     expect(afterHtml).not.toContain('value="v1"');
     expect(afterHtml).toContain("No open vacancies");
+  });
+});
+
+describe("BidsPage delete button", () => {
+  it("removes bid when Delete clicked", () => {
+    const initialBid: Bid = {
+      vacancyId: "v1",
+      bidderEmployeeId: "e1",
+      bidderName: "Alice",
+      bidderStatus: "FT",
+      bidderClassification: "RN",
+      bidTimestamp: "2024-01-01T00:00:00.000Z",
+      notes: "",
+    };
+
+    function Wrapper() {
+      const [bids, setBids] = React.useState<Bid[]>([initialBid]);
+      return (
+        <BidsPage
+          bids={bids}
+          setBids={setBids}
+          vacancies={[]}
+          vacations={[]}
+          employees={[]}
+          employeesById={{}}
+        />
+      );
+    }
+
+    render(<Wrapper />);
+    expect(screen.queryByText("Alice")).not.toBeNull();
+    fireEvent.click(screen.getByText("Delete"));
+    expect(screen.queryByText("Alice")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Add `removeBid` helper and delete button to BidsPage
- Include empty header column for alignment
- Add unit test verifying bid deletion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acaa022240832785e65961259fba75