### PR TITLE
feat: add calendar mini-toolbar and heatmap toggle

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -15,6 +15,7 @@ export default function CalendarView({ vacancies }: Props) {
   const today = React.useMemo(() => new Date(), []);
   const [y, setY] = React.useState(today.getFullYear());
   const [m, setM] = React.useState(today.getMonth());
+  const [showHeatmap, setShowHeatmap] = React.useState(false);
 
   const days: Day[] = React.useMemo(() => buildCalendar(y, m), [y, m]);
 
@@ -29,10 +30,30 @@ export default function CalendarView({ vacancies }: Props) {
     return map;
   }, [vacancies]);
 
+  const todayIso = isoDate(today);
+  const todaysEvents = eventsByDate[todayIso] || [];
+  const openToday = todaysEvents.filter((e: any) => (e as any).status === "Open").length;
+  const pendingToday = todaysEvents.filter((e: any) => (e as any).status === "Pending").length;
+  const awardedToday = todaysEvents.filter((e: any) => (e as any).status === "Awarded").length;
+
   const weekdayShort = new Intl.DateTimeFormat(undefined, { weekday: "short" });
 
   return (
-    <section className="calendar" aria-label="Calendar">
+    <>
+      <div className="calendar-mini-toolbar" role="toolbar">
+        <div className="counts" aria-live="polite">
+          <div className="count"><span className="badge badge-open">{openToday}</span> Open today</div>
+          <div className="count"><span className="badge badge-pending">{pendingToday}</span> Pending today</div>
+          <div className="count"><span className="badge badge-awarded">{awardedToday}</span> Awarded today</div>
+        </div>
+        <div className="actions">
+          <button className="calendar-btn" onClick={() => { setY(today.getFullYear()); setM(today.getMonth()); }} aria-label="Jump to today">Jump to Today</button>
+          <button className="calendar-btn" onClick={() => { /* TODO: navigate to new vacancy */ }} aria-label="Create new vacancy">New Vacancy</button>
+          <button className="calendar-btn" onClick={() => setShowHeatmap((h) => !h)} aria-pressed={showHeatmap} aria-label="Toggle heatmap">Toggle Heatmap</button>
+        </div>
+      </div>
+
+      <section className="calendar" aria-label="Calendar">
       <div className="calendar-toolbar">
         <div className="controls">
           <button className="calendar-btn" onClick={() => prevMonth(setY, setM, y, m)} aria-label="Previous month">◀</button>
@@ -49,7 +70,7 @@ export default function CalendarView({ vacancies }: Props) {
         ))}
       </div>
 
-      <div className="calendar-grid">
+      <div className={"calendar-grid" + (showHeatmap ? " heatmap" : "") }>
         {days.map((d) => {
           const iso = isoDate(d.date);
           const events = (eventsByDate[iso] || []) as any[];
@@ -57,7 +78,12 @@ export default function CalendarView({ vacancies }: Props) {
           const awarded = events.filter((e) => (e as any).status === "Awarded").length;
           const pending = events.filter((e) => (e as any).status === "Pending").length;
           return (
-            <div key={iso} className={"day-cell" + (d.inMonth ? "" : " outside")} aria-label={iso}>
+            <div
+              key={iso}
+              className={"day-cell" + (d.inMonth ? "" : " outside")}
+              aria-label={iso}
+              style={{ ["--event-count" as any]: events.length }}
+            >
               <div className="day-head">
                 <div>{d.date.getDate()}</div>
                 <div style={{ display: "flex", gap: 6 }}>
@@ -91,5 +117,6 @@ export default function CalendarView({ vacancies }: Props) {
         })}
       </div>
     </section>
+    </>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import ThemeToggle from "./ThemeToggle";
 
 type HeaderProps = {
@@ -16,8 +16,19 @@ const NavLink: React.FC<{ href: string; label: string; current?: boolean; icon?:
 };
 
 export default function Header({ current }: HeaderProps) {
+  const headerRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (headerRef.current) {
+      document.documentElement.style.setProperty(
+        "--header-height",
+        `${headerRef.current.offsetHeight}px`
+      );
+    }
+  }, []);
+
   return (
-    <header className="topnav" role="banner">
+    <header ref={headerRef} className="topnav" role="banner">
       <div className="brand">
         <img src="/maplewood-logo.svg" alt="" />
         <div>Maplewood Scheduler</div>

--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -4,6 +4,8 @@
    No new deps; works with your existing CSS variables.
 */
 
+:root { --header-height: 0px; }
+
 /* Light/Dark manual theme override (optional) */
 :root[data-theme="light"] {
   color-scheme: light;
@@ -126,6 +128,30 @@
   padding: 12px;
   box-shadow: 0 2px 10px rgba(0,0,0,.04);
 }
+.calendar-mini-toolbar {
+  position: sticky;
+  top: calc(var(--header-height) + 8px);
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.calendar-mini-toolbar .counts {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.calendar-mini-toolbar .count {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+}
+.calendar-mini-toolbar .actions {
+  display: flex;
+  gap: 8px;
+}
 .calendar-toolbar {
   display: flex;
   align-items: center;
@@ -169,6 +195,10 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+.heatmap .day-cell {
+  background-color: rgba(14,165,233, calc(min(var(--event-count), 10) * 0.1));
+  transition: background-color .2s ease;
 }
 .day-cell.outside { opacity: .45; }
 .day-head {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -72,6 +72,10 @@
   .calendar-grid {
     grid-template-columns: 1fr;
   }
+  .calendar-mini-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }
 
 /* custom checkbox toggle */


### PR DESCRIPTION
## Summary
- expose header height to CSS using a ref and custom property
- add calendar mini-toolbar with counts, actions, and heatmap toggle
- style toolbar and heatmap, including responsive stacking

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acad4048f8832799ee0bd87b41e9f3