### PR TITLE
Refactor archiveBidsForVacancy to return archivedBids map

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -246,17 +246,17 @@ export const archiveBidsForVacancy = (
   bids: Bid[],
   archived: Record<string, Bid[]>,
   vacancyId: string,
-): { bids: Bid[]; archived: Record<string, Bid[]> } => {
+): { bids: Bid[]; archivedBids: Record<string, Bid[]> } => {
   const remaining: Bid[] = [];
   const moved: Bid[] = [];
   for (const b of bids) {
     if (b.vacancyId === vacancyId) moved.push(b);
     else remaining.push(b);
   }
-  if (!moved.length) return { bids: remaining, archived };
+  if (!moved.length) return { bids: remaining, archivedBids: archived };
   return {
     bids: remaining,
-    archived: {
+    archivedBids: {
       ...archived,
       [vacancyId]: [...(archived[vacancyId] ?? []), ...moved],
     },

--- a/tests/archiveBidsForVacancy.test.ts
+++ b/tests/archiveBidsForVacancy.test.ts
@@ -36,8 +36,8 @@ describe("archiveBidsForVacancy", () => {
     const res = archiveBidsForVacancy(bids, archived, "v1");
     expect(res.bids).toHaveLength(1);
     expect(res.bids[0].vacancyId).toBe("v2");
-    expect(res.archived.v1).toHaveLength(1);
-    expect(res.archived.v1[0].vacancyId).toBe("v1");
-    expect(res.archived.v2).toHaveLength(1);
+    expect(res.archivedBids.v1).toHaveLength(1);
+    expect(res.archivedBids.v1[0].vacancyId).toBe("v1");
+    expect(res.archivedBids.v2).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- Clean up merge conflict markers and consolidate `archiveBidsForVacancy`
- Return an `archivedBids` map when moving bids to archive
- Update unit test to use `archivedBids`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc6cfbe308327ae4a9801ab366512