### PR TITLE
Improve error handling for auth fetch and bulk award logging

### DIFF
--- a/src/components/BulkAwardDialog.tsx
+++ b/src/components/BulkAwardDialog.tsx
@@ -15,10 +15,11 @@ export default function BulkAwardDialog({ open, employees, vacancies, onConfirm,
   const [empId, setEmpId] = useState("");
   const [message, setMessage] = useState("");
   const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
   if (!open) return null;
 
-  const confirm = () => {
+  const confirm = async () => {
     const payload = {
       empId: empId || undefined,
       reason: reason || undefined,
@@ -26,11 +27,16 @@ export default function BulkAwardDialog({ open, employees, vacancies, onConfirm,
       message: message || undefined,
     };
     onConfirm(payload);
-    logBulkAward({
-      vacancyIds: vacancies.map((v) => v.id),
-      employeeId: payload.empId,
-      reason: payload.reason,
-    });
+    try {
+      await logBulkAward({
+        vacancyIds: vacancies.map((v) => v.id),
+        employeeId: payload.empId,
+        reason: payload.reason,
+      });
+      setError(null);
+    } catch (err: any) {
+      setError(err.message || "Failed to log bulk award");
+    }
     setEmpId("");
     setMessage("");
     setReason("");
@@ -73,6 +79,11 @@ export default function BulkAwardDialog({ open, employees, vacancies, onConfirm,
           Confirm
         </button>
       </div>
+      {error && (
+        <div role="alert" style={{ color: "red", marginTop: 8 }}>
+          {error}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -23,5 +23,19 @@ export async function authFetch(input: RequestInfo, init: RequestInit = {}) {
   if (token) {
     headers.set("Authorization", `Bearer ${token}`);
   }
-  return fetch(input, { ...init, headers });
+  const response = await fetch(input, { ...init, headers });
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`;
+    try {
+      const text = await response.text();
+      if (text) message += `: ${text}`;
+    } catch {
+      // ignore
+    }
+    const error: any = new Error(message);
+    error.status = response.status;
+    error.response = response;
+    throw error;
+  }
+  return response;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -22,13 +22,9 @@ export async function logBulkAward({
         : undefined),
     timestamp: new Date().toISOString(),
   };
-  try {
-    await authFetch("/api/logs/bulk-award", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    });
-  } catch (err) {
-    console.error("Failed to log bulk award", err);
-  }
+  await authFetch("/api/logs/bulk-award", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
 }


### PR DESCRIPTION
## Summary
- Throw detailed errors in `authFetch` when a request fails
- Allow `logBulkAward` errors to propagate and surface them in the bulk award dialog
- Update analytics flows to handle thrown errors from `authFetch`

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b1d1a0da7c8327866976598c844490