### PR TITLE
Allow moving item to array end

### DIFF
--- a/src/utils/reorder.ts
+++ b/src/utils/reorder.ts
@@ -3,7 +3,7 @@ export function reorder<T>(arr: T[], from: number, to: number): T[] {
     from < 0 ||
     from >= arr.length ||
     to < 0 ||
-    to >= arr.length ||
+    to > arr.length ||
     from === to
   ) {
     return arr;
@@ -11,6 +11,7 @@ export function reorder<T>(arr: T[], from: number, to: number): T[] {
 
   const copy = arr.slice();
   const [item] = copy.splice(from, 1);
-  copy.splice(to, 0, item);
+  const insertIndex = to === arr.length ? arr.length : to;
+  copy.splice(insertIndex, 0, item);
   return copy;
 }

--- a/tests/reorder.test.ts
+++ b/tests/reorder.test.ts
@@ -12,6 +12,11 @@ describe("reorder utility", () => {
     expect(result).toEqual(["c", "a", "b"]);
   });
 
+  it("moves item to end when 'to' equals array length", () => {
+    const result = reorder(["a", "b", "c"], 0, 3);
+    expect(result).toEqual(["b", "c", "a"]);
+  });
+
   it("returns original array when index is out of range", () => {
     const arr = ["a", "b", "c"];
     const result = reorder(arr, 5, 0);


### PR DESCRIPTION
## Summary
- allow `reorder` utility to handle moves to the end of the array
- add test ensuring `reorder` works when target index equals array length

## Testing
- `npm test` *(fails: The symbol "archiveBids" has already been declared)*
- `npm test tests/reorder.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68accca6ebd8832797b948950a551234