### PR TITLE
feat: respect selected coverage days across views

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { recommend } from "./recommend";
 import { isoDate, combineDateTime, formatDateLong, formatDowShort, buildCalendar, prevMonth, nextMonth, minutesBetween, } from "./lib/dates";
 import { matchText } from "./lib/text";
+import { groupVacanciesByDate } from "./lib/vacancy";
 import { reorder } from "./utils/reorder";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
@@ -771,17 +772,8 @@ function MonthlySchedule({ vacancies }) {
     const todayISO = isoDate(today);
     const calDays = useMemo(() => buildCalendar(year, month), [year, month]);
     const vacanciesByDay = useMemo(() => {
-        const m = new Map();
-        vacancies.forEach((v) => {
-            if ((v.status !== "Filled" && v.status !== "Awarded") ||
-                v.shiftDate >= todayISO) {
-                const k = v.shiftDate;
-                const arr = m.get(k) || [];
-                arr.push(v);
-                m.set(k, arr);
-            }
-        });
-        return m;
+        const all = vacancies.filter((v) => (v.status !== "Filled" && v.status !== "Awarded") || v.shiftDate >= todayISO);
+        return groupVacanciesByDate(all);
     }, [vacancies, todayISO]);
     const monthLabel = new Date(year, month, 1).toLocaleString(undefined, {
         month: "long",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
   nextMonth,
   minutesBetween,
 } from "./lib/dates";
+import { groupVacanciesByDate } from "./lib/vacancy";
 import { matchText } from "./lib/text";
 import { reorder } from "./utils/reorder";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
@@ -1898,19 +1899,12 @@ function MonthlySchedule({ vacancies }: { vacancies: Vacancy[] }) {
 
   const calDays = useMemo(() => buildCalendar(year, month), [year, month]);
   const vacanciesByDay = useMemo(() => {
-    const m = new Map<string, Vacancy[]>();
-    vacancies.forEach((v) => {
-      if (
+    const all = vacancies.filter(
+      (v) =>
         (v.status !== "Filled" && v.status !== "Awarded") ||
-        v.shiftDate >= todayISO
-      ) {
-        const k = v.shiftDate;
-        const arr = m.get(k) || [];
-        arr.push(v);
-        m.set(k, arr);
-      }
-    });
-    return m;
+        v.shiftDate >= todayISO,
+    );
+    return groupVacanciesByDate(all);
   }, [vacancies, todayISO]);
 
   const monthLabel = new Date(year, month, 1).toLocaleString(undefined, {

--- a/src/components/CalendarView.js
+++ b/src/components/CalendarView.js
@@ -1,6 +1,7 @@
 import { jsx as _jsx, jsxs as _jsxs, Fragment as _Fragment } from "react/jsx-runtime";
 import React from "react";
 import { buildCalendar, isoDate, prevMonth, nextMonth } from "../lib/dates";
+import { groupVacanciesByDate } from "../lib/vacancy";
 function monthLabel(y, m) {
     return new Date(y, m, 1).toLocaleDateString(undefined, { month: "long", year: "numeric" });
 }
@@ -14,11 +15,9 @@ export default function CalendarView({ vacancies }) {
     // Group events by ISO yyyy-mm-dd
     const eventsByDate = React.useMemo(() => {
         const map = {};
-        for (const v of vacancies ?? []) {
-            const d = v.date || v.start?.slice(0, 10);
-            if (!d)
-                continue;
-            (map[d] || (map[d] = [])).push(v);
+        const grouped = groupVacanciesByDate(vacancies ?? []);
+        for (const [d, arr] of grouped.entries()) {
+            map[d] = arr;
         }
         return map;
     }, [vacancies]);

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import type { Vacancy } from "../types";
 import { buildCalendar, isoDate, prevMonth, nextMonth } from "../lib/dates";
+import { groupVacanciesByDate } from "../lib/vacancy";
 
 type Props = { vacancies: Vacancy[] };
 
@@ -23,10 +24,9 @@ export default function CalendarView({ vacancies }: Props) {
   // Group events by ISO yyyy-mm-dd
   const eventsByDate = React.useMemo(() => {
     const map: Record<string, any[]> = {};
-    for (const v of vacancies ?? []) {
-      const d = (v as any).date || (v as any).start?.slice(0,10);
-      if (!d) continue;
-      (map[d] ||= []).push(v);
+    const grouped = groupVacanciesByDate(vacancies ?? []);
+    for (const [d, arr] of grouped.entries()) {
+      map[d] = arr;
     }
     return map;
   }, [vacancies]);

--- a/src/components/OpenVacancies.js
+++ b/src/components/OpenVacancies.js
@@ -3,6 +3,7 @@ import { useState } from "react";
 import ConfirmDialog from "./ui/ConfirmDialog";
 import Toast from "./ui/Toast";
 import { TrashIcon } from "./ui/Icon";
+import { getVacancyActiveDates } from "../lib/vacancy";
 
 export default function OpenVacancies({ vacancies, stageDelete, undoDelete, staged, readOnly = false, }) {
   const [selected, setSelected] = useState([]);
@@ -124,10 +125,13 @@ export default function OpenVacancies({ vacancies, stageDelete, undoDelete, stag
                               _jsx("span", {
                                 className: "pill",
                                 "data-testid": "coverage-chip",
-                                children:
-                                  v.coverageDates && v.coverageDates.length > 0
-                                    ? `Coverage: ${v.coverageDates.length} days`
-                                    : "Coverage: all days",
+                                children: (() => {
+                                  const active = getVacancyActiveDates(v).length;
+                                  const full = getVacancyActiveDates({ ...v, coverageDates: undefined }).length;
+                                  return active === full
+                                    ? "Coverage: all days"
+                                    : `Coverage: ${active} days`;
+                                })(),
                               }),
                           ],
                         }),

--- a/src/components/OpenVacancies.tsx
+++ b/src/components/OpenVacancies.tsx
@@ -3,6 +3,7 @@ import type { Vacancy } from "../types";
 import ConfirmDialog from "./ui/ConfirmDialog";
 import Toast from "./ui/Toast";
 import { TrashIcon } from "./ui/Icon";
+import { getVacancyActiveDates } from "../lib/vacancy";
 
 interface Props {
   vacancies: Vacancy[];
@@ -136,9 +137,13 @@ export default function OpenVacancies({
                   </span>
                   {v.startDate && v.endDate && v.startDate !== v.endDate && (
                     <span className="pill" data-testid="coverage-chip">
-                      {v.coverageDates && v.coverageDates.length > 0
-                        ? `Coverage: ${v.coverageDates.length} days`
-                        : "Coverage: all days"}
+                      {(() => {
+                        const active = getVacancyActiveDates(v).length;
+                        const full = getVacancyActiveDates({ ...v, coverageDates: undefined }).length;
+                        return active === full
+                          ? "Coverage: all days"
+                          : `Coverage: ${active} days`;
+                      })()}
                     </span>
                   )}
                 </div>

--- a/src/lib/vacancy.js
+++ b/src/lib/vacancy.js
@@ -30,6 +30,32 @@ export function getVacancyActiveDates(v) {
     const end = v.endDate ?? v.shiftDate;
     return getDatesInRange(start, end);
 }
+
+export function coverageDatesForSubmit(v, selectedDates) {
+    const full = getVacancyActiveDates({ ...v, coverageDates: undefined });
+    const sortedSel = [...selectedDates].sort();
+    const sortedFull = [...full].sort();
+    if (sortedSel.length === sortedFull.length && sortedSel.every((d, i) => d === sortedFull[i])) {
+        return undefined;
+    }
+    return selectedDates;
+}
+
+export function hydrateCoverageSelection(v) {
+    return getVacancyActiveDates(v);
+}
+
+export function groupVacanciesByDate(vacs) {
+    const map = new Map();
+    for (const v of vacs) {
+        for (const d of getVacancyActiveDates(v)) {
+            const arr = map.get(d) || [];
+            arr.push(v);
+            map.set(d, arr);
+        }
+    }
+    return map;
+}
 export function fmtCountdown(msLeft) {
     const neg = msLeft < 0;
     const abs = Math.abs(msLeft);

--- a/src/lib/vacancy.ts
+++ b/src/lib/vacancy.ts
@@ -32,6 +32,47 @@ export function getVacancyActiveDates(v: Vacancy): string[] {
   return getDatesInRange(start, end);
 }
 
+/**
+ * Given a vacancy and a selected set of coverage days, decide what should be
+ * persisted to the vacancy record. If the selection matches the full inclusive
+ * range, we omit `coverageDates` to avoid storing redundant data.
+ */
+export function coverageDatesForSubmit(
+  v: Vacancy,
+  selectedDates: string[],
+): string[] | undefined {
+  const full = getVacancyActiveDates({ ...v, coverageDates: undefined });
+  const sortedSel = [...selectedDates].sort();
+  const sortedFull = [...full].sort();
+  if (
+    sortedSel.length === sortedFull.length &&
+    sortedSel.every((d, i) => d === sortedFull[i])
+  ) {
+    return undefined;
+  }
+  return selectedDates;
+}
+
+/** Hydrate coverage selection for editing forms. */
+export function hydrateCoverageSelection(v: Vacancy): string[] {
+  return getVacancyActiveDates(v);
+}
+
+/** Group vacancies by the dates they actually require coverage on. */
+export function groupVacanciesByDate(
+  vacs: Vacancy[],
+): Map<string, Vacancy[]> {
+  const map = new Map<string, Vacancy[]>();
+  for (const v of vacs) {
+    for (const d of getVacancyActiveDates(v)) {
+      const arr = map.get(d) || [];
+      arr.push(v);
+      map.set(d, arr);
+    }
+  }
+  return map;
+}
+
 export function fmtCountdown(msLeft: number) {
   const neg = msLeft < 0;
   const abs = Math.abs(msLeft);

--- a/tests/calendarViewFilled.test.tsx
+++ b/tests/calendarViewFilled.test.tsx
@@ -2,20 +2,20 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { expect, test } from "vitest";
 import CalendarView from "../src/components/CalendarView";
-import type { Vacancy } from "../src/App";
+import type { Vacancy } from "../src/types";
 
 test("filled shifts hidden by default and toggle shows them", () => {
   const todayIso = new Date().toISOString().slice(0, 10);
-  const base: any = {
+  const base: Omit<Vacancy, "id" | "status"> = {
     reason: "Test",
     classification: "RN",
-    date: todayIso,
+    shiftDate: todayIso,
     shiftStart: "08:00",
     shiftEnd: "16:00",
     knownAt: new Date().toISOString(),
     offeringTier: "CASUALS",
     offeringStep: "Casuals",
-  };
+  } as const;
   const vacancies: Vacancy[] = [
     { ...base, id: "v1", status: "Open" },
     { ...base, id: "v2", status: "Pending" as any },

--- a/tests/vacancySelectors.test.ts
+++ b/tests/vacancySelectors.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { coverageDatesForSubmit, hydrateCoverageSelection, groupVacanciesByDate } from "../src/lib/vacancy";
+import type { Vacancy } from "../src/types";
+
+describe("coverageDatesForSubmit and hydrateCoverageSelection", () => {
+  const base: Vacancy = {
+    id: "v1",
+    reason: "Test",
+    classification: "RN",
+    shiftDate: "2025-01-10",
+    shiftStart: "08:00",
+    shiftEnd: "16:00",
+    knownAt: new Date().toISOString(),
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+    startDate: "2025-01-10",
+    endDate: "2025-01-12",
+  };
+
+  it("omits coverageDates when selection covers full range", () => {
+    const selected = ["2025-01-10", "2025-01-11", "2025-01-12"];
+    expect(coverageDatesForSubmit(base, selected)).toBeUndefined();
+  });
+
+  it("persists coverageDates when selection is partial", () => {
+    const selected = ["2025-01-10", "2025-01-12"];
+    expect(coverageDatesForSubmit(base, selected)).toEqual(selected);
+  });
+
+  it("hydrates selection from vacancy", () => {
+    const v: Vacancy = { ...base, coverageDates: ["2025-01-10"] };
+    expect(hydrateCoverageSelection(v)).toEqual(["2025-01-10"]);
+  });
+});
+
+describe("groupVacanciesByDate", () => {
+  const v1: Vacancy = {
+    id: "a",
+    reason: "Test",
+    classification: "RN",
+    shiftDate: "2025-01-10",
+    shiftStart: "08:00",
+    shiftEnd: "16:00",
+    knownAt: new Date().toISOString(),
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+    startDate: "2025-01-10",
+    endDate: "2025-01-12",
+    coverageDates: ["2025-01-10", "2025-01-12"],
+  };
+  const v2: Vacancy = {
+    id: "b",
+    reason: "Test",
+    classification: "RN",
+    shiftDate: "2025-01-11",
+    shiftStart: "08:00",
+    shiftEnd: "16:00",
+    knownAt: new Date().toISOString(),
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+  };
+
+  it("groups by active dates", () => {
+    const map = groupVacanciesByDate([v1, v2]);
+    expect(Array.from(map.keys()).sort()).toEqual([
+      "2025-01-10",
+      "2025-01-11",
+      "2025-01-12",
+    ]);
+    expect(map.get("2025-01-11")?.map((v) => v.id)).toEqual(["b"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add utilities to persist and hydrate coverage date selections
- group vacancies by active dates and use in calendar and schedules
- display coverage chips using active date count and add selector tests

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: Error: Failed to load agreement: Invalid PDF structure; AssertionError: expected [...])*


------
https://chatgpt.com/codex/tasks/task_e_68b8a7084510832785b26af47132e62a