### PR TITLE
Convert vacancy ranges into individual vacancies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { TrashIcon } from "./components/ui/Icon";
 import VacancyRangeForm from "./components/VacancyRangeForm";
 import { appConfig } from "./config";
 import type { VacancyRange } from "./types";
+import { expandRangeToVacancies } from "./lib/expandRange";
 
 /**
  * Maplewood Scheduler — Coverage-first (v2.3.0)
@@ -491,25 +492,7 @@ export default function App() {
   };
 
   const handleSaveRange = (range: VacancyRange) => {
-    const nowISO = new Date().toISOString();
-    const vxs: Vacancy[] = range.workingDays.map((d) => ({
-      id: `VAC-${Math.random().toString(36).slice(2, 7).toUpperCase()}`,
-      reason: range.reason,
-      classification: range.classification,
-      wing: range.wing,
-      shiftDate: d,
-      shiftStart:
-        range.perDayTimes?.[d]?.start ?? range.shiftStart ?? "06:30",
-      shiftEnd:
-        range.perDayTimes?.[d]?.end ?? range.shiftEnd ?? "14:30",
-      knownAt: nowISO,
-      offeringTier: "CASUALS",
-      offeringRoundStartedAt: nowISO,
-      offeringRoundMinutes: 120,
-      offeringAutoProgress: true,
-      offeringStep: range.offeringStep,
-      status: range.status,
-    }));
+    const vxs = expandRangeToVacancies(range);
     setVacancies((prev) => [...vxs, ...prev]);
   };
 

--- a/src/lib/expandRange.ts
+++ b/src/lib/expandRange.ts
@@ -1,0 +1,36 @@
+import type { Vacancy, VacancyRange } from "../types";
+
+/**
+ * Expand a VacancyRange into individual Vacancy objects that the
+ * application already understands.
+ */
+export function expandRangeToVacancies(range: VacancyRange): Vacancy[] {
+  const nowISO = new Date().toISOString();
+  const sortedDays = [...range.workingDays].sort();
+  const coverageDates =
+    range.startDate === range.endDate ? undefined : sortedDays;
+
+  return sortedDays.map<Vacancy>((d) => ({
+    id: `VAC-${Math.random().toString(36).slice(2, 7).toUpperCase()}`,
+    reason: range.reason,
+    classification: range.classification,
+    wing: range.wing,
+    shiftDate: d,
+    shiftStart:
+      range.perDayTimes?.[d]?.start ?? range.shiftStart ?? "06:30",
+    shiftEnd: range.perDayTimes?.[d]?.end ?? range.shiftEnd ?? "14:30",
+    knownAt: nowISO,
+    offeringTier: "CASUALS",
+    offeringRoundStartedAt: nowISO,
+    offeringRoundMinutes: 120,
+    offeringAutoProgress: true,
+    offeringStep: range.offeringStep ?? "Casuals",
+    status: "Open",
+    startDate: range.startDate,
+    endDate: range.endDate,
+    ...(coverageDates ? { coverageDates } : {}),
+  }));
+}
+
+export default expandRangeToVacancies;
+

--- a/tests/expandRangeToVacancies.test.ts
+++ b/tests/expandRangeToVacancies.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { expandRangeToVacancies } from "../src/lib/expandRange";
+import type { VacancyRange } from "../src/types";
+
+describe("expandRangeToVacancies", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("creates vacancies for each working day with overrides", () => {
+    const range: VacancyRange = {
+      id: "r1",
+      reason: "Backfill",
+      classification: "RCA",
+      wing: "Rosewood",
+      startDate: "2025-01-10",
+      endDate: "2025-01-12",
+      knownAt: "2025-01-01T00:00:00Z",
+      workingDays: ["2025-01-12", "2025-01-10"],
+      perDayTimes: {
+        "2025-01-12": { start: "07:00", end: "15:00" },
+      },
+      shiftStart: "06:30",
+      shiftEnd: "14:30",
+      offeringStep: "Casuals",
+      status: "Open",
+    };
+
+    const vxs = expandRangeToVacancies(range);
+    expect(vxs).toHaveLength(2);
+    expect(vxs.map((v) => v.shiftDate)).toEqual([
+      "2025-01-10",
+      "2025-01-12",
+    ]);
+    expect(vxs[0].shiftStart).toBe("06:30");
+    expect(vxs[1].shiftStart).toBe("07:00");
+    expect(vxs[1].shiftEnd).toBe("15:00");
+    expect(vxs[0].startDate).toBe("2025-01-10");
+    expect(vxs[0].endDate).toBe("2025-01-12");
+    expect(vxs[0].coverageDates).toEqual([
+      "2025-01-10",
+      "2025-01-12",
+    ]);
+    expect(vxs.every((v) => v.status === "Open")).toBe(true);
+    expect(vxs.every((v) => v.offeringStep === "Casuals")).toBe(true);
+    expect(vxs.every((v) => v.knownAt === "2025-01-01T00:00:00.000Z")).toBe(
+      true,
+    );
+  });
+
+  it("omits coverageDates for single-day ranges", () => {
+    const range: VacancyRange = {
+      id: "r2",
+      reason: "Backfill",
+      classification: "RCA",
+      wing: "Rosewood",
+      startDate: "2025-01-10",
+      endDate: "2025-01-10",
+      knownAt: "2025-01-01T00:00:00Z",
+      workingDays: ["2025-01-10"],
+      shiftStart: "06:30",
+      shiftEnd: "14:30",
+      offeringStep: "Casuals",
+      status: "Open",
+    };
+
+    const vxs = expandRangeToVacancies(range);
+    expect(vxs).toHaveLength(1);
+    expect(vxs[0].coverageDates).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `expandRangeToVacancies` utility to convert `VacancyRange` into normal `Vacancy` entries
- wire up `handleSaveRange` to use the new utility when saving range selections
- add unit test coverage for expanding ranges into per-day vacancies

## Testing
- `npx vitest run` *(fails: Failed to load agreement: Invalid PDF structure, other existing test failures)*
- `npx vitest run tests/expandRangeToVacancies.test.ts`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab9d86d083279dc16daaf202e22f