### PR TITLE
Use UTC increment for date ranges

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2285,11 +2285,11 @@ function EmployeeCombo({
 }
 
 // ---------- Helpers ----------
-function dateRangeInclusive(startISO: string, endISO: string) {
+export function dateRangeInclusive(startISO: string, endISO: string) {
   const out: string[] = [];
   const s = new Date(startISO + "T00:00:00");
   const e = new Date(endISO + "T00:00:00");
-  for (let d = new Date(s); d <= e; d.setDate(d.getDate() + 1))
+  for (let d = new Date(s); d <= e; d.setUTCDate(d.getUTCDate() + 1))
     out.push(isoDate(d));
   return out;
 }

--- a/tests/dateRangeInclusive.test.ts
+++ b/tests/dateRangeInclusive.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { dateRangeInclusive } from "../src/App";
+
+describe("dateRangeInclusive", () => {
+  it("returns all dates including start and end", () => {
+    const result = dateRangeInclusive("2021-03-13", "2021-03-15");
+    expect(result).toEqual([
+      "2021-03-13",
+      "2021-03-14",
+      "2021-03-15",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Use UTC-based day increment in `dateRangeInclusive` to avoid DST issues
- Export and test `dateRangeInclusive` for inclusive start/end coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae02bcea608327afe1393d5760163b