### PR TITLE
feat: add search options and back navigation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -67,7 +67,16 @@ app.post(
 app.get("/api/collective-agreement/search", requireAuth, (req, res) => {
   const q = req.query.q;
   if (typeof q !== "string" || !q) return res.json({ matches: [] });
-  res.json({ matches: searchAgreement(q) });
+  const caseSensitive = req.query.caseSensitive === "true";
+  const limit = parseInt(req.query.limit);
+  const context = parseInt(req.query.context);
+  res.json({
+    matches: searchAgreement(q, {
+      caseSensitive,
+      limit: isNaN(limit) ? undefined : limit,
+      context: isNaN(context) ? undefined : context,
+    }),
+  });
 });
 
 const port = process.env.PORT || 3000;

--- a/src/Agreement.tsx
+++ b/src/Agreement.tsx
@@ -1,13 +1,18 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { authFetch } from "./utils/api";
 
 export default function Agreement() {
+  const navigate = useNavigate();
   const [uploaded, setUploaded] = useState(false);
   const [query, setQuery] = useState("");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [limit, setLimit] = useState(5);
+  const [context, setContext] = useState(1);
   interface Match {
     line: string;
     lineNumber: number;
-    context: string;
+    context: string[];
   }
   const [results, setResults] = useState<Match[]>([]);
 
@@ -25,7 +30,9 @@ export default function Agreement() {
 
   const search = async () => {
     const res = await authFetch(
-      `/api/collective-agreement/search?q=${encodeURIComponent(query)}`,
+      `/api/collective-agreement/search?q=${encodeURIComponent(
+        query,
+      )}&caseSensitive=${caseSensitive}&limit=${limit}&context=${context}`,
     );
     const data = await res.json();
     const matches = (data.matches ?? []) as Match[];
@@ -35,7 +42,8 @@ export default function Agreement() {
   return (
     <div className="container">
       <div className="nav">
-        <div>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <button className="btn" onClick={() => navigate("/")}>Back</button>
           <div className="title">Collective Agreement</div>
         </div>
       </div>
@@ -52,6 +60,38 @@ export default function Agreement() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
             />
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              <label style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                <input
+                  type="checkbox"
+                  checked={caseSensitive}
+                  onChange={(e) => setCaseSensitive(e.target.checked)}
+                />
+                Case sensitive
+              </label>
+              <label style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                Max results
+                <input
+                  type="number"
+                  min={1}
+                  value={limit}
+                  onChange={(e) => setLimit(parseInt(e.target.value, 10) || 1)}
+                  style={{ width: 60 }}
+                />
+              </label>
+              <label style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                Context lines
+                <input
+                  type="number"
+                  min={0}
+                  value={context}
+                  onChange={(e) =>
+                    setContext(parseInt(e.target.value, 10) || 0)
+                  }
+                  style={{ width: 60 }}
+                />
+              </label>
+            </div>
             <button className="btn" onClick={search}>
               Search
             </button>
@@ -60,7 +100,7 @@ export default function Agreement() {
                 <li key={i}>
                   <div>{r.line}</div>
                   <small>
-                    Line {r.lineNumber}: {r.context}
+                    Line {r.lineNumber}: {r.context.join(" — ")}
                   </small>
                 </li>
               ))}

--- a/tests/collectiveAgreement.test.ts
+++ b/tests/collectiveAgreement.test.ts
@@ -60,5 +60,35 @@ describe("collectiveAgreement", () => {
       fs.unlinkSync(tmpPath);
     }
   });
+
+  it("supports search options", async () => {
+    const { loadAgreement, searchAgreement } = await import(
+      "../server/collectiveAgreement.js",
+    );
+    const text = [
+      "Alpha", // line 1
+      "beta keyword", // line 2
+      "Keyword", // line 3
+      "keyword", // line 4
+    ].join("\n");
+    const tmpPath = path.join(process.cwd(), "temp-agreement-case.txt");
+    fs.writeFileSync(tmpPath, text);
+    try {
+      await loadAgreement(tmpPath);
+      const caseSensitive = searchAgreement("Keyword", { caseSensitive: true });
+      expect(caseSensitive).toHaveLength(1);
+      const caseInsensitive = searchAgreement("Keyword", { caseSensitive: false });
+      expect(caseInsensitive).toHaveLength(3);
+      const limited = searchAgreement("keyword", { limit: 1 });
+      expect(limited).toHaveLength(1);
+      const noContext = searchAgreement("Keyword", {
+        caseSensitive: true,
+        context: 0,
+      });
+      expect(noContext[0].context).toEqual(["Keyword"]);
+    } finally {
+      fs.unlinkSync(tmpPath);
+    }
+  });
 });
 


### PR DESCRIPTION
## Summary
- add configurable case sensitivity, result limit, and context lines to collective agreement search
- expose new search options through API and UI with a back button to main screen
- expand tests to cover search option behavior

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acb30131d48327a0dc3737753784f3