### PR TITLE
feat: open bid date picker when label is clicked

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1433,6 +1433,7 @@ export function BidsPage({
   const [newBid, setNewBid] = useState<
     Partial<Bid & { bidDate: string; bidTime: string }>
   >({});
+  const bidDateRef = useRef<HTMLInputElement>(null);
 
   const vacWithCoveredName = (v: Vacancy) => {
     const vac = vacations.find((x) => x.id === v.vacationId);
@@ -1497,10 +1498,12 @@ export function BidsPage({
                 }}
               />
             </div>
-            <div>
+            {/* clicking wrapper triggers picker; use same pattern for future date fields */}
+            <div onClick={() => bidDateRef.current?.showPicker()}>
               <label>Bid Date</label>
               <input
                 type="date"
+                ref={bidDateRef}
                 value={newBid.bidDate ?? ""}
                 onChange={(e) =>
                   setNewBid((b) => ({ ...b, bidDate: e.target.value }))


### PR DESCRIPTION
## Summary
- allow clicking Bid Date label to trigger native date picker via `showPicker`
- add reference for bid date input to support programmatic picker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acaee0ce7c83279d8f815a8ab1faa3