### PR TITLE
Require override reason for bulk awards with class mismatch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1010,17 +1010,18 @@ export default function App() {
           </div>
         )}
 
-        {tab === "settings" && (
-          <SettingsPage settings={settings} setSettings={setSettings} />
-        )}
-        <BulkAwardDialog
-          open={bulkAwardOpen}
-          employees={employees}
-          onClose={() => setBulkAwardOpen(false)}
-          onConfirm={(payload) => {
-            setVacancies((prev) =>
-              applyAwardVacancies(prev, selectedVacancyIds, payload),
-            );
+          {tab === "settings" && (
+            <SettingsPage settings={settings} setSettings={setSettings} />
+          )}
+          <BulkAwardDialog
+            open={bulkAwardOpen}
+            employees={employees}
+            vacancies={vacancies.filter((v) => selectedVacancyIds.includes(v.id))}
+            onClose={() => setBulkAwardOpen(false)}
+            onConfirm={(payload) => {
+              setVacancies((prev) =>
+                applyAwardVacancies(prev, selectedVacancyIds, payload),
+              );
             setSelectedVacancyIds([]);
             setBulkAwardOpen(false);
           }}

--- a/src/components/BulkAwardDialog.tsx
+++ b/src/components/BulkAwardDialog.tsx
@@ -1,31 +1,64 @@
 import { useState } from "react";
-import type { Employee } from "../App";
+import type { Employee, Vacancy } from "../App";
 import { OVERRIDE_REASONS } from "../App";
 
 type Props = {
   open: boolean;
   employees: Employee[];
-  onConfirm: (payload: { empId?: string; reason?: string; overrideUsed?: boolean; message?: string }) => void;
+  vacancies: Vacancy[];
+  onConfirm: (
+    payload: {
+      empId?: string;
+      reason?: string;
+      overrideUsed?: boolean;
+      message?: string;
+    },
+  ) => void;
   onClose: () => void;
 };
 
-export default function BulkAwardDialog({ open, employees, onConfirm, onClose }: Props) {
+export default function BulkAwardDialog({
+  open,
+  employees,
+  vacancies,
+  onConfirm,
+  onClose,
+}: Props) {
   const [empId, setEmpId] = useState("");
   const [message, setMessage] = useState("");
   const [reason, setReason] = useState("");
+  const [allowOverride, setAllowOverride] = useState(false);
+  const [error, setError] = useState("");
 
   if (!open) return null;
 
   const confirm = () => {
+    setError("");
+    const chosen = employees.find((e) => e.id === empId);
+    if (!chosen) return;
+    const classMismatch = vacancies.some(
+      (v) => v.classification !== chosen.classification,
+    );
+    if (classMismatch && !allowOverride) {
+      setError(
+        'Selected employee classification does not match vacancy classification. Check "Allow class override" to proceed.',
+      );
+      return;
+    }
+    if (allowOverride && !reason) {
+      setError("Please select an override reason.");
+      return;
+    }
     onConfirm({
       empId: empId || undefined,
-      reason: reason || undefined,
-      overrideUsed: !!reason,
+      reason: allowOverride ? reason : undefined,
+      overrideUsed: allowOverride,
       message: message || undefined,
     });
     setEmpId("");
     setMessage("");
     setReason("");
+    setAllowOverride(false);
   };
 
   return (
@@ -47,16 +80,31 @@ export default function BulkAwardDialog({ open, employees, onConfirm, onClose }:
         <textarea value={message} onChange={(e) => setMessage(e.target.value)} />
       </label>
       <label>
-        Override reason
-        <select value={reason} onChange={(e) => setReason(e.target.value)}>
-          <option value="">None</option>
-          {OVERRIDE_REASONS.map((r) => (
-            <option key={r} value={r}>
-              {r}
-            </option>
-          ))}
-        </select>
+        <input
+          type="checkbox"
+          checked={allowOverride}
+          onChange={(e) => setAllowOverride(e.target.checked)}
+        />
+        Allow class override
       </label>
+      {allowOverride && (
+        <label>
+          Override reason
+          <select value={reason} onChange={(e) => setReason(e.target.value)}>
+            <option value="">Select reason…</option>
+            {OVERRIDE_REASONS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+      {error && (
+        <p role="alert" style={{ color: "red" }}>
+          {error}
+        </p>
+      )}
       <div style={{ marginTop: 12, display: "flex", gap: 8, justifyContent: "flex-end" }}>
         <button className="btn" onClick={onClose}>
           Cancel

--- a/tests/bulkAwardDialog.test.tsx
+++ b/tests/bulkAwardDialog.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { vi, describe, it, expect, afterEach } from "vitest";
+import BulkAwardDialog from "../src/components/BulkAwardDialog";
+import { OVERRIDE_REASONS, type Employee, type Vacancy } from "../src/App";
+
+const employees: Employee[] = [
+  {
+    id: "e1",
+    firstName: "Ann",
+    lastName: "A",
+    classification: "RN",
+    status: "FT",
+    seniorityRank: 1,
+    active: true,
+  },
+  {
+    id: "e2",
+    firstName: "Bob",
+    lastName: "B",
+    classification: "LPN",
+    status: "FT",
+    seniorityRank: 2,
+    active: true,
+  },
+];
+
+const vacancies: Vacancy[] = [
+  {
+    id: "v1",
+    reason: "Test",
+    classification: "RN",
+    shiftDate: "2024-01-01",
+    shiftStart: "08:00",
+    shiftEnd: "16:00",
+    knownAt: "2024-01-01T00:00:00.000Z",
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+  },
+];
+
+afterEach(() => cleanup());
+
+describe("BulkAwardDialog", () => {
+  it("blocks class mismatch without override", () => {
+    const onConfirm = vi.fn();
+    render(
+      <BulkAwardDialog
+        open
+        employees={employees}
+        vacancies={vacancies}
+        onConfirm={onConfirm}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Employee/), {
+      target: { value: "e2" },
+    });
+    fireEvent.click(screen.getByText("Confirm"));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("alert").textContent,
+    ).toContain("Allow class override");
+  });
+
+  it("requires reason when override enabled", () => {
+    const onConfirm = vi.fn();
+    render(
+      <BulkAwardDialog
+        open
+        employees={employees}
+        vacancies={vacancies}
+        onConfirm={onConfirm}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Employee/), {
+      target: { value: "e2" },
+    });
+    fireEvent.click(screen.getByLabelText(/Allow class override/));
+    fireEvent.click(screen.getByText("Confirm"));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert").textContent).toContain("override reason");
+  });
+
+  it("allows award with override and reason", () => {
+    const onConfirm = vi.fn();
+    render(
+      <BulkAwardDialog
+        open
+        employees={employees}
+        vacancies={vacancies}
+        onConfirm={onConfirm}
+        onClose={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Employee/), {
+      target: { value: "e2" },
+    });
+    fireEvent.click(screen.getByLabelText(/Allow class override/));
+    fireEvent.change(screen.getByLabelText(/Override reason/), {
+      target: { value: OVERRIDE_REASONS[0] },
+    });
+    fireEvent.click(screen.getByText("Confirm"));
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        empId: "e2",
+        reason: OVERRIDE_REASONS[0],
+        overrideUsed: true,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce class matching in bulk award dialog and require an override reason when mismatches are allowed
- Pass selected vacancies to the dialog so classifications can be checked
- Add tests covering override validation for bulk awards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca9eb376c83278c4adefd839a4ba9