### PR TITLE
feat: add expandable bundle row component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import BulkAwardDialog from "./components/BulkAwardDialog";
 import { TrashIcon } from "./components/ui/Icon";
 import VacancyRangeForm from "./components/VacancyRangeForm";
 import BundleRow from "./components/BundleRow";
+import CoverageDaysModal from "./components/CoverageDaysModal";
 import { appConfig } from "./config";
 import type { VacancyRange } from "./types";
 import { expandRangeToVacancies } from "./lib/expandRange";
@@ -328,6 +329,7 @@ export default function App() {
   const [filterStart, setFilterStart] = useState<string>("");
   const [filterEnd, setFilterEnd] = useState<string>("");
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const [editingBundle, setEditingBundle] = useState<Vacancy[] | null>(null);
 
   // Tick for countdowns
   const [now, setNow] = useState<number>(Date.now());


### PR DESCRIPTION
## Summary
- replace BundleRow with expandable version that lists child dates, provides edit/split/delete actions, and computes countdown from first day
- prep App for bundle editing by importing CoverageDaysModal and tracking editing state

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8bd0e6a20832799a1634a3412402a