### PR TITLE
refactor: use fileURLToPath for stored agreement path

### DIFF
--- a/server/collectiveAgreement.js
+++ b/server/collectiveAgreement.js
@@ -1,8 +1,10 @@
 import fs from "fs";
 import pdfParse from "pdf-parse";
+import { fileURLToPath } from "url";
 
 const uploadDir = new URL("./uploads", import.meta.url);
 const storedPath = new URL("./uploads/agreement", import.meta.url);
+const storedFilePath = fileURLToPath(storedPath);
 
 let agreementText = "";
 let agreementLines = [];
@@ -10,8 +12,8 @@ let agreementIndex = new Map();
 
 export async function initAgreement() {
   try {
-    if (fs.existsSync(storedPath)) {
-      await loadAgreement(storedPath.pathname);
+    if (fs.existsSync(storedFilePath)) {
+      await loadAgreement(storedFilePath);
     }
   } catch (err) {
     console.error("Failed to initialize agreement", err);
@@ -42,7 +44,7 @@ export async function loadAgreement(filePath) {
     }
   });
   fs.mkdirSync(uploadDir, { recursive: true });
-  fs.copyFileSync(filePath, storedPath);
+  fs.copyFileSync(filePath, storedFilePath);
 }
 
 export function searchAgreement(


### PR DESCRIPTION
## Summary
- import `fileURLToPath` and compute stored agreement file path
- use `fileURLToPath` for all filesystem calls to the stored agreement

## Testing
- `npm test` *(fails: The symbol "archiveBids" has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68accb8694708327a794d7cefa40c772