### PR TITLE
feat: award bundles without prior bids

### DIFF
--- a/src/components/VacancyList.tsx
+++ b/src/components/VacancyList.tsx
@@ -21,7 +21,15 @@ interface Props {
   settings: Settings;
   now: number;
   dueNextId: string | null;
-  awardVacancy: (id: string, payload: { empId?: string; reason?: string; overrideUsed?: boolean }) => void;
+  awardVacancy: (
+    id: string,
+    payload: {
+      empId?: string;
+      reason?: string;
+      overrideUsed?: boolean;
+      skipConflictCheck?: boolean;
+    },
+  ) => void;
   resetKnownAt: (id: string) => void;
   setBids?: (u: any) => void;
   bids?: any[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,10 @@ export type Bid = {
   coverageType?: "full" | "some-days" | "partial-day";
   selectedDays?: string[]; // ISO dates if not full
   timeOverrides?: Record<string, { start: string; end: string }>;
+  id?: string;
+  employeeId?: string;
+  createdAt?: string;
+  source?: string;
 };
 
 export type Settings = {


### PR DESCRIPTION
## Summary
- create missing bids when awarding a bundle and mark them admin-generated
- add bundle-award helper with classification and conflict checks
- allow awardVacancy to skip conflict checking for bundle awards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9e008ae0c832783ad45f5e18af925