### PR TITLE
Add classification picker for vacant vacancy creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -995,6 +995,24 @@ export default function App() {
                       }}
                     />
                   </div>
+                  {newVacay.employeeId === VACANT_EMPLOYEE_ID && (
+                    <div>
+                      <label>Classification</label>
+                      <select
+                        value={newVacay.classification ?? "RCA"}
+                        onChange={(e) =>
+                          setNewVacay((v) => ({
+                            ...v,
+                            classification: e.target.value as Classification,
+                          }))
+                        }
+                      >
+                        <option value="RCA">RCA</option>
+                        <option value="LPN">LPN</option>
+                        <option value="RN">RN</option>
+                      </select>
+                    </div>
+                  )}
                   <div>
                     <label>Wing / Unit</label>
                     <select


### PR DESCRIPTION
## Summary
- show classification select when creating a vacancy for Vacant/Empty employee

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0698a24c8327ac03244f2d9ec6cb