### PR TITLE
feat: add shared row cells components and styles

### DIFF
--- a/src/components/rows/RowCells.tsx
+++ b/src/components/rows/RowCells.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import type { Vacancy, Settings } from "../../types";
+import { deadlineFor, pickWindowMinutes, fmtCountdown } from "../../lib/vacancy";
+import { minutesBetween } from "../../lib/dates";
+
+export function CellSelect({ checked, onChange }: { checked: boolean; onChange: (checked: boolean) => void; }) {
+  return (
+    <td className="cell-select">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+    </td>
+  );
+}
+
+export function CellDetails({ children }: { children: ReactNode }) {
+  return (
+    <td>
+      <div className="cell-details__wrap">{children}</div>
+    </td>
+  );
+}
+
+type CountdownProps = {
+  vacancy: Vacancy;
+  settings: Settings;
+  now: number;
+};
+
+export function CellCountdown({ vacancy, settings, now }: CountdownProps) {
+  const msLeft = deadlineFor(vacancy, settings).getTime() - now;
+  const winMin = pickWindowMinutes(vacancy, settings);
+  const sinceKnownMin = minutesBetween(new Date(), new Date(vacancy.knownAt));
+  const pct = Math.max(0, Math.min(1, (winMin - sinceKnownMin) / winMin));
+  let cdClass = "cd-green";
+  if (msLeft <= 0) cdClass = "cd-red";
+  else if (pct < 0.25) cdClass = "cd-yellow";
+
+  return (
+    <td className="cell-countdown">
+      <span className={`countdown ${cdClass}`}>{fmtCountdown(msLeft)}</span>
+    </td>
+  );
+}
+
+export function CellActions({ children }: { children: ReactNode }) {
+  return <td className="cell-actions">{children}</td>;
+}
+

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -132,3 +132,47 @@
 .btn{ cursor:pointer; }
 .btn.btn-sm{ padding:4px 8px; font-size:12px; }
 .btn.primary{ background:#0b5; color:#fff; border:none; }
+
+/* vacancy row shared cells */
+.cell-select {
+  width: 40px;
+}
+
+.cell-details__wrap {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.cell-countdown {
+  text-align: right;
+}
+
+.cell-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.countdown {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--stroke);
+  font-weight: 700;
+}
+
+.cd-green {
+  background: rgba(22,163,74,.12);
+}
+
+.cd-yellow {
+  background: rgba(245,158,11,.12);
+}
+
+.cd-red {
+  background: rgba(239,68,68,.12);
+}
+


### PR DESCRIPTION
## Summary
- add `CellSelect`, `CellDetails`, `CellCountdown`, and `CellActions` components for vacancy rows
- style shared cells and countdown indicators in `responsive.css`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fa9438a48327bf4ad173431ea18f