### PR TITLE
Remove default award reason handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -224,7 +224,7 @@ export const applyAwardVacancy = (
           status: "Filled",
           awardedTo: empId,
           awardedAt: new Date().toISOString(),
-          awardReason: payload.reason ?? "",
+          awardReason: payload.reason,
           overrideUsed: !!payload.overrideUsed,
         }
       : v,

--- a/tests/awardVacancy.test.ts
+++ b/tests/awardVacancy.test.ts
@@ -18,6 +18,7 @@ describe("applyAwardVacancy", () => {
     const updated = applyAwardVacancy([vac], "v1", { empId: "EMPTY" });
     expect(updated[0].status).toBe("Filled");
     expect(updated[0].awardedTo).toBeUndefined();
+    expect(updated[0].awardReason).toBeUndefined();
   });
 
   it("awards multiple vacancies with identical details and differing overrides", () => {

--- a/tests/bidsPage.test.tsx
+++ b/tests/bidsPage.test.tsx
@@ -40,6 +40,7 @@ describe("BidsPage vacancy dropdown", () => {
     expect(beforeHtml).toContain('value="v1"');
 
     const awarded = applyAwardVacancy([vac], "v1", { empId: "e1" });
+    expect(awarded[0].awardReason).toBeUndefined();
     const afterHtml = renderToStaticMarkup(
       <BidsPage
         bids={[]}
@@ -48,7 +49,7 @@ describe("BidsPage vacancy dropdown", () => {
         vacations={[]}
         employees={[]}
         employeesById={{}}
-      />,
+      />, 
     );
     expect(afterHtml).not.toContain('value="v1"');
     expect(afterHtml).toContain("No open vacancies");

--- a/tests/bulkAwardVacancies.test.ts
+++ b/tests/bulkAwardVacancies.test.ts
@@ -21,5 +21,7 @@ describe("applyAwardVacancies", () => {
     expect(updated[1].status).toBe("Filled");
     expect(updated[0].awardedTo).toBe("e1");
     expect(updated[1].awardedTo).toBe("e1");
+    expect(updated[0].awardReason).toBeUndefined();
+    expect(updated[1].awardReason).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Set `applyAwardVacancy` to store the provided `awardReason` without defaulting to an empty string
- Update tests to expect `undefined` when no award reason is supplied

## Testing
- `npm test` *(fails: The symbol "archiveBids" has already been declared in src/App.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68accca4b2e08327af2f4498d4a934b7