### PR TITLE
test: add dateRangeInclusive coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "server": "node server/index.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "chart.js": "^4.4.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2285,7 +2285,7 @@ function EmployeeCombo({
 }
 
 // ---------- Helpers ----------
-function dateRangeInclusive(startISO: string, endISO: string) {
+export function dateRangeInclusive(startISO: string, endISO: string) {
   const out: string[] = [];
   const s = new Date(startISO + "T00:00:00");
   const e = new Date(endISO + "T00:00:00");

--- a/src/__tests__/dateRangeInclusive.test.ts
+++ b/src/__tests__/dateRangeInclusive.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { dateRangeInclusive } from '../App';
+
+describe('dateRangeInclusive', () => {
+  it('returns all dates in an inclusive range', () => {
+    const range = dateRangeInclusive('2024-06-30', '2024-07-02');
+    expect(range).toEqual(['2024-06-30', '2024-07-01', '2024-07-02']);
+  });
+
+  it('includes each day once across a daylight-saving transition', () => {
+    const originalTZ = process.env.TZ;
+    process.env.TZ = 'America/New_York';
+
+    const range = dateRangeInclusive('2024-03-09', '2024-03-12');
+    expect(range).toEqual([
+      '2024-03-09',
+      '2024-03-10',
+      '2024-03-11',
+      '2024-03-12',
+    ]);
+    expect(new Set(range).size).toBe(range.length);
+
+    process.env.TZ = originalTZ;
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `dateRangeInclusive` covering normal and DST-spanning ranges
- expose `dateRangeInclusive` from `App` for external testing
- add `test:watch` script to package.json to run Vitest in watch mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae02c0a73c832791cbd4c26a69e50a