### PR TITLE
feat: add vacancy delete with undo

### DIFF
--- a/src/components/OpenVacancies.tsx
+++ b/src/components/OpenVacancies.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import type { Vacancy } from "../types";
+import useVacancies from "../state/useVacancies";
+import ConfirmDialog from "./ui/ConfirmDialog";
+import Toast from "./ui/Toast";
+
+export default function OpenVacancies() {
+  const { vacancies, stageDelete, undoDelete, staged } = useVacancies();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [pending, setPending] = useState<string[] | null>(null);
+
+  const toggleSelect = (id: string) => {
+    setSelected((ids) =>
+      ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id],
+    );
+  };
+
+  const allChecked =
+    vacancies.length > 0 && selected.length === vacancies.length;
+
+  const toggleAll = (checked: boolean) => {
+    setSelected(checked ? vacancies.map((v) => v.id) : []);
+  };
+
+  const confirmDelete = (ids: string[]) => {
+    setPending(ids);
+  };
+
+  const handleConfirm = () => {
+    if (pending) {
+      stageDelete(pending);
+      setSelected((ids) => ids.filter((id) => !pending.includes(id)));
+      setPending(null);
+    }
+  };
+
+  const handleCancel = () => setPending(null);
+
+  const singleMessage = (v: Vacancy) =>
+    `This will remove the vacancy for ${v.classification} – ${v.shiftDate} ${v.shiftStart}. You can undo within 10 seconds.`;
+
+  return (
+    <div>
+      {selected.length > 0 && (
+        <button
+          className="btn btn-sm danger"
+          data-testid="vacancy-delete-selected"
+          aria-label="Delete selected vacancies"
+          onClick={() => confirmDelete(selected)}
+        >
+          Delete selected
+        </button>
+      )}
+      <table className="responsive-table">
+        <thead>
+          <tr>
+            <th>
+              <input
+                type="checkbox"
+                checked={allChecked}
+                onChange={(e) => toggleAll(e.target.checked)}
+                aria-label="Select all vacancies"
+              />
+            </th>
+            <th>Role</th>
+            <th>Date</th>
+            <th>Time</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {vacancies.map((v) => (
+            <tr key={v.id}>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={selected.includes(v.id)}
+                  onChange={() => toggleSelect(v.id)}
+                />
+              </td>
+              <td>{v.classification}</td>
+              <td>{v.shiftDate}</td>
+              <td>
+                {v.shiftStart}–{v.shiftEnd}
+              </td>
+              <td>
+                <button
+                  className="btn btn-sm"
+                  title="Delete vacancy"
+                  aria-label="Delete vacancy"
+                  data-testid={`vacancy-delete-${v.id}`}
+                  onClick={() => confirmDelete([v.id])}
+                >
+                  🗑
+                </button>
+              </td>
+            </tr>
+          ))}
+          {vacancies.length === 0 && (
+            <tr>
+              <td colSpan={5} style={{ textAlign: "center" }}>
+                No vacancies
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <ConfirmDialog
+        open={!!pending}
+        title="Delete vacancy?"
+        body={
+          pending && pending.length === 1
+            ? singleMessage(vacancies.find((v) => v.id === pending[0]) as Vacancy)
+            : `This will remove ${pending?.length ?? 0} selected vacancies. You can undo within 10 seconds.`
+        }
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+      <Toast
+        open={!!staged}
+        message={staged && staged.length > 1 ? "Vacancies deleted." : "Vacancy deleted."}
+        actionLabel="Undo"
+        onAction={undoDelete}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+
+interface Props {
+  open: boolean;
+  title: string;
+  body: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  body,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open && cancelRef.current) {
+      cancelRef.current.focus();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="modal"
+      role="dialog"
+      aria-modal="true"
+      data-testid="confirm-delete-modal"
+    >
+      <h2>{title}</h2>
+      <p>{body}</p>
+      <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+        <button ref={cancelRef} onClick={onCancel}>
+          Cancel
+        </button>
+        <button className="btn danger" onClick={onConfirm}>
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,37 @@
+interface Props {
+  open: boolean;
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export default function Toast({ open, message, actionLabel, onAction }: Props) {
+  if (!open) return null;
+  return (
+    <div
+      role="status"
+      className="toast"
+      data-testid="undo-delete-toast"
+      style={{
+        position: "fixed",
+        bottom: 16,
+        left: "50%",
+        transform: "translateX(-50%)",
+        background: "#333",
+        color: "#fff",
+        padding: "8px 16px",
+        borderRadius: 4,
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+      }}
+    >
+      <span>{message}</span>
+      {actionLabel && onAction && (
+        <button className="btn btn-sm" onClick={onAction}>
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/state/useVacancies.ts
+++ b/src/state/useVacancies.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from "react";
+import type { Vacancy } from "../types";
+import { loadState, saveState } from "../utils/storage";
+
+export type AuditEntry = {
+  id: string;
+  type: "VACANCY_DELETE";
+  at: string;
+  payload: {
+    vacancyIds: string[];
+    userAction: "single" | "bulk";
+  };
+};
+
+const UNDO_MS = 10000;
+
+export function useVacancies() {
+  const persisted: any = loadState() || {};
+  let initialVacancies: Vacancy[] = Array.isArray(persisted.vacancies)
+    ? persisted.vacancies.map((v: any) => ({
+        id:
+          v.id ||
+          (typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : Date.now().toString()),
+        ...v,
+      }))
+    : [];
+
+  // backfill ids if needed
+  useEffect(() => {
+    if (persisted.vacancies && persisted.vacancies.some((v: any) => !v.id)) {
+      persist(initialVacancies, persisted.auditLog || []);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const [vacancies, setVacancies] = useState<Vacancy[]>(initialVacancies);
+  const [auditLog, setAuditLog] = useState<AuditEntry[]>(
+    Array.isArray(persisted.auditLog) ? persisted.auditLog : [],
+  );
+  const [staged, setStaged] = useState<Vacancy[] | null>(null);
+  const undoTimerRef = useRef<number | null>(null);
+
+  function persist(vacs: Vacancy[], log: AuditEntry[] = auditLog) {
+    const current = loadState() || {};
+    current.vacancies = vacs;
+    current.auditLog = log;
+    saveState(current);
+  }
+
+  function stageDelete(ids: string[]) {
+    const toDelete = vacancies.filter((v) => ids.includes(v.id));
+    if (!toDelete.length) return;
+    setStaged(toDelete);
+    const remaining = vacancies.filter((v) => !ids.includes(v.id));
+    setVacancies(remaining);
+    persist(remaining);
+    if (undoTimerRef.current) window.clearTimeout(undoTimerRef.current);
+    undoTimerRef.current = window.setTimeout(() => finalizeDeletes(ids), UNDO_MS);
+  }
+
+  function undoDelete() {
+    if (!staged) return;
+    const restored = [...staged, ...vacancies];
+    setVacancies(restored);
+    setStaged(null);
+    if (undoTimerRef.current) {
+      window.clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+    persist(restored);
+  }
+
+  function finalizeDeletes(ids: string[]) {
+    const entry: AuditEntry = {
+      id:
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : Math.random().toString(36).slice(2),
+      type: "VACANCY_DELETE",
+      at: new Date().toISOString(),
+      payload: {
+        vacancyIds: ids,
+        userAction: ids.length > 1 ? "bulk" : "single",
+      },
+    };
+    const nextLog = [...auditLog, entry];
+    setAuditLog(nextLog);
+    setStaged(null);
+    undoTimerRef.current = null;
+    persist(vacancies, nextLog);
+  }
+
+  return {
+    vacancies,
+    stageDelete,
+    undoDelete,
+    staged,
+  } as const;
+}
+
+export default useVacancies;


### PR DESCRIPTION
## Summary
- add vacancy deletion state with undo timer and audit log
- provide confirm dialog and toast components
- expose OpenVacancies list with per-row and bulk delete actions

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b87662c7e0832784c8a55f03a5b6c1