### PR TITLE
feat: redesign open vacancies list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import VacancyRangeForm from "./components/VacancyRangeForm";
 import BundleRow from "./components/BundleRow";
 import CoverageDaysModal from "./components/CoverageDaysModal";
 import VacancyRow from "./components/VacancyRow";
+import OpenVacanciesRedesign from "./components/OpenVacanciesRedesign";
 import { appConfig } from "./config";
 import type { VacancyRange } from "./types";
 import { expandRangeToVacancies } from "./lib/expandRange";
@@ -1174,6 +1175,30 @@ export default function App() {
             <div className="card">
               <div className="card-h">Open Vacancies</div>
               <div className="card-c">
+                {appConfig.features.vacancyListRedesign ? (
+                  <OpenVacanciesRedesign
+                    vacancies={vacancies}
+                    employees={employees}
+                    settings={settings}
+                    selectedIds={selectedVacancyIds}
+                    dueNextId={dueNextId}
+                    onToggleSelect={(id) =>
+                      setSelectedVacancyIds((ids) =>
+                        ids.includes(id)
+                          ? ids.filter((x) => x !== id)
+                          : [...ids, id],
+                      )
+                    }
+                    onToggleSelectMany={toggleMany}
+                    onDelete={deleteVacancy}
+                    onDeleteMany={stageDeleteMany}
+                    awardVacancy={awardVacancy}
+                    awardBundle={awardBundle}
+                    resetKnownAt={resetKnownAt}
+                    recommendations={recommendations}
+                  />
+                ) : (
+                  <>
                 <div
                   style={{
                     marginBottom: 8,
@@ -1348,31 +1373,30 @@ export default function App() {
                         vacations.find((x) => x.id === v.vacationId)?.employeeName ?? "";
                       const isDueNext = dueNextId === v.id;
 
-                      return (
-                        <VacancyRow
-                          key={v.id}
-                          v={v}
-                          recId={recId}
-                          recName={recName}
-                          recWhy={recWhy}
-                          employees={employees}
-                          selected={selectedVacancyIds.includes(v.id)}
-                          onToggleSelect={() =>
-                            setSelectedVacancyIds((ids) =>
-                              ids.includes(v.id)
-                                ? ids.filter((id) => id !== v.id)
-                                : [...ids, v.id],
-                            )
-                          }
-                          isDueNext={!!isDueNext}
-                          onAward={(payload) => awardVacancy(v.id, payload)}
-                          onResetKnownAt={() => resetKnownAt(v.id)}
-                          onDelete={deleteVacancy}
-                          coveredName={coveredName}
-                          settings={settings}
-                          now={now}
-                        />
-                      );
+                        return (
+                          <VacancyRow
+                            key={v.id}
+                            v={v}
+                            recId={recId}
+                            recName={recName}
+                            recWhy={recWhy}
+                            employees={employees}
+                            selected={selectedVacancyIds.includes(v.id)}
+                            onToggleSelect={() =>
+                              setSelectedVacancyIds((ids) =>
+                                ids.includes(v.id)
+                                  ? ids.filter((id) => id !== v.id)
+                                  : [...ids, v.id],
+                              )
+                            }
+                            isDueNext={!!isDueNext}
+                            awardVacancy={(payload) => awardVacancy(v.id, payload)}
+                            resetKnownAt={() => resetKnownAt(v.id)}
+                            onDelete={deleteVacancy}
+                            coveredName={coveredName}
+                            settings={settings}
+                          />
+                        );
                     })}
                   </tbody>
                 </table>
@@ -1380,6 +1404,8 @@ export default function App() {
                   <div className="subtitle" style={{ marginTop: 8 }}>
                     No open vacancies 🎉
                   </div>
+                )}
+                  </>
                 )}
               </div>
             </div>

--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -3,7 +3,12 @@ import type { Vacancy, Employee, Settings } from "../types";
 import type { Recommendation } from "../recommend";
 import { formatDateLong, combineDateTime } from "../lib/dates";
 import EmployeePickerModal from "./EmployeePickerModal";
-import { CellSelect, CellDetails, CellCountdown, CellActions } from "./rows/RowCells";
+import {
+  CellSelect,
+  CellDetails,
+  CellCountdown,
+  CellActions,
+} from "./rows/RowCells";
 
 type Props = {
   groupId: string;
@@ -45,7 +50,6 @@ export default function BundleRow({
   const toggleAll = () => onToggleSelectMany(childIds);
   const isDueNext = dueNextId ? childIds.includes(dueNextId) : false;
 
-  const now = Date.now();
   const wingText = primary.wing ?? "Wing";
   const title = `${items.length} days • ${wingText} • ${primary.classification}`;
   const dateList = sorted.map((v) => formatDateLong(v.shiftDate)).join(", ");
@@ -72,32 +76,32 @@ export default function BundleRow({
         data-bundle-id={groupId}
         className={`${isDueNext ? "due-next " : ""}${allSelected ? "selected" : ""}`.trim()}
       >
-        <CellSelect checked={allSelected} onChange={toggleAll} />
+        <CellSelect
+          checked={allSelected}
+          onChange={toggleAll}
+          ariaLabel="Select bundle"
+        />
         <CellDetails
-          rightTag={
-            <>
-              {multipleWings && (
-                <span className="pill" title={distinctWings.join(", ")}>
-                  Multiple wings
-                </span>
-              )}
-              {recWhy.map((w, i) => (
-                <span key={i} className="pill">
-                  {w}
-                </span>
-              ))}
-            </>
-          }
-        >
-          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-            <div style={{ fontWeight: 600 }}>{title}</div>
+          title={<div style={{ fontWeight: 600 }}>{title}</div>}
+          subtitle={
             <div
-              className="subtitle"
-              style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                flexWrap: "wrap",
+              }}
             >
-              {dateList}
-            </div>
-            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+              <span
+                className="subtitle"
+                style={{
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {dateList}
+              </span>
               {recId ? (
                 <span
                   className="pill"
@@ -110,9 +114,21 @@ export default function BundleRow({
                 <span className="subtitle">—</span>
               )}
             </div>
-          </div>
-        </CellDetails>
-        <CellCountdown vacancy={primary} settings={settings} now={now} />
+          }
+          rightTag={
+            <>
+              {multipleWings && (
+                <span className="pill" title={distinctWings.join(", ")}>Multiple wings</span>
+              )}
+              {recWhy.map((w, i) => (
+                <span key={i} className="pill">
+                  {w}
+                </span>
+              ))}
+            </>
+          }
+        />
+        <CellCountdown source={primary} settings={settings} />
         <CellActions>
           <button className="btn btn-sm" onClick={() => setOpen((o) => !o)}>
             {open ? "Hide" : "Expand"}

--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -1,0 +1,168 @@
+import React, { useMemo } from "react";
+import type { Vacancy, Employee, Settings } from "../types";
+import type { Recommendation } from "../recommend";
+import BundleRow from "./BundleRow";
+import VacancyRow from "./VacancyRow";
+import { combineDateTime } from "../lib/dates";
+
+type Props = {
+  vacancies: Vacancy[];
+  employees: Employee[];
+  settings: Settings;
+  selectedIds: string[];
+  dueNextId: string | null;
+  onToggleSelect: (id: string) => void;
+  onToggleSelectMany: (ids: string[]) => void;
+  onDelete: (id: string) => void;
+  onDeleteMany: (ids: string[]) => void;
+  awardVacancy: (id: string, payload: any) => void;
+  awardBundle?: (bundleId: string, employeeId: string) => void;
+  onEditCoverage?: (bundleId: string) => void;
+  resetKnownAt: (id: string) => void;
+  filters?: {
+    search?: string;
+    wing?: string;
+    classification?: string;
+    bundlesOnly?: boolean;
+    singlesOnly?: boolean;
+  };
+  recommendations: Record<string, Recommendation>;
+};
+
+export default function OpenVacanciesRedesign(props: Props) {
+  const { vacancies, filters, settings, employees, recommendations } = props;
+  const employeesById = useMemo(() => {
+    const map: Record<string, Employee> = {};
+    employees.forEach((e) => {
+      map[e.id] = e;
+    });
+    return map;
+  }, [employees]);
+  const filtered = useMemo(() => {
+    let list = vacancies.filter(
+      (v) => v.status !== "Filled" && v.status !== "Awarded",
+    );
+    if (filters?.search) {
+      const q = filters.search.toLowerCase();
+      list = list.filter(
+        (v) =>
+          (v.reason || "").toLowerCase().includes(q) ||
+          (v.wing || "").toLowerCase().includes(q),
+      );
+    }
+    if (filters?.wing) list = list.filter((v) => (v.wing || "") === filters!.wing);
+    if (filters?.classification)
+      list = list.filter((v) => v.classification === filters!.classification);
+    if (filters?.bundlesOnly) list = list.filter((v) => v.bundleId);
+    if (filters?.singlesOnly) list = list.filter((v) => !v.bundleId);
+    return list;
+  }, [vacancies, filters]);
+
+  const byDate = useMemo(() => {
+    const m = new Map<string, Vacancy[]>();
+    for (const v of filtered) {
+      const key = v.shiftDate;
+      if (!m.has(key)) m.set(key, []);
+      m.get(key)!.push(v);
+    }
+    for (const [k, arr] of m)
+      arr.sort(
+        (a, b) =>
+          combineDateTime(a.shiftDate, a.shiftStart).getTime() -
+          combineDateTime(b.shiftDate, b.shiftStart).getTime(),
+      );
+    return Array.from(m.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [filtered]);
+
+  const fmtDate = (iso: string) =>
+    new Date(iso + "T00:00:00").toLocaleDateString(undefined, {
+      weekday: "long",
+      month: "short",
+      day: "numeric",
+    });
+
+  return (
+    <div>
+      <table className="vacancies">
+        <thead>
+          <tr>
+            <th style={{ width: 40 }}></th>
+            <th>Open Vacancies</th>
+            <th style={{ width: 140 }}>Time Left</th>
+            <th style={{ width: "1%" }}></th>
+          </tr>
+        </thead>
+        <tbody>
+          {byDate.map(([date, items]) => {
+            const groups = new Map<string, Vacancy[]>();
+            items.forEach((v) => {
+              if (v.bundleId) {
+                const a = groups.get(v.bundleId) || [];
+                a.push(v);
+                groups.set(v.bundleId, a);
+              }
+            });
+            const rendered: React.ReactNode[] = [];
+            for (const [key, arr] of groups) {
+              if (arr.length < 2) continue;
+              rendered.push(
+                <BundleRow
+                  key={`bundle-${key}-${date}`}
+                  groupId={key}
+                  items={arr}
+                  employees={employees}
+                  settings={settings}
+                  recommendations={recommendations}
+                  selectedIds={props.selectedIds}
+                  onToggleSelectMany={props.onToggleSelectMany}
+                  onDeleteMany={props.onDeleteMany}
+                  onSplitBundle={(ids) => console.warn("split bundle", ids)}
+                  onEditCoverage={props.onEditCoverage}
+                  onAwardBundle={(eid) => props.awardBundle?.(key, eid)}
+                  dueNextId={props.dueNextId}
+                />,
+              );
+            }
+            for (const v of items) {
+              const size = v.bundleId ? groups.get(v.bundleId)?.length || 0 : 0;
+              if (size >= 2) continue;
+              const rec = recommendations[v.id];
+              const recId = rec?.id;
+              const recName = recId
+                ? `${employeesById[recId]?.firstName ?? ""} ${
+                    employeesById[recId]?.lastName ?? ""
+                  }`.trim()
+                : "—";
+              const recWhy = rec?.why ?? [];
+              rendered.push(
+                <VacancyRow
+                  key={v.id}
+                  v={v}
+                  recId={recId}
+                  recName={recName}
+                  recWhy={recWhy}
+                  employees={employees}
+                  selected={props.selectedIds.includes(v.id)}
+                  onToggleSelect={() => props.onToggleSelect(v.id)}
+                  awardVacancy={(payload) => props.awardVacancy(v.id, payload)}
+                  resetKnownAt={() => props.resetKnownAt(v.id)}
+                  onDelete={props.onDelete}
+                  isDueNext={props.dueNextId === v.id}
+                  settings={settings}
+                />,
+              );
+            }
+            return (
+              <React.Fragment key={`sec-${date}`}>
+                <tr className="section-h">
+                  <td colSpan={4}>{fmtDate(date)}</td>
+                </tr>
+                {rendered}
+              </React.Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/VacancyList.tsx
+++ b/src/components/VacancyList.tsx
@@ -221,11 +221,10 @@ export default function VacancyList({
                     )
                   }
                   isDueNext={!!isDueNext}
-                  onAward={(payload) => awardVacancy(v.id, payload)}
-                  onResetKnownAt={() => resetKnownAt(v.id)}
+                  awardVacancy={(payload) => awardVacancy(v.id, payload)}
+                  resetKnownAt={() => resetKnownAt(v.id)}
                   onDelete={deleteVacancy}
                   settings={settings}
-                  now={now}
                 />
               );
             })}

--- a/src/components/VacancyRow.tsx
+++ b/src/components/VacancyRow.tsx
@@ -5,7 +5,12 @@ import { OVERRIDE_REASONS } from "../types";
 import { matchText } from "../lib/text";
 import CoverageChip from "./ui/CoverageChip";
 import { TrashIcon } from "./ui/Icon";
-import { CellSelect, CellDetails, CellCountdown, CellActions } from "./rows/RowCells";
+import {
+  CellSelect,
+  CellDetails,
+  CellCountdown,
+  CellActions,
+} from "./rows/RowCells";
 
 export default function VacancyRow({
   v,
@@ -16,12 +21,11 @@ export default function VacancyRow({
   selected,
   onToggleSelect,
   isDueNext,
-  onAward,
-  onResetKnownAt,
+  awardVacancy,
+  resetKnownAt,
   onDelete,
   coveredName,
   settings,
-  now,
 }: {
   v: Vacancy;
   recId?: string;
@@ -31,12 +35,15 @@ export default function VacancyRow({
   selected: boolean;
   onToggleSelect: () => void;
   isDueNext: boolean;
-  onAward: (payload: { empId?: string; reason?: string; overrideUsed?: boolean }) => void;
-  onResetKnownAt: () => void;
+  awardVacancy: (payload: {
+    empId?: string;
+    reason?: string;
+    overrideUsed?: boolean;
+  }) => void;
+  resetKnownAt: () => void;
   onDelete: (id: string) => void;
   coveredName?: string;
   settings: Settings;
-  now: number;
 }) {
   const [choice, setChoice] = useState<string>("");
   const [overrideClass, setOverrideClass] = useState<boolean>(false);
@@ -55,26 +62,37 @@ export default function VacancyRow({
       alert("Please select a reason for this override.");
       return;
     }
-    onAward({ empId: choice || undefined, reason: reason || undefined, overrideUsed: overrideClass });
+    awardVacancy({
+      empId: choice || undefined,
+      reason: reason || undefined,
+      overrideUsed: overrideClass,
+    });
     setChoice("");
     setReason("");
     setOverrideClass(false);
   }
 
   return (
-    <tr className={`${isDueNext ? "due-next " : ""}${selected ? "selected" : ""}`.trim()} aria-selected={selected} tabIndex={0}>
-      <CellSelect checked={selected} onChange={() => onToggleSelect()} />
+    <tr
+      className={`${isDueNext ? "due-next " : ""}${
+        selected ? "selected" : ""
+      }`.trim()}
+      aria-selected={selected}
+      tabIndex={0}
+    >
+      <CellSelect
+        checked={selected}
+        onChange={onToggleSelect}
+        ariaLabel={`Select vacancy ${v.id}`}
+      />
       <CellDetails
-        rightTag={recWhy.map((w, i) => (
-          <span key={i} className="pill">
-            {w}
-          </span>
-        ))}
-      >
-        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        title={
+          <div
+            style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
+          >
             <span>
-              <span className="pill">{formatDowShort(v.shiftDate)}</span> {formatDateLong(v.shiftDate)} • {v.shiftStart}-{v.shiftEnd}
+              <span className="pill">{formatDowShort(v.shiftDate)}</span>{" "}
+              {formatDateLong(v.shiftDate)} • {v.shiftStart}-{v.shiftEnd}
               {coveredName && <> • Covering {coveredName}</>}
             </span>
             <CoverageChip
@@ -84,18 +102,32 @@ export default function VacancyRow({
               variant="compact"
             />
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        }
+        subtitle={
+          <div
+            style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
+          >
             {v.wing && <span className="pill">{v.wing}</span>}
             <span className="pill">{v.classification}</span>
             <span className="pill">{v.offeringStep}</span>
             <span>{recName}</span>
           </div>
-        </div>
-      </CellDetails>
-      <CellCountdown vacancy={v} settings={settings} now={now} />
+        }
+        rightTag={recWhy.map((w, i) => (
+          <span key={i} className="pill">
+            {w}
+          </span>
+        ))}
+      />
+      <CellCountdown source={v} settings={settings} />
       <CellActions>
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          <SelectEmployee allowEmpty employees={employees} value={choice} onChange={setChoice} />
+          <SelectEmployee
+            allowEmpty
+            employees={employees}
+            value={choice}
+            onChange={setChoice}
+          />
           <div style={{ whiteSpace: "nowrap" }}>
             <input
               id={`override-toggle-${v.id}`}
@@ -121,10 +153,14 @@ export default function VacancyRow({
             <span className="subtitle">—</span>
           )}
           <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-            <button className="btn btn-sm" onClick={onResetKnownAt}>
+            <button className="btn btn-sm" onClick={resetKnownAt}>
               Reset timer
             </button>
-            <button className="btn btn-sm" onClick={handleAward} disabled={!choice}>
+            <button
+              className="btn btn-sm"
+              onClick={handleAward}
+              disabled={!choice}
+            >
               Award
             </button>
             <button

--- a/src/components/rows/RowCells.tsx
+++ b/src/components/rows/RowCells.tsx
@@ -1,60 +1,34 @@
-import type { ReactNode } from "react";
+import React from "react";
 import type { Vacancy, Settings } from "../../types";
-import { deadlineFor, pickWindowMinutes, fmtCountdown } from "../../lib/vacancy";
-import { minutesBetween } from "../../lib/dates";
+import { fmtCountdown, deadlineFor, pickWindowMinutes } from "../../lib/vacancy";
+import { combineDateTime, minutesBetween } from "../../lib/dates";
 
-export function CellSelect({ checked, onChange }: { checked: boolean; onChange: (checked: boolean) => void; }) {
-  return (
-    <td className="cell-select">
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-      />
-    </td>
-  );
+export function CellSelect({checked,onChange,ariaLabel="Select row"}:{checked:boolean;onChange:()=>void;ariaLabel?:string}) {
+  return <td className="cell-select"><input type="checkbox" checked={checked} onChange={onChange} aria-label={ariaLabel} /></td>;
 }
-
-export function CellDetails({
-  children,
-  rightTag,
-}: {
-  children: ReactNode;
-  rightTag?: ReactNode;
-}) {
+export function CellDetails({title,subtitle,rightTag}:{title:React.ReactNode;subtitle?:React.ReactNode;rightTag?:React.ReactNode;}) {
   return (
-    <td>
+    <td className="cell-details">
       <div className="cell-details__wrap">
-        {children}
-        {rightTag}
+        <div className="cell-details__left">
+          <div className="cell-details__title">{title}</div>
+          {subtitle && <div className="cell-details__subtitle">{subtitle}</div>}
+        </div>
+        {rightTag && <div className="cell-details__tag">{rightTag}</div>}
       </div>
     </td>
   );
 }
-
-type CountdownProps = {
-  vacancy: Vacancy;
-  settings: Settings;
-  now: number;
-};
-
-export function CellCountdown({ vacancy, settings, now }: CountdownProps) {
-  const msLeft = deadlineFor(vacancy, settings).getTime() - now;
-  const winMin = pickWindowMinutes(vacancy, settings);
-  const sinceKnownMin = minutesBetween(new Date(), new Date(vacancy.knownAt));
+export function CellCountdown({source,settings}:{source:Vacancy;settings:Settings}) {
+  const now = Date.now();
+  const deadline = deadlineFor(source, settings).getTime();
+  const msLeft = deadline - now;
+  const winMin = pickWindowMinutes(source, settings);
+  const sinceKnownMin = minutesBetween(new Date(), new Date(source.knownAt));
   const pct = Math.max(0, Math.min(1, (winMin - sinceKnownMin) / winMin));
-  let cdClass = "cd-green";
-  if (msLeft <= 0) cdClass = "cd-red";
-  else if (pct < 0.25) cdClass = "cd-yellow";
-
-  return (
-    <td className="cell-countdown">
-      <span className={`countdown ${cdClass}`}>{fmtCountdown(msLeft)}</span>
-    </td>
-  );
+  let cdClass = "cd-green"; if (msLeft <= 0) cdClass = "cd-red"; else if (pct < 0.25) cdClass = "cd-yellow";
+  return <td className="cell-countdown"><div className={`countdown ${cdClass}`}>{fmtCountdown(msLeft)}</div></td>;
 }
-
-export function CellActions({ children }: { children: ReactNode }) {
+export function CellActions({children}:{children:React.ReactNode}) {
   return <td className="cell-actions">{children}</td>;
 }
-

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 export const appConfig = {
   features: {
     coverageDayPicker: true,
+    bundleVacancies: true,
+    vacancyListRedesign: true,
   },
 } as const;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import Dashboard from "./Dashboard";
 import AuditLog from "./AuditLog";
 import "./styles/responsive.css";
 import "./styles/color-map.css";
+import "./styles/vacancies-redesign.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/styles/vacancies-redesign.css
+++ b/src/styles/vacancies-redesign.css
@@ -1,0 +1,25 @@
+table.vacancies { width:100%; border-collapse:separate; border-spacing:0; }
+table.vacancies thead th { position:sticky; top:0; background:#fff; z-index:2; text-align:left; font-weight:600; padding:10px 12px; border-bottom:1px solid #e9e9e9; }
+table.vacancies tbody tr { border-bottom:1px solid #f0f0f0; }
+table.vacancies tbody tr:nth-child(odd) { background:#fafafa; }
+table.vacancies tbody tr:hover { background:#f6faff; }
+
+td.cell-select { width:40px; padding:10px 12px; }
+td.cell-details { padding:10px 12px; }
+.cell-details__wrap { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; }
+.cell-details__title { font-weight:600; font-size:14px; line-height:1.3; }
+.cell-details__subtitle { font-size:12px; opacity:.85; margin-top:2px; }
+.cell-details__tag { white-space:nowrap; font-size:12px; opacity:.85; }
+
+td.cell-countdown { width:140px; padding:10px 12px; }
+.countdown.cd-red { color:#b30000; }
+.countdown.cd-yellow { color:#925f00; }
+.countdown.cd-green { color:#266a2e; }
+
+td.cell-actions { width:1%; white-space:nowrap; text-align:right; padding:10px 12px; }
+.btn-row { display:inline-flex; gap:6px; }
+.badge { display:inline-block; padding:2px 6px; font-size:11px; border-radius:999px; background:#eef2f7; color:#334155; }
+.badge-wing { background:#eefaf3; color:#206341; }
+.badge-class { background:#eef2ff; color:#42389d; }
+
+.section-h { position:sticky; top:36px; z-index:1; background:#fff; padding:6px 12px; font-weight:600; color:#364152; border-top:1px solid #e9e9e9; border-bottom:1px solid #e9e9e9; }


### PR DESCRIPTION
## Summary
- add `vacancyListRedesign` feature flag
- build shared row cells and redesigned open vacancies table
- update vacancy and bundle rows to match new layout and countdown styling

## Testing
- `npm test` *(fails: Unable to find an element with the text: Bulk Award)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba1464375c832784b60e8d94e05597