### PR TITLE
feat: hide filled shifts by default

### DIFF
--- a/src/Analytics.tsx
+++ b/src/Analytics.tsx
@@ -153,7 +153,7 @@ export default function Analytics() {
 
   const labels = rows.map((r) => r.period);
   const posted = rows.map((r) => r.posted);
-  const awarded = rows.map((r) => r.awarded);
+  const filled = rows.map((r) => r.awarded);
   const cancellationRate = rows.map((r) => r.cancellationRate * 100);
   const overtime = rows.map((r) => r.overtime);
   return (
@@ -177,8 +177,8 @@ export default function Analytics() {
                 backgroundColor: "rgba(54,162,235,0.5)",
               },
               {
-                label: "Awarded",
-                data: awarded,
+                label: "Filled",
+                data: filled,
                 backgroundColor: "rgba(75,192,192,0.5)",
               },
             ],

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -24,18 +24,18 @@ export default function Dashboard() {
 
   const [view, setView] = useState<"list" | "calendar">("list");
 
-  const awarded = useMemo(
-    () => vacancies.filter((v) => v.status === "Awarded"),
+  const filled = useMemo(
+    () => vacancies.filter((v) => v.status === "Filled" || v.status === "Awarded"),
     [vacancies],
   );
   const open = useMemo(
-    () => vacancies.filter((v) => v.status !== "Awarded"),
+    () => vacancies.filter((v) => v.status !== "Filled" && v.status !== "Awarded"),
     [vacancies],
   );
 
   const employeeLastAssigned = useMemo(() => {
     const map: Record<string, string> = {};
-    for (const v of awarded) {
+    for (const v of filled) {
       if (v.awardedTo && v.awardedAt) {
         const prev = map[v.awardedTo];
         if (!prev || new Date(v.awardedAt) > new Date(prev)) {
@@ -44,7 +44,7 @@ export default function Dashboard() {
       }
     }
     return map;
-  }, [awarded]);
+  }, [filled]);
 
   const employeesWithLast = useMemo(
     () =>
@@ -90,14 +90,14 @@ export default function Dashboard() {
         ) : (
           <>
             <section>
-              <h2>Awarded Shifts</h2>
+              <h2>Filled Shifts</h2>
               <div className="shift-list">
-                {awarded.map((v) => (
+                {filled.map((v) => (
                   <div key={v.id} className="shift-card awarded">
                     {v.shiftDate} {v.shiftStart}–{v.shiftEnd} • {v.wing ?? ""} • {v.classification}
                   </div>
                 ))}
-                {awarded.length === 0 && <p>No awarded shifts.</p>}
+                {filled.length === 0 && <p>No filled shifts.</p>}
               </div>
             </section>
 

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -1,11 +1,11 @@
 
 type Props = {
   openCount: number;
-  awardedToday: number;
+  filledToday: number;
   pendingRequests: number;
 };
 
-export default function SummaryCards({ openCount, awardedToday, pendingRequests }: Props) {
+export default function SummaryCards({ openCount, filledToday, pendingRequests }: Props) {
   return (
     <section className="summary-grid" aria-label="Summary">
       <div className="card" role="status">
@@ -14,8 +14,8 @@ export default function SummaryCards({ openCount, awardedToday, pendingRequests 
         <div className="delta">Awaiting award</div>
       </div>
       <div className="card">
-        <div className="label">Awarded Today</div>
-        <div className="value">{awardedToday}</div>
+        <div className="label">Filled Today</div>
+        <div className="value">{filledToday}</div>
         <div className="delta">Congrats &amp; notifications sent</div>
       </div>
       <div className="card">

--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -215,8 +215,9 @@
   border: 1px solid var(--stroke);
 }
 .badge-open { background: #fee2e2; color: #7f1d1d; }
-.badge-awarded { background: #dcfce7; color: #14532d; }
 .badge-pending { background: #fef3c7; color: #7c2d12; }
+.badge-awarded { background: #dcfce7; color: #14532d; }
+.badge-filled { background: #e0e7ff; color: #1e3a8a; }
 
 .events {
   display: flex;
@@ -237,6 +238,7 @@
 .event-pill[data-status="Open"] { outline: 2px solid #fca5a5; }
 .event-pill[data-status="Pending"] { outline: 2px solid #fcd34d; }
 .event-pill[data-status="Awarded"] { outline: 2px solid #86efac; }
+.event-pill[data-status="Filled"] { outline: 2px solid #a5b4fc; }
 
 .event-meta { opacity: .8; font-size: .78rem; }
 

--- a/tests/awardVacancy.test.ts
+++ b/tests/awardVacancy.test.ts
@@ -16,7 +16,7 @@ describe("applyAwardVacancy", () => {
       status: "Open",
     };
     const updated = applyAwardVacancy([vac], "v1", { empId: "EMPTY" });
-    expect(updated[0].status).toBe("Awarded");
+    expect(updated[0].status).toBe("Filled");
     expect(updated[0].awardedTo).toBeUndefined();
   });
 
@@ -73,8 +73,8 @@ describe("applyAwardVacancy", () => {
     const v2 = updated.find((v) => v.id === "v2")!;
     const v3 = updated.find((v) => v.id === "v3")!;
 
-    expect(v1.status).toBe("Awarded");
-    expect(v2.status).toBe("Awarded");
+    expect(v1.status).toBe("Filled");
+    expect(v2.status).toBe("Filled");
     expect(v1.awardedTo).toBeUndefined();
     expect(v2.awardedTo).toBeUndefined();
     expect(v1.awardedTo).toBe(v2.awardedTo);

--- a/tests/awardVacancy.test.tsx
+++ b/tests/awardVacancy.test.tsx
@@ -85,14 +85,14 @@ describe("award vacancy UI", () => {
     await waitFor(() => {
       const stored = JSON.parse(localStorage.getItem(LS_KEY)!);
       const v1 = stored.vacancies.find((v: any) => v.id === "v1");
-      if (v1?.status !== "Awarded") throw new Error("not yet");
+      if (v1?.status !== "Filled") throw new Error("not yet");
     });
 
     const stored = JSON.parse(localStorage.getItem(LS_KEY)!);
     const v1 = stored.vacancies.find((v: any) => v.id === "v1");
     const v2 = stored.vacancies.find((v: any) => v.id === "v2");
-    expect(v1.status).toBe("Awarded");
-    expect(v2.status).toBe("Awarded");
+    expect(v1.status).toBe("Filled");
+    expect(v2.status).toBe("Filled");
     expect(v1.awardedTo).toBe("e1");
     expect(v2.awardedTo).toBe("e1");
     expect(v1.awardReason).toBe(reason);

--- a/tests/bulkAwardVacancies.test.ts
+++ b/tests/bulkAwardVacancies.test.ts
@@ -17,8 +17,8 @@ describe("applyAwardVacancies", () => {
     };
     const vac2: Vacancy = { ...vac1, id: "v2" };
     const updated = applyAwardVacancies([vac1, vac2], ["v1", "v2"], { empId: "e1" });
-    expect(updated[0].status).toBe("Awarded");
-    expect(updated[1].status).toBe("Awarded");
+    expect(updated[0].status).toBe("Filled");
+    expect(updated[1].status).toBe("Filled");
     expect(updated[0].awardedTo).toBe("e1");
     expect(updated[1].awardedTo).toBe("e1");
   });

--- a/tests/calendarViewFilled.test.tsx
+++ b/tests/calendarViewFilled.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { expect, test } from "vitest";
+import CalendarView from "../src/components/CalendarView";
+import type { Vacancy } from "../src/App";
+
+test("filled shifts hidden by default and toggle shows them", () => {
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const base: any = {
+    reason: "Test",
+    classification: "RN",
+    date: todayIso,
+    shiftStart: "08:00",
+    shiftEnd: "16:00",
+    knownAt: new Date().toISOString(),
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+  };
+  const vacancies: Vacancy[] = [
+    { ...base, id: "v1", status: "Open" },
+    { ...base, id: "v2", status: "Pending" as any },
+    { ...base, id: "v3", status: "Filled" },
+  ];
+
+  const { container } = render(<CalendarView vacancies={vacancies} />);
+  const toolbar = container.querySelector(".calendar-mini-toolbar")!;
+  expect(toolbar.querySelector(".badge-open")?.textContent).toBe("1");
+  expect(toolbar.querySelector(".badge-pending")?.textContent).toBe("1");
+  expect(toolbar.querySelector(".badge-filled")?.textContent).toBe("1");
+  expect(container.querySelector('.event-pill[data-status="Filled"]')).toBeNull();
+
+  fireEvent.click(screen.getByRole("button", { name: /Show Filled/i }));
+  expect(container.querySelector('.event-pill[data-status="Filled"]')).not.toBeNull();
+});
+


### PR DESCRIPTION
## Summary
- add `Filled` vacancy status and award shifts into it
- hide filled shifts in calendar unless "Show Filled" toggle is active
- track filled counts on dashboard and summary cards with new styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acc7f7df7c8327acd4754c8cb8511a