### PR TITLE
Handle empty API tokens

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -7,8 +7,8 @@ export function getToken(): string | null {
     if (stored) return stored;
   }
   // Fallback to environment variable
-  const envToken = import.meta.env.VITE_API_TOKEN as string | undefined;
-  return envToken ?? null;
+  const envToken = (import.meta.env.VITE_API_TOKEN || '').trim();
+  return envToken || null;
 }
 
 export function setToken(token: string) {


### PR DESCRIPTION
## Summary
- trim API token from environment
- avoid Authorization header when token is empty

## Testing
- `npm test` *(fails: Failed Suites 6)*
- `npm run typecheck` *(fails: Cannot redeclare block-scoped variable 'archiveBids')*


------
https://chatgpt.com/codex/tasks/task_e_68accb8c07448327a97c569d6a3fcf43