### PR TITLE
Archive bids with helper in award flows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -497,8 +497,8 @@ export default function App() {
     vacId: string,
     payload: { empId?: string; reason?: string; overrideUsed?: boolean },
   ) => {
-    archiveBids([vacId]);
     setVacancies((prev) => applyAwardVacancy(prev, vacId, payload));
+    archiveBids([vacId]);
   };
 
   const resetKnownAt = (vacId: string) => {


### PR DESCRIPTION
## Summary
- archive selected vacancy bids via new helper
- invoke helper after awards and in bulk award handler

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68acc7fd77b88327b04245e890b5f26f