### PR TITLE
feat: add vacancy coverage dates support

### DIFF
--- a/migrations/2025-coverage-dates.ts
+++ b/migrations/2025-coverage-dates.ts
@@ -1,0 +1,12 @@
+export default function migrate(state: any) {
+  if (Array.isArray(state?.vacancies)) {
+    state.vacancies = state.vacancies.map((v: any) => ({
+      ...v,
+      coverageDates:
+        Array.isArray(v.coverageDates) && v.coverageDates.length > 0
+          ? v.coverageDates
+          : undefined,
+    }));
+  }
+  return state;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,7 @@
+export const appConfig = {
+  features: {
+    coverageDayPicker: false,
+  },
+} as const;
+
+export type AppConfig = typeof appConfig;

--- a/src/lib/vacancy.js
+++ b/src/lib/vacancy.js
@@ -1,4 +1,5 @@
 import { formatDateLong, combineDateTime } from "./dates";
+import { getDatesInRange } from "../utils/date";
 export const displayVacancyLabel = (v) => {
     const d = formatDateLong(v.shiftDate);
     return `${d} • ${v.shiftStart}–${v.shiftEnd} • ${v.wing ?? ""} • ${v.classification}`.replace(/\s+•\s+$/, "");
@@ -20,6 +21,14 @@ export function pickWindowMinutes(v, settings) {
 export function deadlineFor(v, settings) {
     const winMin = pickWindowMinutes(v, settings);
     return new Date(new Date(v.knownAt).getTime() + winMin * 60000);
+}
+export function getVacancyActiveDates(v) {
+    if (Array.isArray(v.coverageDates) && v.coverageDates.length > 0) {
+        return v.coverageDates;
+    }
+    const start = v.startDate ?? v.shiftDate;
+    const end = v.endDate ?? v.shiftDate;
+    return getDatesInRange(start, end);
 }
 export function fmtCountdown(msLeft) {
     const neg = msLeft < 0;

--- a/src/lib/vacancy.ts
+++ b/src/lib/vacancy.ts
@@ -1,4 +1,5 @@
 import { formatDateLong, combineDateTime, minutesBetween } from "./dates";
+import { getDatesInRange } from "../utils/date";
 import type { Vacancy, Settings, Bid } from "../types";
 
 export const displayVacancyLabel = (v: Vacancy) => {
@@ -20,6 +21,15 @@ export function pickWindowMinutes(v: Vacancy, settings: Settings) {
 export function deadlineFor(v: Vacancy, settings: Settings) {
   const winMin = pickWindowMinutes(v, settings);
   return new Date(new Date(v.knownAt).getTime() + winMin * 60000);
+}
+
+export function getVacancyActiveDates(v: Vacancy): string[] {
+  if (Array.isArray(v.coverageDates) && v.coverageDates.length > 0) {
+    return v.coverageDates;
+  }
+  const start = v.startDate ?? v.shiftDate;
+  const end = v.endDate ?? v.shiftDate;
+  return getDatesInRange(start, end);
 }
 
 export function fmtCountdown(msLeft: number) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export type Vacancy = {
   // For multi-day vacancies converted from VacancyRange
   startDate?: string;     // YYYY-MM-DD (when this is part of a range)
   endDate?: string;       // YYYY-MM-DD (when this is part of a range)
-  coverageDates?: string[]; // ISO dates for days that actually require coverage
+  coverageDates?: string[]; // ISO YYYY-MM-DD dates that actually require coverage
 };
 
 // Extend Bid for range coverage (safe: all optional)

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,9 +1,14 @@
+import { appConfig } from "../config";
+import migrateCoverageDates from "../../migrations/2025-coverage-dates";
+
 const LS_KEY = "maplewood-scheduler-v3";
 
 export function loadState() {
   try {
     const raw = localStorage.getItem(LS_KEY);
-    return raw ? JSON.parse(raw) : null;
+    const data = raw ? JSON.parse(raw) : null;
+    if (data) migrateCoverageDates(data);
+    return data;
   } catch {
     return null;
   }
@@ -11,7 +16,21 @@ export function loadState() {
 
 export function saveState(state: any): boolean {
   try {
-    localStorage.setItem(LS_KEY, JSON.stringify(state));
+    const toSave = { ...state };
+    if (Array.isArray(toSave.vacancies)) {
+      toSave.vacancies = toSave.vacancies.map((v: any) => {
+        if (
+          appConfig.features.coverageDayPicker &&
+          Array.isArray(v.coverageDates) &&
+          v.coverageDates.length > 0
+        ) {
+          return v;
+        }
+        const { coverageDates, ...rest } = v;
+        return rest;
+      });
+    }
+    localStorage.setItem(LS_KEY, JSON.stringify(toSave));
     return true;
   } catch (err) {
     console.warn("Unable to access localStorage. State not persisted.", err);

--- a/tests/getVacancyActiveDates.test.ts
+++ b/tests/getVacancyActiveDates.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { getVacancyActiveDates } from "../src/lib/vacancy";
+import type { Vacancy } from "../src/types";
+
+const baseVacancy: Vacancy = {
+  id: "1",
+  reason: "vacation",
+  classification: "RCA",
+  shiftDate: "2025-01-10",
+  shiftStart: "06:30",
+  shiftEnd: "14:30",
+  knownAt: "2025-01-01T00:00:00Z",
+  offeringTier: {},
+  offeringStep: "Casuals",
+  status: "Open",
+};
+
+describe("getVacancyActiveDates", () => {
+  it("returns single shift date for single-day vacancy", () => {
+    expect(getVacancyActiveDates(baseVacancy)).toEqual(["2025-01-10"]);
+  });
+
+  it("returns coverageDates when provided", () => {
+    const v: Vacancy = {
+      ...baseVacancy,
+      startDate: "2025-01-10",
+      endDate: "2025-01-12",
+      coverageDates: ["2025-01-10", "2025-01-12"],
+    };
+    expect(getVacancyActiveDates(v)).toEqual(["2025-01-10", "2025-01-12"]);
+  });
+
+  it("uses full range when coverageDates undefined", () => {
+    const v: Vacancy = {
+      ...baseVacancy,
+      startDate: "2025-01-10",
+      endDate: "2025-01-12",
+    };
+    expect(getVacancyActiveDates(v)).toEqual([
+      "2025-01-10",
+      "2025-01-11",
+      "2025-01-12",
+    ]);
+  });
+
+  it("includes weekend dates in range", () => {
+    const v: Vacancy = {
+      ...baseVacancy,
+      startDate: "2025-01-10", // Friday
+      endDate: "2025-01-13",   // Monday
+    };
+    expect(getVacancyActiveDates(v)).toEqual([
+      "2025-01-10",
+      "2025-01-11",
+      "2025-01-12",
+      "2025-01-13",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `features.coverageDayPicker` flag and serialize coverage dates only when enabled
- add migration to scrub empty `coverageDates` from stored vacancies
- implement `getVacancyActiveDates` helper with tests

## Testing
- `npx vitest run` *(fails: Failed to load agreement: Invalid PDF structure; various existing assertion mismatches)*
- `npx vitest run tests/getVacancyActiveDates.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b8a197f8308327a986a5d20b9a5816