### PR TITLE
feat: add bulk delete toolbar for vacancies

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import { matchText } from "./lib/text";
 import { reorder } from "./utils/reorder";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
+import { TrashIcon } from "./components/ui/Icon";
 // ---------- Constants ----------
 const TAB_KEYS = [
     "coverage",
@@ -345,6 +346,11 @@ export default function App() {
     const resetKnownAt = (vacId) => {
         setVacancies((prev) => prev.map((v) => v.id === vacId ? { ...v, knownAt: new Date().toISOString() } : v));
     };
+    const stageDelete = (ids) => {
+        setVacancies((prev) => prev.filter((v) => !ids.includes(v.id)));
+        archiveBids(ids);
+        setSelectedVacancyIds((curr) => curr.filter((id) => !ids.includes(id)));
+    };
     // Figure out which open vacancy is "due next" (soonest positive deadline)
     const dueNextId = useMemo(() => {
         let min = Infinity;
@@ -545,14 +551,23 @@ export default function App() {
                                                             alignItems: "center",
                                                         }, children: [_jsxs("label", { style: { display: "flex", alignItems: "center", gap: 4 }, children: [_jsx("input", { type: "checkbox", checked: filteredVacancies.length > 0 &&
                                                                             selectedVacancyIds.length ===
-                                                                                filteredVacancies.length, onChange: (e) => toggleAllVacancies(e.target.checked) }), "All"] }), _jsx("button", { className: "btn btn-sm", onClick: () => setFiltersOpen((o) => !o), children: filtersOpen ? "Hide Filters ▲" : "Show Filters ▼" }), selectedVacancyIds.length > 0 && (_jsxs(_Fragment, { children: [_jsx("button", { className: "btn btn-sm", onClick: () => setBulkAwardOpen(true), children: "Bulk Award" }), _jsxs("span", { className: "badge", children: [selectedVacancyIds.length, " selected"] })] }))] }), filtersOpen && (_jsxs("div", { className: "toolbar", style: { marginBottom: 8 }, children: [_jsxs("select", { value: filterWing, onChange: (e) => setFilterWing(e.target.value), children: [_jsx("option", { value: "", children: "All Wings" }), WINGS.map((w) => (_jsx("option", { value: w, children: w }, w)))] }), _jsxs("select", { value: filterClass, onChange: (e) => setFilterClass(e.target.value), children: [_jsx("option", { value: "", children: "All Classes" }), ["RCA", "LPN", "RN"].map((c) => (_jsx("option", { value: c, children: c }, c)))] }), _jsxs("select", { value: filterShift, onChange: (e) => setFilterShift(e.target.value), children: [_jsx("option", { value: "", children: "All Shifts" }), SHIFT_PRESETS.map((s) => (_jsx("option", { value: s.label, children: s.label }, s.label)))] }), _jsxs("select", { value: filterCountdown, onChange: (e) => setFilterCountdown(e.target.value), children: [_jsx("option", { value: "", children: "All Countdowns" }), _jsx("option", { value: "green", children: "Green" }), _jsx("option", { value: "yellow", children: "Yellow" }), _jsx("option", { value: "red", children: "Red" })] }), _jsx("input", { type: "date", value: filterStart, onChange: (e) => setFilterStart(e.target.value) }), _jsx("input", { type: "date", value: filterEnd, onChange: (e) => setFilterEnd(e.target.value) }), _jsx("button", { className: "btn", onClick: () => {
+                                                                                filteredVacancies.length, onChange: (e) => toggleAllVacancies(e.target.checked) }), "All"] }), _jsx("button", { className: "btn btn-sm", onClick: () => setFiltersOpen((o) => !o), children: filtersOpen ? "Hide Filters ▲" : "Show Filters ▼" }), selectedVacancyIds.length > 0 && (_jsx("button", { className: "btn btn-sm", onClick: () => setBulkAwardOpen(true), children: "Bulk Award" }))] }), filtersOpen && (_jsxs("div", { className: "toolbar", style: { marginBottom: 8 }, children: [_jsxs("select", { value: filterWing, onChange: (e) => setFilterWing(e.target.value), children: [_jsx("option", { value: "", children: "All Wings" }), WINGS.map((w) => (_jsx("option", { value: w, children: w }, w)))] }), _jsxs("select", { value: filterClass, onChange: (e) => setFilterClass(e.target.value), children: [_jsx("option", { value: "", children: "All Classes" }), ["RCA", "LPN", "RN"].map((c) => (_jsx("option", { value: c, children: c }, c)))] }), _jsxs("select", { value: filterShift, onChange: (e) => setFilterShift(e.target.value), children: [_jsx("option", { value: "", children: "All Shifts" }), SHIFT_PRESETS.map((s) => (_jsx("option", { value: s.label, children: s.label }, s.label)))] }), _jsxs("select", { value: filterCountdown, onChange: (e) => setFilterCountdown(e.target.value), children: [_jsx("option", { value: "", children: "All Countdowns" }), _jsx("option", { value: "green", children: "Green" }), _jsx("option", { value: "yellow", children: "Yellow" }), _jsx("option", { value: "red", children: "Red" })] }), _jsx("input", { type: "date", value: filterStart, onChange: (e) => setFilterStart(e.target.value) }), _jsx("input", { type: "date", value: filterEnd, onChange: (e) => setFilterEnd(e.target.value) }), _jsx("button", { className: "btn", onClick: () => {
                                                                     setFilterWing("");
                                                                     setFilterClass("");
                                                                     setFilterShift("");
                                                                     setFilterCountdown("");
                                                                     setFilterStart("");
                                                                     setFilterEnd("");
-                                                                }, children: "Clear" })] })), _jsxs("table", { className: "vac-table responsive-table", children: [_jsx("thead", { children: _jsxs("tr", { children: [_jsx("th", { children: _jsx("input", { type: "checkbox", "aria-label": "Select all vacancies", checked: filteredVacancies.length > 0 &&
+                                                                }, children: "Clear" })] })), selectedVacancyIds.length > 0 && (_jsxs("div", { style: {
+                                                            display: "flex",
+                                                            justifyContent: "space-between",
+                                                            alignItems: "center",
+                                                            gap: 8,
+                                                            marginBottom: 8,
+                                                            border: "1px solid var(--stroke)",
+                                                            padding: 8,
+                                                            borderRadius: 8,
+                                                        }, children: [_jsxs("span", { children: [selectedVacancyIds.length, " selected"] }), _jsx("button", { className: "btn btn-sm danger", "data-testid": "vacancy-delete-selected", "aria-label": "Delete selected vacancies", tabIndex: 0, onClick: () => stageDelete(selectedVacancyIds), title: "Delete selected vacancies", children: _jsxs("span", { style: { display: "inline-flex", alignItems: "center", gap: 4 }, children: [TrashIcon ? (_jsx(TrashIcon, { style: { width: 16, height: 16 }, "aria-hidden": "true" })) : ("Delete"), _jsx("span", { children: "Delete selected" })] }) })] })), _jsxs("table", { className: "vac-table responsive-table", children: [_jsx("thead", { children: _jsxs("tr", { children: [_jsx("th", { children: _jsx("input", { type: "checkbox", "aria-label": "Select all vacancies", checked: filteredVacancies.length > 0 &&
                                                                                     selectedVacancyIds.length ===
                                                                                         filteredVacancies.length, onChange: (e) => toggleAllVacancies(e.target.checked) }) }), _jsx("th", { children: "Shift" }), _jsx("th", { children: "Wing" }), _jsx("th", { children: "Class" }), _jsx("th", { children: "Offering" }), _jsx("th", { children: "Recommended" }), _jsx("th", { children: "Countdown" }), _jsx("th", { children: "Assign" }), _jsx("th", { children: "Override" }), _jsx("th", { children: "Reason (if overriding)" }), _jsx("th", { children: "Actions" })] }) }), _jsx("tbody", { children: filteredVacancies.map((v) => {
                                                                     const rec = recommendations[v.id];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { matchText } from "./lib/text";
 import { reorder } from "./utils/reorder";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
+import { TrashIcon } from "./components/ui/Icon";
 
 /**
  * Maplewood Scheduler — Coverage-first (v2.3.0)
@@ -524,6 +525,12 @@ export default function App() {
     );
   };
 
+  const stageDelete = (ids: string[]) => {
+    setVacancies((prev) => prev.filter((v) => !ids.includes(v.id)));
+    archiveBids(ids);
+    setSelectedVacancyIds((curr) => curr.filter((id) => !ids.includes(id)));
+  };
+
   // Figure out which open vacancy is "due next" (soonest positive deadline)
   const dueNextId = useMemo(() => {
     let min = Infinity;
@@ -985,17 +992,12 @@ export default function App() {
                     {filtersOpen ? "Hide Filters ▲" : "Show Filters ▼"}
                   </button>
                   {selectedVacancyIds.length > 0 && (
-                    <>
-                      <button
-                        className="btn btn-sm"
-                        onClick={() => setBulkAwardOpen(true)}
-                      >
-                        Bulk Award
-                      </button>
-                      <span className="badge">
-                        {selectedVacancyIds.length} selected
-                      </span>
-                    </>
+                    <button
+                      className="btn btn-sm"
+                      onClick={() => setBulkAwardOpen(true)}
+                    >
+                      Bulk Award
+                    </button>
                   )}
                 </div>
                 {filtersOpen && (
@@ -1069,6 +1071,42 @@ export default function App() {
                     </button>
                   </div>
                 )}
+                {selectedVacancyIds.length > 0 && (
+                  <div
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      gap: 8,
+                      marginBottom: 8,
+                      border: "1px solid var(--stroke)",
+                      padding: 8,
+                      borderRadius: 8,
+                    }}
+                  >
+                    <span>{selectedVacancyIds.length} selected</span>
+                    <button
+                      className="btn btn-sm danger"
+                      data-testid="vacancy-delete-selected"
+                      aria-label="Delete selected vacancies"
+                      tabIndex={0}
+                      onClick={() => stageDelete(selectedVacancyIds)}
+                      title="Delete selected vacancies"
+                    >
+                      <span
+                        style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+                      >
+                        {TrashIcon ? (
+                          <TrashIcon style={{ width: 16, height: 16 }} aria-hidden="true" />
+                        ) : (
+                          "Delete"
+                        )}
+                        <span>Delete selected</span>
+                      </span>
+                    </button>
+                  </div>
+                )}
+
                 <table className="vac-table responsive-table">
                   <thead>
                     <tr>

--- a/src/components/VacancyList.js
+++ b/src/components/VacancyList.js
@@ -3,9 +3,10 @@ import { useMemo } from "react";
 import VacancyRow from "./VacancyRow";
 import { useVacancyFilters } from "../hooks/useVacancyFilters";
 import { WINGS, SHIFT_PRESETS } from "../types";
-import { deadlineFor, pickWindowMinutes, fmtCountdown } from "../lib/vacancy";
+import { deadlineFor, pickWindowMinutes, fmtCountdown, } from "../lib/vacancy";
 import { minutesBetween } from "../lib/dates";
-export default function VacancyList({ vacancies, employees, employeesById, recommendations, selectedVacancyIds, setSelectedVacancyIds, settings, now, dueNextId, awardVacancy, resetKnownAt, }) {
+import { TrashIcon } from "./ui/Icon";
+export default function VacancyList({ vacancies, employees, employeesById, recommendations, selectedVacancyIds, setSelectedVacancyIds, settings, now, dueNextId, awardVacancy, resetKnownAt, stageDelete, openConfirm, }) {
     const { filterWing, setFilterWing, filterClass, setFilterClass, filterShift, setFilterShift, filterCountdown, setFilterCountdown, filterStart, setFilterStart, filterEnd, setFilterEnd, filtersOpen, setFiltersOpen, } = useVacancyFilters();
     const filteredVacancies = useMemo(() => {
         return vacancies.filter((v) => {
@@ -61,7 +62,18 @@ export default function VacancyList({ vacancies, employees, employeesById, recom
                                     setFilterCountdown("");
                                     setFilterStart("");
                                     setFilterEnd("");
-                                }, children: "Clear" })] })), _jsxs("table", { className: "vac-table responsive-table", children: [_jsx("thead", { children: _jsxs("tr", { children: [_jsx("th", { children: _jsx("input", { type: "checkbox", "aria-label": "Select all vacancies", checked: filteredVacancies.length > 0 &&
+                                }, children: "Clear" })] })), selectedVacancyIds.length > 0 && (_jsxs("div", { style: {
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                            gap: 8,
+                            marginBottom: 8,
+                            border: "1px solid var(--stroke)",
+                            padding: 8,
+                            borderRadius: 8,
+                        }, children: [_jsxs("span", { children: [selectedVacancyIds.length, " selected"] }), _jsx("button", { className: "btn btn-sm danger", "data-testid": "vacancy-delete-selected", "aria-label": "Delete selected vacancies", tabIndex: 0, onClick: () => stageDelete
+                                    ? stageDelete(selectedVacancyIds)
+                                    : openConfirm?.(selectedVacancyIds), title: "Delete selected vacancies", children: _jsxs("span", { style: { display: "inline-flex", alignItems: "center", gap: 4 }, children: [TrashIcon ? (_jsx(TrashIcon, { style: { width: 16, height: 16 }, "aria-hidden": "true" })) : ("Delete"), _jsx("span", { children: "Delete selected" })] }) })] })), _jsxs("table", { className: "vac-table responsive-table", children: [_jsx("thead", { children: _jsxs("tr", { children: [_jsx("th", { children: _jsx("input", { type: "checkbox", "aria-label": "Select all vacancies", checked: filteredVacancies.length > 0 &&
                                                     selectedVacancyIds.length === filteredVacancies.length, onChange: (e) => toggleAllVacancies(e.target.checked) }) }), _jsx("th", { children: "Shift" }), _jsx("th", { children: "Wing" }), _jsx("th", { children: "Class" }), _jsx("th", { children: "Offering" }), _jsx("th", { children: "Recommended" }), _jsx("th", { children: "Countdown" }), _jsx("th", { children: "Assign" }), _jsx("th", { children: "Override" }), _jsx("th", { children: "Reason (if overriding)" }), _jsx("th", { children: "Actions" })] }) }), _jsx("tbody", { children: filteredVacancies.map((v) => {
                                     const rec = recommendations[v.id];
                                     const recId = rec?.id;

--- a/src/components/VacancyList.tsx
+++ b/src/components/VacancyList.tsx
@@ -3,8 +3,14 @@ import type { Vacancy, Employee, Settings } from "../types";
 import VacancyRow from "./VacancyRow";
 import { useVacancyFilters } from "../hooks/useVacancyFilters";
 import { WINGS, SHIFT_PRESETS } from "../types";
-import { deadlineFor, pickWindowMinutes, fmtCountdown, archiveBidsForVacancy } from "../lib/vacancy";
+import {
+  deadlineFor,
+  pickWindowMinutes,
+  fmtCountdown,
+  archiveBidsForVacancy,
+} from "../lib/vacancy";
 import { minutesBetween } from "../lib/dates";
+import { TrashIcon } from "./ui/Icon";
 
 export interface Recommendation {
   id?: string;
@@ -26,6 +32,8 @@ interface Props {
   setBids?: (u: any) => void;
   bids?: any[];
   archivedBids?: Record<string, any[]>;
+  stageDelete?: (ids: string[]) => void;
+  openConfirm?: (ids: string[]) => void;
 }
 
 export default function VacancyList({
@@ -40,6 +48,8 @@ export default function VacancyList({
   dueNextId,
   awardVacancy,
   resetKnownAt,
+  stageDelete,
+  openConfirm,
 }: Props) {
   const {
     filterWing,
@@ -166,6 +176,46 @@ export default function VacancyList({
             </button>
           </div>
         )}
+        {selectedVacancyIds.length > 0 && (
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: 8,
+              marginBottom: 8,
+              border: "1px solid var(--stroke)",
+              padding: 8,
+              borderRadius: 8,
+            }}
+          >
+            <span>{selectedVacancyIds.length} selected</span>
+            <button
+              className="btn btn-sm danger"
+              data-testid="vacancy-delete-selected"
+              aria-label="Delete selected vacancies"
+              tabIndex={0}
+              onClick={() =>
+                stageDelete
+                  ? stageDelete(selectedVacancyIds)
+                  : openConfirm?.(selectedVacancyIds)
+              }
+              title="Delete selected vacancies"
+            >
+              <span
+                style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+              >
+                {TrashIcon ? (
+                  <TrashIcon style={{ width: 16, height: 16 }} aria-hidden="true" />
+                ) : (
+                  "Delete"
+                )}
+                <span>Delete selected</span>
+              </span>
+            </button>
+          </div>
+        )}
+
         <table className="vac-table responsive-table">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- add bulk-delete toolbar to vacancy list
- call new stageDelete helper from app to remove multiple vacancies

## Testing
- `npm run typecheck`
- `npx vitest run` *(fails: Missing pdfjs-dist module; several assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b89649d3788327991d39919e57780c