### PR TITLE
feat: centralize wing and class color map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1720,7 +1720,12 @@ function MonthlySchedule({ vacancies }: { vacancies: Vacancy[] }) {
                 {dayVacancies.length ? (
                   <>
                     {dayVacancies.slice(0, 3).map((v) => (
-                      <span key={v.id} className="cal-chip">
+                      <span
+                        key={v.id}
+                        className="cal-chip"
+                        data-wing={v.wing || undefined}
+                        data-class={v.classification}
+                      >
                         {v.wing ? `${v.wing} ` : ""}
                         {v.classification}
                       </span>

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -68,7 +68,13 @@ export default function CalendarView({ vacancies }: Props) {
               </div>
               <div className="events">
                 {events.slice(0, 4).map((e, idx) => (
-                  <div key={idx} className="event-pill has-tooltip" data-status={(e as any).status || "Open"}>
+                  <div
+                    key={idx}
+                    className="event-pill has-tooltip"
+                    data-status={(e as any).status || "Open"}
+                    data-wing={(e as any).wing || undefined}
+                    data-class={(e as any).classification || undefined}
+                  >
                     <div>
                       <strong>{(e as any).shiftStart ?? ""}–{(e as any).shiftEnd ?? ""}</strong>
                       <span className="event-meta"> {(e as any).wing ?? ""} {(e as any).classification ?? ""}</span>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import Agreement from "./Agreement";
 import Dashboard from "./Dashboard";
 import AuditLog from "./AuditLog";
 import "./styles/responsive.css";
+import "./styles/color-map.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/styles/color-map.css
+++ b/src/styles/color-map.css
@@ -1,0 +1,43 @@
+:root {
+  /* Base colors */
+  --teal: #14b8a6;
+  --indigo: #6366f1;
+  --emerald: #10b981;
+  --amber: #f59e0b;
+  --sky: #0ea5e9;
+  --violet: #8b5cf6;
+
+  /* Wing mappings */
+  --wing-Rosewood: var(--teal);
+  --wing-Bluebell: var(--indigo);
+  --wing-Shamrock: var(--emerald);
+
+  /* Class mappings */
+  --class-RCA: var(--amber);
+  --class-LPN: var(--sky);
+  --class-RN: var(--violet);
+}
+
+/* Apply mapped colors to chip/badge elements */
+.cal-chip[data-wing],
+.cal-chip[data-class],
+.badge[data-wing],
+.badge[data-class],
+.pill[data-wing],
+.pill[data-class],
+.event-pill[data-wing],
+.event-pill[data-class] {
+  background-color: var(--chipColor);
+  color: #fff;
+  border-color: var(--chipColor);
+}
+
+/* Wing selectors */
+[data-wing="Rosewood"] { --chipColor: var(--wing-Rosewood); }
+[data-wing="Bluebell"] { --chipColor: var(--wing-Bluebell); }
+[data-wing="Shamrock"] { --chipColor: var(--wing-Shamrock); }
+
+/* Class selectors */
+[data-class="RCA"] { --chipColor: var(--class-RCA); }
+[data-class="LPN"] { --chipColor: var(--class-LPN); }
+[data-class="RN"] { --chipColor: var(--class-RN); }


### PR DESCRIPTION
## Summary
- add `color-map.css` with CSS variables for wing and class colors
- colorize chips and event pills via `data-wing` and `data-class` selectors
- load global color map in main entry

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acac19a7088327939007e4941ad44b