### PR TITLE
feat: enable coverage day overrides in range form

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,8 @@ export type VacancyRange = {
 
   // Optional per-day time overrides (when some days have different times)
   perDayTimes?: Record<string, { start: string; end: string }>;
+  // Optional per-day wing overrides
+  perDayWings?: Record<string, string>;
   shiftStart?: string;
   shiftEnd?: string;
 


### PR DESCRIPTION
## Summary
- show `Edit coverage days` for multi-day ranges
- allow per-day time and wing overrides in coverage modal
- track per-day wing overrides in vacancy range type

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b8ba47d5b8832781f28b5f8b9509bc