### PR TITLE
Add bundleId for multi-day vacancies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ export type Vacation = {
 export type Vacancy = {
   id: string;
   vacationId?: string;
+  bundleId?: string;
   reason: string; // e.g. Vacation Backfill
   classification: Classification;
   wing?: string;

--- a/src/lib/expandRange.ts
+++ b/src/lib/expandRange.ts
@@ -9,9 +9,14 @@ export function expandRangeToVacancies(range: VacancyRange): Vacancy[] {
   const sortedDays = [...range.workingDays].sort();
   const coverageDates =
     range.startDate === range.endDate ? undefined : sortedDays;
+  const bundleId =
+    sortedDays.length > 1
+      ? `BND-${Math.random().toString(36).slice(2, 7).toUpperCase()}`
+      : undefined;
 
   return sortedDays.map<Vacancy>((d) => ({
     id: `VAC-${Math.random().toString(36).slice(2, 7).toUpperCase()}`,
+    ...(bundleId ? { bundleId } : {}),
     reason: range.reason,
     classification: range.classification,
     wing: range.wing,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type Vacation = {
 export type Vacancy = {
   id: string;
   vacationId?: string;
+  bundleId?: string;
   reason: string;
   classification: Classification;
   wing?: string;


### PR DESCRIPTION
## Summary
- support bundling of non-vacation multi-day vacancies with shared `bundleId`
- maintain existing vacation bundling via `vacationId`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck -- --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b8b288e8f08327a4d9231c2a5048b6