### PR TITLE
feat: add multi-day vacancy creation form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,9 @@ import { reorder } from "./utils/reorder";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
 import { TrashIcon } from "./components/ui/Icon";
+import VacancyRangeForm from "./components/VacancyRangeForm";
+import { appConfig } from "./config";
+import type { VacancyRange } from "./types";
 
 /**
  * Maplewood Scheduler — Coverage-first (v2.3.0)
@@ -302,6 +305,7 @@ export default function App() {
   );
   const [selectedVacancyIds, setSelectedVacancyIds] = useState<string[]>([]);
   const [bulkAwardOpen, setBulkAwardOpen] = useState(false);
+  const [showRangeForm, setShowRangeForm] = useState(false);
   const persistedSettings = persisted?.settings ?? {};
   const storedOrder: string[] = persistedSettings.tabOrder || [];
   const mergedOrder = [
@@ -484,6 +488,29 @@ export default function App() {
       shiftPreset: defaultShift.label,
     });
     setMultiDay(false);
+  };
+
+  const handleSaveRange = (range: VacancyRange) => {
+    const nowISO = new Date().toISOString();
+    const vxs: Vacancy[] = range.workingDays.map((d) => ({
+      id: `VAC-${Math.random().toString(36).slice(2, 7).toUpperCase()}`,
+      reason: range.reason,
+      classification: range.classification,
+      wing: range.wing,
+      shiftDate: d,
+      shiftStart:
+        range.perDayTimes?.[d]?.start ?? range.shiftStart ?? "06:30",
+      shiftEnd:
+        range.perDayTimes?.[d]?.end ?? range.shiftEnd ?? "14:30",
+      knownAt: nowISO,
+      offeringTier: "CASUALS",
+      offeringRoundStartedAt: nowISO,
+      offeringRoundMinutes: 120,
+      offeringAutoProgress: true,
+      offeringStep: range.offeringStep,
+      status: range.status,
+    }));
+    setVacancies((prev) => [...vxs, ...prev]);
   };
 
   const archiveBids = (vacancyIds: string[]) => {
@@ -996,6 +1023,14 @@ export default function App() {
                   >
                     {filtersOpen ? "Hide Filters ▲" : "Show Filters ▼"}
                   </button>
+                  {appConfig.features.coverageDayPicker && (
+                    <button
+                      className="btn btn-sm"
+                      onClick={() => setShowRangeForm(true)}
+                    >
+                      New Multi-Day Vacancy
+                    </button>
+                  )}
                   {selectedVacancyIds.length > 0 && (
                     <>
                       <button
@@ -1226,6 +1261,13 @@ export default function App() {
 
         {tab === "settings" && (
           <SettingsPage settings={settings} setSettings={setSettings} />
+        )}
+        {appConfig.features.coverageDayPicker && (
+          <VacancyRangeForm
+            open={showRangeForm}
+            onClose={() => setShowRangeForm(false)}
+            onSave={handleSaveRange}
+          />
         )}
         <BulkAwardDialog
           open={bulkAwardOpen}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 export const appConfig = {
   features: {
-    coverageDayPicker: false,
+    coverageDayPicker: true,
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- enable coverageDayPicker feature flag
- add button and modal to create multi-day vacancies
- expand selected dates into individual vacancy records on save

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8aa1dec248327b3228ee4bdb3636c