### PR TITLE
Validate numeric search query parameters

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -68,13 +68,24 @@ app.get("/api/collective-agreement/search", requireAuth, (req, res) => {
   const q = req.query.q;
   if (typeof q !== "string" || !q) return res.json({ matches: [] });
   const caseSensitive = req.query.caseSensitive === "true";
-  const limit = parseInt(req.query.limit);
-  const context = parseInt(req.query.context);
+  const rawLimit = req.query.limit;
+  const rawContext = req.query.context;
+
+  const limit = rawLimit === undefined ? undefined : parseInt(rawLimit, 10);
+  if (rawLimit !== undefined && Number.isNaN(limit)) {
+    return res.status(400).json({ error: "limit must be numeric" });
+  }
+
+  const context = rawContext === undefined ? undefined : parseInt(rawContext, 10);
+  if (rawContext !== undefined && Number.isNaN(context)) {
+    return res.status(400).json({ error: "context must be numeric" });
+  }
+
   res.json({
     matches: searchAgreement(q, {
       caseSensitive,
-      limit: isNaN(limit) ? undefined : limit,
-      context: isNaN(context) ? undefined : context,
+      limit,
+      context,
     }),
   });
 });


### PR DESCRIPTION
## Summary
- ensure `limit` and `context` are parsed in base-10 and validated before use in the collective agreement search endpoint

## Testing
- `npm test` *(fails: ERROR: The symbol "archiveBids" has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68accb894adc83278ad964d257cd9eda