### PR TITLE
Simplify vacancy table selection toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -265,7 +265,6 @@ export default function App() {
   );
   const [bids, setBids] = useState<Bid[]>(persisted?.bids ?? []);
   const [selectedVacancyIds, setSelectedVacancyIds] = useState<string[]>([]);
-  const [allSelected, setAllSelected] = useState(false);
   const [bulkAwardOpen, setBulkAwardOpen] = useState(false);
   const persistedSettings = persisted?.settings ?? {};
   const storedOrder: string[] = persistedSettings.tabOrder || [];
@@ -472,18 +471,11 @@ export default function App() {
     });
   }, [vacancies, filterWing, filterClass, filterStart, filterEnd]);
 
-  useEffect(() => {
-    if (allSelected) {
-      setSelectedVacancyIds(filteredVacancies.map((v) => v.id));
-    }
-  }, [allSelected, filteredVacancies]);
-
-  useEffect(() => {
-    const allIds = filteredVacancies.map((v) => v.id);
-    setAllSelected(
-      allIds.length > 0 && allIds.every((id) => selectedVacancyIds.includes(id)),
+  const toggleAllVacancies = (checked: boolean) => {
+    setSelectedVacancyIds(
+      checked ? filteredVacancies.map((v) => v.id) : [],
     );
-  }, [filteredVacancies, selectedVacancyIds]);
+  };
 
   return (
     <div
@@ -853,16 +845,12 @@ export default function App() {
                   >
                     <input
                       type="checkbox"
-                      checked={allSelected}
-                      onChange={(e) => {
-                        const checked = e.target.checked;
-                        setAllSelected(checked);
-                        setSelectedVacancyIds(
-                          checked
-                            ? filteredVacancies.map((v) => v.id)
-                            : [],
-                        );
-                      }}
+                      checked={
+                        filteredVacancies.length > 0 &&
+                        selectedVacancyIds.length ===
+                          filteredVacancies.length
+                      }
+                      onChange={(e) => toggleAllVacancies(e.target.checked)}
                     />
                     All
                   </label>


### PR DESCRIPTION
## Summary
- drop stale `allSelected` state and related effects
- add `toggleAllVacancies` helper
- update header checkbox to reflect and toggle selection via helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acaeb478608327baf1e26badd6465a