### PR TITLE
refactor: use async fs methods with better error handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -62,7 +62,7 @@ app.post(
       res.json({ success: true });
     } catch (err) {
       console.error(err);
-      res.status(500).json({ error: "Failed to process agreement" });
+      res.status(500).json({ error: err.message });
     }
   },
 );


### PR DESCRIPTION
## Summary
- replace synchronous `fs.readFileSync` and `fs.copyFileSync` with async `fs.promises` versions
- handle errors when loading the collective agreement and propagate meaningful messages
- return detailed errors to clients on agreement upload failures

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1d1ab0220832795a5b0e6d65494e7