### PR TITLE
fix: clear employee search when vacancy resets

### DIFF
--- a/src/components/VacancyRow.js
+++ b/src/components/VacancyRow.js
@@ -1,5 +1,5 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { formatDateLong, formatDowShort } from "../lib/dates";
 import { OVERRIDE_REASONS } from "../types";
 import { matchText } from "../lib/text";
@@ -31,6 +31,10 @@ export default function VacancyRow({ v, recId, recName, recWhy, employees, selec
 function SelectEmployee({ employees, value, onChange, allowEmpty = false, }) {
     const [open, setOpen] = useState(false);
     const [q, setQ] = useState("");
+    useEffect(() => {
+        if (!value)
+            setQ("");
+    }, [value]);
     const list = employees
         .filter((e) => matchText(q, `${e.firstName} ${e.lastName} ${e.id}`))
         .slice(0, 50);

--- a/src/components/VacancyRow.tsx
+++ b/src/components/VacancyRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { formatDateLong, formatDowShort } from "../lib/dates";
 import type { Vacancy, Employee } from "../types";
 import { OVERRIDE_REASONS } from "../types";
@@ -162,6 +162,9 @@ function SelectEmployee({
 }) {
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState("");
+  useEffect(() => {
+    if (!value) setQ("");
+  }, [value]);
   const list = employees
     .filter((e) => matchText(q, `${e.firstName} ${e.lastName} ${e.id}`))
     .slice(0, 50);


### PR DESCRIPTION
## Summary
- reset employee dropdown query when its value is cleared to avoid stale names

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: ReferenceError: DOMMatrix is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c4653af483278f1459607cf18164