### PR TITLE
Reset coverage selections when date range changes and show coverage chip

### DIFF
--- a/src/components/OpenVacancies.tsx
+++ b/src/components/OpenVacancies.tsx
@@ -3,7 +3,7 @@ import type { Vacancy } from "../types";
 import ConfirmDialog from "./ui/ConfirmDialog";
 import Toast from "./ui/Toast";
 import { TrashIcon } from "./ui/Icon";
-import { getVacancyActiveDates } from "../lib/vacancy";
+import CoverageChip from "./ui/CoverageChip";
 
 interface Props {
   vacancies: Vacancy[];
@@ -135,17 +135,11 @@ export default function OpenVacancies({
                       ? `${v.startDate}–${v.endDate}`
                       : v.shiftDate}
                   </span>
-                  {v.startDate && v.endDate && v.startDate !== v.endDate && (
-                    <span className="pill" data-testid="coverage-chip">
-                      {(() => {
-                        const active = getVacancyActiveDates(v).length;
-                        const full = getVacancyActiveDates({ ...v, coverageDates: undefined }).length;
-                        return active === full
-                          ? "Coverage: all days"
-                          : `Coverage: ${active} days`;
-                      })()}
-                    </span>
-                  )}
+                  <CoverageChip
+                    startDate={v.startDate}
+                    endDate={v.endDate}
+                    coverageDates={v.coverageDates}
+                  />
                 </div>
               </td>
               <td>


### PR DESCRIPTION
## Summary
- reset coverage day selections and per-day overrides when date range changes
- keep per-day overrides in sync with selected days and presets
- display coverage summary chip in open vacancies list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b8ad26ec1883278ff90fded347f2ef