### PR TITLE
feat: archive bids on vacancy award

### DIFF
--- a/tests/archiveBidsForVacancy.test.ts
+++ b/tests/archiveBidsForVacancy.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { archiveBidsForVacancy, type Bid } from "../src/App";
+
+describe("archiveBidsForVacancy", () => {
+  it("moves bids for a vacancy into archived map", () => {
+    const bids: Bid[] = [
+      {
+        vacancyId: "v1",
+        bidderEmployeeId: "e1",
+        bidderName: "A",
+        bidderStatus: "FT",
+        bidderClassification: "RN",
+        bidTimestamp: "2024-01-01T00:00:00Z",
+      },
+      {
+        vacancyId: "v2",
+        bidderEmployeeId: "e2",
+        bidderName: "B",
+        bidderStatus: "PT",
+        bidderClassification: "RN",
+        bidTimestamp: "2024-01-02T00:00:00Z",
+      },
+    ];
+    const archived: Record<string, Bid[]> = {
+      v2: [
+        {
+          vacancyId: "v2",
+          bidderEmployeeId: "e3",
+          bidderName: "C",
+          bidderStatus: "FT",
+          bidderClassification: "RN",
+          bidTimestamp: "2024-01-03T00:00:00Z",
+        },
+      ],
+    };
+    const res = archiveBidsForVacancy(bids, archived, "v1");
+    expect(res.bids).toHaveLength(1);
+    expect(res.bids[0].vacancyId).toBe("v2");
+    expect(res.archived.v1).toHaveLength(1);
+    expect(res.archived.v1[0].vacancyId).toBe("v1");
+    expect(res.archived.v2).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- persist archived bids alongside active bids
- move bids to archive when awarding vacancies individually or in bulk
- add unit test for bid archival

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb2bb6fa0832787fe34eacc29bd66