### PR TITLE
Fix BulkAwardDialog vacancies prop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1061,7 +1061,7 @@ export default function App() {
         <BulkAwardDialog
           open={bulkAwardOpen}
           employees={employees}
-          vacancyIds={selectedVacancyIds}
+          vacancies={vacancies.filter((v) => selectedVacancyIds.includes(v.id))}
           onClose={() => setBulkAwardOpen(false)}
           onConfirm={(payload) => {
             setVacancies((prev) =>

--- a/src/components/BulkAwardDialog.tsx
+++ b/src/components/BulkAwardDialog.tsx
@@ -1,17 +1,17 @@
 import { useState } from "react";
-import type { Employee } from "../App";
+import type { Employee, Vacancy } from "../App";
 import { OVERRIDE_REASONS } from "../App";
 import { logBulkAward } from "../utils/logger";
 
 type Props = {
   open: boolean;
   employees: Employee[];
-  vacancyIds: string[];
+  vacancies: Vacancy[];
   onConfirm: (payload: { empId?: string; reason?: string; overrideUsed?: boolean; message?: string }) => void;
   onClose: () => void;
 };
 
-export default function BulkAwardDialog({ open, employees, vacancyIds, onConfirm, onClose }: Props) {
+export default function BulkAwardDialog({ open, employees, vacancies, onConfirm, onClose }: Props) {
   const [empId, setEmpId] = useState("");
   const [message, setMessage] = useState("");
   const [reason, setReason] = useState("");
@@ -27,7 +27,7 @@ export default function BulkAwardDialog({ open, employees, vacancyIds, onConfirm
     };
     onConfirm(payload);
     logBulkAward({
-      vacancyIds,
+      vacancyIds: vacancies.map((v) => v.id),
       employeeId: payload.empId,
       reason: payload.reason,
     });


### PR DESCRIPTION
## Summary
- pass filtered vacancy objects to `BulkAwardDialog`
- update `BulkAwardDialog` props to accept vacancies instead of vacancy IDs

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acad4b30cc8327bf2567c896f8bc17