### PR TITLE
Fix TypeScript warnings in range evaluation and settings type

### DIFF
--- a/src/lib/range.ts
+++ b/src/lib/range.ts
@@ -36,15 +36,16 @@ export function evaluateBidWarnings(opts: {
   statDays?: Set<string>;
 }): string[] {
   const out: string[] = [];
-  const sel = new Set(bid.selectedDays ?? []);
+  const sel = new Set<string>(opts.bid.selectedDays ?? []);
   const sameDayOther = (opts.allBids || []).some(
-    b => b.bidderEmployeeId === bid.bidderEmployeeId &&
-         b.vacancyId !== bid.vacancyId &&
-         (b.selectedDays ?? []).some(d => sel.has(d))
+    (b) =>
+      b.bidderEmployeeId === opts.bid.bidderEmployeeId &&
+      b.vacancyId !== opts.bid.vacancyId &&
+      (b.selectedDays ?? []).some((d) => sel.has(d)),
   );
   if (sameDayOther) out.push("Bidder has another bid on at least one selected day.");
 
-  if (opts.statDays && [...sel].some(d => opts.statDays!.has(d))) {
+  if (opts.statDays && Array.from(sel).some((d) => opts.statDays!.has(d))) {
     out.push("Reminder: One or more selected days are stat/holiday.");
   }
   return out;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,10 +73,10 @@ export type Settings = {
     h24to72: number;
     gt72: number;
   };
-  theme: "dark" | "light";
-  fontScale: number;
-  tabOrder: string[];
-  defaultShiftPreset: string;
+  theme?: "dark" | "light";
+  fontScale?: number;
+  tabOrder?: string[];
+  defaultShiftPreset?: string;
 };
 
 export const WINGS = [


### PR DESCRIPTION
## Summary
- Guard range bid warnings by referencing `opts.bid` and ensuring day sets are typed
- Relax `Settings` type so optional UI fields don't break defaults

## Testing
- `npm run typecheck`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8794c01f483278afa6757b379e559