### PR TITLE
Handle missing file in collective agreement upload

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -54,6 +54,9 @@ app.post(
   requireAuth,
   upload.single("file"),
   async (req, res) => {
+    if (!req.file) {
+      return res.status(400).json({ error: "No file uploaded" });
+    }
     try {
       await loadAgreement(req.file.path);
       res.json({ success: true });


### PR DESCRIPTION
## Summary
- return 400 error when collective agreement upload request contains no file

## Testing
- `npm test` *(fails: The symbol "archiveBids" has already been declared)*
- `npm run typecheck` *(fails: Cannot redeclare block-scoped variable 'archiveBids')*

------
https://chatgpt.com/codex/tasks/task_e_68accb8b238c83279d99091a399547ba