### PR TITLE
Handle corrupted local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,7 +159,16 @@ const loadState = () => {
   try {
     const raw = localStorage.getItem(LS_KEY);
     return raw ? JSON.parse(raw) : null;
-  } catch {
+  } catch (err) {
+    console.error("Failed to parse saved state", err);
+    if (typeof window !== "undefined" && typeof window.alert === "function") {
+      window.alert("Stored data was corrupted and has been reset.");
+    }
+    try {
+      localStorage.removeItem(LS_KEY);
+    } catch (removeErr) {
+      console.error("Failed to reset localStorage", removeErr);
+    }
     return null;
   }
 };

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -8,7 +8,16 @@ const loadState = () => {
   try {
     const raw = localStorage.getItem(LS_KEY);
     return raw ? JSON.parse(raw) : null;
-  } catch {
+  } catch (err) {
+    console.error("Failed to parse saved state", err);
+    if (typeof window !== "undefined" && typeof window.alert === "function") {
+      window.alert("Stored data was corrupted and has been reset.");
+    }
+    try {
+      localStorage.removeItem(LS_KEY);
+    } catch (removeErr) {
+      console.error("Failed to reset localStorage", removeErr);
+    }
     return null;
   }
 };

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -23,7 +23,16 @@ function read(storage: Storage): AuditLog[] {
   try {
     const raw = storage.getItem(KEY);
     return raw ? (JSON.parse(raw) as AuditLog[]) : [];
-  } catch {
+  } catch (err) {
+    console.error("Failed to parse audit log storage", err);
+    if (typeof window !== "undefined" && typeof window.alert === "function") {
+      window.alert("Audit log storage was corrupted and has been reset.");
+    }
+    try {
+      storage.setItem(KEY, JSON.stringify([]));
+    } catch (writeErr) {
+      console.error("Failed to reset audit log storage", writeErr);
+    }
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- log and reset when local storage JSON parsing fails in App and Dashboard
- guard audit log storage parsing with error handling and reset

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b1d1a36e2c8327abee3f4476c09585