### PR TITLE
feat: add selected vacancy highlight

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1749,7 +1749,11 @@ function VacancyRow({
   }
 
   return (
-    <tr className={isDueNext ? "due-next" : ""}>
+    <tr
+      className={`${isDueNext ? "due-next " : ""}${selected ? "selected" : ""}`.trim()}
+      aria-selected={selected}
+      tabIndex={0}
+    >
       <td>
         <input type="checkbox" checked={selected} onChange={onToggleSelect} />
       </td>

--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -234,3 +234,15 @@
 }
 .tooltip .line { font-size: .85rem; opacity: .9; }
 .tooltip .title { font-weight: 800; margin-bottom: 4px; }
+
+/* Selected vacancy row */
+.selected {
+  background: rgba(16, 185, 129, 0.15);
+  box-shadow: 0 0 0 2px var(--accent) inset;
+}
+
+.selected:focus-visible,
+.selected:focus-within {
+  outline: 2px solid var(--brand);
+  outline-offset: -2px;
+}


### PR DESCRIPTION
## Summary
- style selected table rows with accent-tinted background and bold inset border
- mark vacancy rows as selected when their ID matches, including aria-selected and focusable behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca9e753248327a578ff26c71d9152