### PR TITLE
Handle bundle-wide bid and award actions

### DIFF
--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -9,8 +9,8 @@ interface Props {
   settings: Settings;
   selectedIds: string[];
   onToggleSelectMany: (ids: string[]) => void;
-  onEdit: (items: Vacancy[]) => void;
-  onSplit: (ids: string[]) => void;
+  onEdit?: (items: Vacancy[]) => void;
+  onSplit?: (ids: string[]) => void;
   onDeleteMany: (ids: string[]) => void;
   dueNextId: string | null;
 }
@@ -105,12 +105,16 @@ export default function BundleRow({
           </div>
         </td>
         <td colSpan={2} style={{ textAlign: "right", whiteSpace: "nowrap" }}>
-          <button className="btn btn-sm" onClick={() => onEdit(items)}>
-            Edit
-          </button>
-          <button className="btn btn-sm" onClick={() => onSplit(childIds)}>
-            Split
-          </button>
+          {onEdit && (
+            <button className="btn btn-sm" onClick={() => onEdit(items)}>
+              Edit
+            </button>
+          )}
+          {onSplit && (
+            <button className="btn btn-sm" onClick={() => onSplit(childIds)}>
+              Split
+            </button>
+          )}
           <button
             className="btn btn-sm danger"
             onClick={() => onDeleteMany(childIds)}


### PR DESCRIPTION
## Summary
- Award bundled vacancies in one step with eligibility checks and bid coverage verification
- Expand manual bid entry to apply to all vacancies in a bundle
- Make bundle row edit/split controls optional

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: Invalid PDF structure & other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bf26cce48327b7617aba41c71119