### PR TITLE
feat: add calendar coverage day picker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1078,7 +1078,10 @@ export default function App() {
                     <button
                       type="button"
                       className="btn btn-sm"
-                      onClick={() => setCoverageOpen(true)}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setCoverageOpen(true);
+                      }}
                     >
                       Edit coverage days
                     </button>
@@ -1453,11 +1456,11 @@ export default function App() {
         {coverageOpen && (
           <CoverageDaysModal
             open={coverageOpen}
-            startDate={newVacay.startDate ?? ""}
-            endDate={newVacay.endDate ?? ""}
+            startDate={newVacay.startDate!}
+            endDate={newVacay.endDate!}
             defaultStart={newVacay.shiftStart ?? defaultShift.start}
             defaultEnd={newVacay.shiftEnd ?? defaultShift.end}
-            classification={newVacay.classification ?? ""}
+            classification={newVacay.classification!}
             initial={coverage ?? undefined}
             onSave={(payload) => {
               setCoverage(payload);

--- a/src/components/CoverageDaysModal.tsx
+++ b/src/components/CoverageDaysModal.tsx
@@ -3,11 +3,11 @@ import React, { useMemo, useState } from "react";
 type Times = { start: string; end: string };
 type Props = {
   open: boolean;
-  startDate: string;
-  endDate: string;
-  defaultStart: string;
-  defaultEnd: string;
-  classification: string;
+  startDate: string; // YYYY-MM-DD
+  endDate: string;   // YYYY-MM-DD
+  defaultStart: string; // HH:mm
+  defaultEnd: string;   // HH:mm
+  classification: string; // display only (locked)
   initial?: {
     selectedDates?: string[];
     perDayTimes?: Record<string, Times>;
@@ -21,79 +21,118 @@ type Props = {
   onClose: () => void;
 };
 
-function isoDatesInclusive(a: string, b: string): string[] {
-  const out: string[] = [];
-  const start = new Date(a + "T00:00:00");
-  const end = new Date(b + "T00:00:00");
-  for (let d = new Date(start); d.getTime() <= end.getTime(); d.setDate(d.getDate() + 1)) {
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    out.push(`${y}-${m}-${day}`);
-  }
-  return out;
+function addDaysISO(iso: string, n: number) {
+  const d = new Date(iso + "T00:00:00");
+  d.setDate(d.getDate() + n);
+  return d.toISOString().slice(0,10);
 }
-
+function startOfWeekISO(iso: string) {
+  const d = new Date(iso + "T00:00:00");
+  const day = d.getDay(); // 0 Sun..6 Sat
+  d.setDate(d.getDate() - ((day + 6) % 7)); // make Monday start; for Sunday-start use 'day'
+  return d.toISOString().slice(0,10);
+}
+function endOfWeekISO(iso: string) {
+  const start = new Date(startOfWeekISO(iso) + "T00:00:00");
+  start.setDate(start.getDate() + 6);
+  return start.toISOString().slice(0,10);
+}
 function formatShort(iso: string) {
   const d = new Date(iso + "T00:00:00");
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", weekday: "short" });
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
+function weekdayLabel(i: number) { return ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"][i]; }
 
 export default function CoverageDaysModal({
-  open,
-  startDate,
-  endDate,
-  defaultStart,
-  defaultEnd,
-  classification,
-  initial,
-  onSave,
-  onClose,
+  open, startDate, endDate, defaultStart, defaultEnd, classification, initial, onSave, onClose
 }: Props) {
-  const allDates = useMemo(() => isoDatesInclusive(startDate, endDate), [startDate, endDate]);
-  const [selected, setSelected] = useState<Record<string, boolean>>(() => {
-    const init = Object.fromEntries(allDates.map((d) => [d, true]));
-    if (initial?.selectedDates?.length) {
-      allDates.forEach((d) => {
-        init[d] = initial.selectedDates!.includes(d);
-      });
-    }
-    return init;
-  });
-  const [perDayTimes, setPerDayTimes] = useState<Record<string, Times>>(() => {
-    const init: Record<string, Times> = {};
-    allDates.forEach((d) => {
-      init[d] = initial?.perDayTimes?.[d] ?? { start: defaultStart, end: defaultEnd };
-    });
-    return init;
-  });
-  const [perDayWing, setPerDayWing] = useState<Record<string, string>>(() => {
-    const init: Record<string, string> = {};
-    allDates.forEach((d) => {
-      init[d] = initial?.perDayWing?.[d] ?? "";
-    });
-    return init;
-  });
-
   if (!open) return null;
 
-  const applyFourOnTwoOff = () => {
-    const next: Record<string, boolean> = {};
-    let onCount = 0;
-    for (let i = 0; i < allDates.length; i++) {
-      const d = allDates[i];
-      next[d] = onCount < 4;
-      onCount = (onCount + 1) % 6;
+  // Build a week-grid (calendar) that fully covers the range
+  const grid = useMemo(() => {
+    const start = startOfWeekISO(startDate);
+    const end   = endOfWeekISO(endDate);
+    const days: string[] = [];
+    for (let d = start; d <= end; d = addDaysISO(d, 1)) days.push(d);
+    // chunk into weeks of 7
+    const weeks: string[][] = [];
+    for (let i = 0; i < days.length; i += 7) weeks.push(days.slice(i, i+7));
+    return weeks;
+  }, [startDate, endDate]);
+
+  // All in-range dates
+  const inRangeSet = useMemo(() => {
+    const set = new Set<string>();
+    for (let d = startDate; d <= endDate; d = addDaysISO(d, 1)) set.add(d);
+    return set;
+  }, [startDate, endDate]);
+
+  // Selection + overrides
+  const [selected, setSelected] = useState<Record<string, boolean>>(() => {
+    // default: all in range selected
+    const seed: Record<string, boolean> = {};
+    grid.flat().forEach(d => { seed[d] = inRangeSet.has(d) ? true : false; });
+    if (initial?.selectedDates?.length) {
+      const chosen = new Set(initial.selectedDates);
+      grid.flat().forEach(d => { seed[d] = chosen.has(d); });
     }
-    setSelected(next);
+    return seed;
+  });
+
+  const [perDayTimes, setPerDayTimes] = useState<Record<string, Times>>(() => {
+    const t: Record<string, Times> = {};
+    grid.flat().forEach(d => {
+      t[d] = initial?.perDayTimes?.[d] ?? { start: defaultStart, end: defaultEnd };
+    });
+    return t;
+  });
+
+  const [perDayWing, setPerDayWing] = useState<Record<string, string>>(() => {
+    const w: Record<string, string> = {};
+    grid.flat().forEach(d => { w[d] = initial?.perDayWing?.[d] ?? ""; });
+    return w;
+  });
+
+  const toggle = (d: string) => {
+    if (!inRangeSet.has(d)) return;
+    setSelected(s => ({ ...s, [d]: !s[d] }));
+  };
+
+  const selectAll = () => {
+    setSelected(s => {
+      const next = { ...s };
+      grid.flat().forEach(d => { if (inRangeSet.has(d)) next[d] = true; });
+      return next;
+    });
+  };
+  const selectNone = () => {
+    setSelected(s => {
+      const next = { ...s };
+      grid.flat().forEach(d => { if (inRangeSet.has(d)) next[d] = false; });
+      return next;
+    });
+  };
+  const applyFourOnTwoOff = () => {
+    let onCount = 0;
+    setSelected(s => {
+      const next = { ...s };
+      // cadence across the in-range days in chronological order
+      const seq: string[] = [];
+      for (let d = startDate; d <= endDate; d = addDaysISO(d, 1)) seq.push(d);
+      seq.forEach(d => {
+        next[d] = onCount < 4;
+        onCount = (onCount + 1) % 6;
+      });
+      return next;
+    });
   };
 
   const save = () => {
-    const chosen = allDates.filter((d) => selected[d]);
+    const chosen = grid.flat().filter(d => selected[d] && inRangeSet.has(d));
     onSave({
       selectedDates: chosen,
-      perDayTimes: Object.fromEntries(chosen.map((d) => [d, perDayTimes[d]])),
-      perDayWing: Object.fromEntries(chosen.map((d) => [d, perDayWing[d] ?? ""])),
+      perDayTimes: Object.fromEntries(chosen.map(d => [d, perDayTimes[d]])),
+      perDayWing:  Object.fromEntries(chosen.map(d => [d, perDayWing[d] ?? ""])),
     });
   };
 
@@ -101,93 +140,49 @@ export default function CoverageDaysModal({
     <div className="modal-overlay" role="dialog" aria-modal="true">
       <div className="modal">
         <div className="modal-h">Coverage days • Class: {classification}</div>
-        <div className="modal-c" style={{ maxHeight: 420, overflow: "auto" }}>
-          <div style={{ display: "flex", gap: 8, marginBottom: 8 }}>
-            <button
-              className="btn btn-sm"
-              onClick={() =>
-                setSelected(Object.fromEntries(allDates.map((d) => [d, true])))
-              }
-            >
-              All
-            </button>
-            <button
-              className="btn btn-sm"
-              onClick={() =>
-                setSelected(Object.fromEntries(allDates.map((d) => [d, false])))
-              }
-            >
-              None
-            </button>
-            <button className="btn btn-sm" onClick={applyFourOnTwoOff}>
-              4-on / 2-off
-            </button>
-            <span style={{ fontSize: 12, opacity: 0.7, marginLeft: 6 }}>
-              Toggle dates; times & wing per day are optional.
-            </span>
-          </div>
 
-          {allDates.map((d) => (
-            <div
-              key={d}
-              className="row"
-              style={{
-                display: "grid",
-                gridTemplateColumns: "auto 1fr auto auto auto",
-                gap: 8,
-                alignItems: "center",
-                padding: "4px 0",
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={!!selected[d]}
-                onChange={(e) =>
-                  setSelected((s) => ({ ...s, [d]: e.target.checked }))
-                }
-                aria-label={`Include ${d}`}
-              />
-              <div style={{ minWidth: 160 }}>{formatShort(d)}</div>
-              <input
-                type="time"
-                value={perDayTimes[d].start}
-                onChange={(e) =>
-                  setPerDayTimes((t) => ({
-                    ...t,
-                    [d]: { ...t[d], start: e.target.value },
-                  }))
-                }
-              />
-              <input
-                type="time"
-                value={perDayTimes[d].end}
-                onChange={(e) =>
-                  setPerDayTimes((t) => ({
-                    ...t,
-                    [d]: { ...t[d], end: e.target.value },
-                  }))
-                }
-              />
-              <input
-                placeholder="Wing (optional)"
-                value={perDayWing[d] ?? ""}
-                onChange={(e) =>
-                  setPerDayWing((w) => ({ ...w, [d]: e.target.value }))
-                }
-              />
+        <div style={{ display:"flex", gap:8, marginBottom:8 }}>
+          <button className="btn btn-sm" onClick={selectAll}>All</button>
+          <button className="btn btn-sm" onClick={selectNone}>None</button>
+          <button className="btn btn-sm" onClick={applyFourOnTwoOff}>4-on / 2-off</button>
+        </div>
+
+        <div className="calendar">
+          {/* Weekday headers */}
+          {["Mon","Tue","Wed","Thu","Fri","Sat","Sun"].map((h) => (
+            <div key={h} className="cal-head">{h}</div>
+          ))}
+          {/* Weeks */}
+          {grid.map((week, wi) => week.map((d, di) => {
+            const disabled = !inRangeSet.has(d);
+            const isSel = !!selected[d] && !disabled;
+            return (
+              <div
+                key={`${wi}-${di}`}
+                className={`day ${isSel ? "selected" : ""} ${disabled ? "disabled" : ""}`}
+                onClick={() => toggle(d)}
+              >
+                <div className="day-label">{formatShort(d)}</div>
+              </div>
+            );
+          }))}
+        </div>
+
+        {/* Per-day overrides (only selected days) */}
+        <div style={{ marginTop: 12, maxHeight: 220, overflow: "auto" }}>
+          {grid.flat().filter(d => selected[d] && inRangeSet.has(d)).map(d => (
+            <div key={`ovr-${d}`} className="row" style={{ display:"grid", gridTemplateColumns:"160px 100px 100px 1fr", gap:8, alignItems:"center", padding:"4px 0" }}>
+              <div>{formatShort(d)}</div>
+              <input type="time" value={perDayTimes[d].start} onChange={(e) => setPerDayTimes(t => ({ ...t, [d]: { ...t[d], start: e.target.value } }))} />
+              <input type="time" value={perDayTimes[d].end}   onChange={(e) => setPerDayTimes(t => ({ ...t, [d]: { ...t[d], end: e.target.value } }))} />
+              <input placeholder="Wing (optional)" value={perDayWing[d] ?? ""} onChange={(e) => setPerDayWing(w => ({ ...w, [d]: e.target.value }))} />
             </div>
           ))}
         </div>
-        <div
-          className="modal-f"
-          style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}
-        >
-          <button className="btn" onClick={onClose}>
-            Cancel
-          </button>
-          <button className="btn primary" onClick={save}>
-            Save
-          </button>
+
+        <div className="modal-f" style={{ display:"flex", justifyContent:"flex-end", gap:8, marginTop:12 }}>
+          <button className="btn" onClick={onClose}>Cancel</button>
+          <button className="btn primary" onClick={save}>Save</button>
         </div>
       </div>
     </div>

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -120,3 +120,15 @@
   background: var(--brand);
   border-color: var(--brand);
 }
+
+.modal-overlay{ position:fixed; inset:0; background:rgba(0,0,0,.4); z-index:9999; display:flex; align-items:flex-start; justify-content:center; padding-top:5vh;}
+.modal{ background:#fff; border-radius:12px; box-shadow:0 10px 30px rgba(0,0,0,.25); width:min(800px, 95vw); padding:16px;}
+.modal-h{ font-weight:600; margin-bottom:8px; }
+.calendar{ display:grid; grid-template-columns: repeat(7, 1fr); gap:6px; user-select:none; margin-bottom:8px;}
+.cal-head{ font-size:12px; opacity:.7; text-align:center; }
+.day{ border:1px solid #ddd; border-radius:8px; padding:8px; text-align:center; cursor:pointer; background:#fafafa; }
+.day.selected{ outline:2px solid #333; background:#fff; }
+.day.disabled{ opacity:.35; pointer-events:none; }
+.btn{ cursor:pointer; }
+.btn.btn-sm{ padding:4px 8px; font-size:12px; }
+.btn.primary{ background:#0b5; color:#fff; border:none; }


### PR DESCRIPTION
## Summary
- add calendar-style CoverageDaysModal for selecting coverage days, times, and wings
- wire Add Vacation form to open modal and respect chosen days when generating vacancies
- style modal with basic overlay and button styles

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9cf839ec88327b951497fe52efbff