### PR TITLE
Add screen reader label for vacancy select-all checkbox

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -471,6 +471,12 @@ export default function App() {
     });
   }, [vacancies, filterWing, filterClass, filterStart, filterEnd]);
 
+  const toggleAllVacancies = (checked: boolean) => {
+    setSelectedVacancyIds(
+      checked ? filteredVacancies.map((v) => v.id) : [],
+    );
+  };
+
   return (
     <div
       className="app"
@@ -893,7 +899,20 @@ export default function App() {
                 <table className="vac-table responsive-table">
                   <thead>
                     <tr>
-                      <th>Select</th>
+                      <th>
+                        <input
+                          type="checkbox"
+                          aria-label="Select all vacancies"
+                          checked={
+                            filteredVacancies.length > 0 &&
+                            selectedVacancyIds.length ===
+                              filteredVacancies.length
+                          }
+                          onChange={(e) =>
+                            toggleAllVacancies(e.target.checked)
+                          }
+                        />
+                      </th>
                       <th>Shift</th>
                       <th>Wing</th>
                       <th>Class</th>


### PR DESCRIPTION
## Summary
- add select-all handler and aria label for vacancy table checkbox

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acaa353ee88327bc3c997880babd11