### PR TITLE
Refactor vacancy row to use shared cell components

### DIFF
--- a/src/components/VacancyList.tsx
+++ b/src/components/VacancyList.tsx
@@ -3,7 +3,7 @@ import type { Vacancy, Employee, Settings } from "../types";
 import VacancyRow from "./VacancyRow";
 import { useVacancyFilters } from "../hooks/useVacancyFilters";
 import { WINGS, SHIFT_PRESETS } from "../types";
-import { deadlineFor, pickWindowMinutes, fmtCountdown, archiveBidsForVacancy } from "../lib/vacancy";
+import { deadlineFor, pickWindowMinutes } from "../lib/vacancy";
 import { minutesBetween } from "../lib/dates";
 
 export interface Recommendation {
@@ -212,14 +212,6 @@ export default function VacancyList({
                 ? `${employeesById[recId]?.firstName ?? ""} ${employeesById[recId]?.lastName ?? ""}`.trim()
                 : "—";
               const recWhy = rec?.why ?? [];
-              const dl = deadlineFor(v, settings);
-              const msLeft = dl.getTime() - now;
-              const winMin = pickWindowMinutes(v, settings);
-              const sinceKnownMin = minutesBetween(new Date(), new Date(v.knownAt));
-              const pct = Math.max(0, Math.min(1, (winMin - sinceKnownMin) / winMin));
-              let cdClass = "cd-green";
-              if (msLeft <= 0) cdClass = "cd-red";
-              else if (pct < 0.25) cdClass = "cd-yellow";
               const isDueNext = dueNextId === v.id;
               return (
                 <VacancyRow
@@ -237,12 +229,12 @@ export default function VacancyList({
                         : [...ids, v.id],
                     )
                   }
-                  countdownLabel={fmtCountdown(msLeft)}
-                  countdownClass={cdClass}
                   isDueNext={!!isDueNext}
                   onAward={(payload) => awardVacancy(v.id, payload)}
                   onResetKnownAt={() => resetKnownAt(v.id)}
                   onDelete={deleteVacancy}
+                  settings={settings}
+                  now={now}
                 />
               );
             })}

--- a/src/components/VacancyRow.tsx
+++ b/src/components/VacancyRow.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { formatDateLong, formatDowShort } from "../lib/dates";
-import type { Vacancy, Employee } from "../types";
+import type { Vacancy, Employee, Settings } from "../types";
 import { OVERRIDE_REASONS } from "../types";
 import { matchText } from "../lib/text";
 import CoverageChip from "./ui/CoverageChip";
 import { TrashIcon } from "./ui/Icon";
+import { CellSelect, CellDetails, CellCountdown, CellActions } from "./rows/RowCells";
 
 export default function VacancyRow({
   v,
@@ -14,13 +15,13 @@ export default function VacancyRow({
   employees,
   selected,
   onToggleSelect,
-  countdownLabel,
-  countdownClass,
   isDueNext,
   onAward,
   onResetKnownAt,
   onDelete,
   coveredName,
+  settings,
+  now,
 }: {
   v: Vacancy;
   recId?: string;
@@ -29,13 +30,13 @@ export default function VacancyRow({
   employees: Employee[];
   selected: boolean;
   onToggleSelect: () => void;
-  countdownLabel: string;
-  countdownClass: string;
   isDueNext: boolean;
   onAward: (payload: { empId?: string; reason?: string; overrideUsed?: boolean }) => void;
   onResetKnownAt: () => void;
   onDelete: (id: string) => void;
   coveredName?: string;
+  settings: Settings;
+  now: number;
 }) {
   const [choice, setChoice] = useState<string>("");
   const [overrideClass, setOverrideClass] = useState<boolean>(false);
@@ -62,9 +63,7 @@ export default function VacancyRow({
 
   return (
     <tr className={`${isDueNext ? "due-next " : ""}${selected ? "selected" : ""}`.trim()} aria-selected={selected} tabIndex={0}>
-      <td>
-        <input type="checkbox" checked={selected} onChange={onToggleSelect} />
-      </td>
+      <CellSelect checked={selected} onChange={() => onToggleSelect()} />
       <td>
         <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
           <span>
@@ -82,19 +81,16 @@ export default function VacancyRow({
       <td>{v.wing ?? ""}</td>
       <td>{v.classification}</td>
       <td>{v.offeringStep}</td>
-      <td>
-        <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: 4 }}>
-          <span>{recName}</span>
-          {recWhy.map((w, i) => (
-            <span key={i} className="pill">
-              {w}
-            </span>
-          ))}
-        </div>
-      </td>
-      <td>
-        <span className={`cd-chip ${countdownClass}`}>{countdownLabel}</span>
-      </td>
+      <CellDetails
+        rightTag={recWhy.map((w, i) => (
+          <span key={i} className="pill">
+            {w}
+          </span>
+        ))}
+      >
+        <span>{recName}</span>
+      </CellDetails>
+      <CellCountdown vacancy={v} settings={settings} now={now} />
       <td style={{ minWidth: 220 }}>
         <SelectEmployee allowEmpty employees={employees} value={choice} onChange={setChoice} />
       </td>
@@ -124,14 +120,14 @@ export default function VacancyRow({
           <span className="subtitle">—</span>
         )}
       </td>
-      <td style={{ display: "flex", gap: 6 }}>
+      <CellActions>
         <button className="btn" onClick={onResetKnownAt}>
           Reset timer
         </button>
         <button className="btn" onClick={handleAward} disabled={!choice}>
           Award
         </button>
-      </td>
+      </CellActions>
       <td>
         <button
           className="btn btn-sm"

--- a/src/components/rows/RowCells.tsx
+++ b/src/components/rows/RowCells.tsx
@@ -15,10 +15,19 @@ export function CellSelect({ checked, onChange }: { checked: boolean; onChange: 
   );
 }
 
-export function CellDetails({ children }: { children: ReactNode }) {
+export function CellDetails({
+  children,
+  rightTag,
+}: {
+  children: ReactNode;
+  rightTag?: ReactNode;
+}) {
   return (
     <td>
-      <div className="cell-details__wrap">{children}</div>
+      <div className="cell-details__wrap">
+        {children}
+        {rightTag}
+      </div>
     </td>
   );
 }

--- a/tests/vacancyRowCoveredName.test.tsx
+++ b/tests/vacancyRowCoveredName.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import VacancyRow from "../src/components/VacancyRow";
-import type { Vacancy, Employee } from "../src/types";
+import type { Vacancy, Employee, Settings } from "../src/types";
 
 describe("VacancyRow", () => {
   it("shows the covered employee name", () => {
@@ -21,6 +21,16 @@ describe("VacancyRow", () => {
       status: "Open",
     };
 
+    const settings: Settings = {
+      responseWindows: {
+        lt2h: 30,
+        h2to4: 60,
+        h4to24: 120,
+        h24to72: 240,
+        gt72: 480,
+      },
+    };
+
     render(
       <table>
         <tbody>
@@ -31,13 +41,13 @@ describe("VacancyRow", () => {
             employees={[] as Employee[]}
             selected={false}
             onToggleSelect={() => {}}
-            countdownLabel="1h"
-            countdownClass="cd-green"
             isDueNext={false}
             onAward={() => {}}
             onResetKnownAt={() => {}}
             onDelete={() => {}}
             coveredName="Jane Doe"
+            settings={settings}
+            now={0}
           />
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
- replace raw `<td>` elements in vacancy row with reusable CellSelect, CellDetails, CellCountdown and CellActions components
- move recommendation pill into `CellDetails.rightTag`
- compute countdown within CellCountdown via settings and now props

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba011b00108327bc4813feb711cdcf