### PR TITLE
Add range utilities for bid warnings and deadlines

### DIFF
--- a/src/lib/range.ts
+++ b/src/lib/range.ts
@@ -1,28 +1,16 @@
-import type { Settings, Bid } from "../types";
+import type { Settings, Bid, VacancyRange } from "../types";
 
-export type VacancyRange = {
-  id: string;
-  startDate: string;
-  endDate: string;
-  workingDays: string[];
-  perDayTimes?: Record<string, { start: string; end: string }>;
-  shiftStart?: string;
-  shiftEnd?: string;
-};
-
-/** Return sorted list of working days (ISO YYYY-MM-DD) */
 export function workingDays(range: VacancyRange): string[] {
   return [...(range.workingDays || [])].sort();
 }
 
-/** Simple earliest-deadline calculator (uses earliest working day) */
 export function deadlineForRange(range: VacancyRange, settings: Settings): Date {
   const days = workingDays(range);
   const first = days[0];
-  // Fallbacks to avoid undefined
-  const start = (range.perDayTimes && range.perDayTimes[first]?.start)
-    || range.shiftStart
-    || "06:30";
+  const start =
+    (range.perDayTimes && range.perDayTimes[first]?.start) ||
+    range.shiftStart ||
+    "06:30";
   const dt = new Date(`${first}T${start}:00`);
   const minutes = settings.responseWindows?.h4to24 ?? 30;
   const d = new Date(dt);
@@ -30,16 +18,34 @@ export function deadlineForRange(range: VacancyRange, settings: Settings): Date 
   return d;
 }
 
-/** True iff a bid explicitly covers all required working days */
 export function bidCoversAllDays(range: VacancyRange, bid: Bid): boolean {
   const days = new Set(workingDays(range));
-  const selected = bid.selectedDays ?? [];
+  const selected: string[] = bid.selectedDays ?? [];
   const isFull = bid.coverageType === "full";
   const coversAll = isFull && selected.length === days.size && selected.every((d: string) => days.has(d));
   return Boolean(coversAll);
 }
 
-/** Collect non-blocking warnings (placeholder: integrate fatigue/eligibility later) */
-export function evaluateBidWarnings(_range: VacancyRange, _bid: Bid): string[] {
-  return [];
+// Soft warnings:
+// - same-day conflict: bidder already bid another thing on any selected day
+// - stat/holiday reminder: show label if selected day is in provided set
+export function evaluateBidWarnings(opts: {
+  range: VacancyRange;
+  bid: Bid;
+  allBids: Bid[];
+  statDays?: Set<string>;
+}): string[] {
+  const out: string[] = [];
+  const sel = new Set(bid.selectedDays ?? []);
+  const sameDayOther = (opts.allBids || []).some(
+    b => b.bidderEmployeeId === bid.bidderEmployeeId &&
+         b.vacancyId !== bid.vacancyId &&
+         (b.selectedDays ?? []).some(d => sel.has(d))
+  );
+  if (sameDayOther) out.push("Bidder has another bid on at least one selected day.");
+
+  if (opts.statDays && [...sel].some(d => opts.statDays!.has(d))) {
+    out.push("Reminder: One or more selected days are stat/holiday.");
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary
- extract working days and compute response deadlines
- check bids for full coverage of all working days
- warn on same-day conflicts and stat holidays when evaluating bids

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node'; Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68b1f2c4086c8327a32478ac31af091b