### PR TITLE
Add Three.js 3D chess board and pieces modules

### DIFF
--- a/games/chess3d/board.js
+++ b/games/chess3d/board.js
@@ -1,0 +1,46 @@
+import * as THREE from './lib/three.module.js';
+
+const BOARD_SIZE = 8;
+const SQUARE_SIZE = 1;
+
+export function squareToPosition(square) {
+  const file = square.charCodeAt(0) - 'a'.charCodeAt(0);
+  const rank = parseInt(square[1], 10) - 1;
+  const x = file - (BOARD_SIZE / 2 - 0.5);
+  const z = rank - (BOARD_SIZE / 2 - 0.5);
+  return new THREE.Vector3(x * SQUARE_SIZE, 0, z * SQUARE_SIZE);
+}
+
+export function positionToSquare(position) {
+  const fileIndex = Math.round(position.x / SQUARE_SIZE + BOARD_SIZE / 2 - 0.5);
+  const rankIndex = Math.round(position.z / SQUARE_SIZE + BOARD_SIZE / 2 - 0.5);
+  if (
+    fileIndex < 0 ||
+    fileIndex >= BOARD_SIZE ||
+    rankIndex < 0 ||
+    rankIndex >= BOARD_SIZE
+  ) {
+    return null;
+  }
+  const file = String.fromCharCode('a'.charCodeAt(0) + fileIndex);
+  const rank = (rankIndex + 1).toString();
+  return file + rank;
+}
+
+export function createBoard(scene) {
+  const board = new THREE.Group();
+  for (let f = 0; f < BOARD_SIZE; f++) {
+    for (let r = 0; r < BOARD_SIZE; r++) {
+      const color = (f + r) % 2 === 0 ? 0xffffff : 0x333333;
+      const geometry = new THREE.BoxGeometry(SQUARE_SIZE, 0.1, SQUARE_SIZE);
+      const material = new THREE.MeshStandardMaterial({ color });
+      const square = new THREE.Mesh(geometry, material);
+      const pos = squareToPosition(String.fromCharCode(97 + f) + (r + 1));
+      square.position.set(pos.x, -0.05, pos.z);
+      board.add(square);
+    }
+  }
+  scene.add(board);
+  return board;
+}
+

--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -1,0 +1,45 @@
+import * as THREE from './lib/three.module.js';
+import { OrbitControls } from './lib/OrbitControls.js';
+import { createBoard } from './board.js';
+import { createPieces } from './pieces.js';
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const scene = new THREE.Scene();
+
+const camera = new THREE.PerspectiveCamera(
+  45,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+camera.position.set(8, 10, 8);
+camera.lookAt(0, 0, 0);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 0, 0);
+
+const ambient = new THREE.AmbientLight(0xffffff, 0.8);
+scene.add(ambient);
+const dirLight = new THREE.DirectionalLight(0xffffff, 0.5);
+dirLight.position.set(10, 10, 0);
+scene.add(dirLight);
+
+createBoard(scene);
+createPieces(scene);
+
+function animate() {
+  requestAnimationFrame(animate);
+  controls.update();
+  renderer.render(scene, camera);
+}
+animate();
+
+window.addEventListener('resize', () => {
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+});
+

--- a/games/chess3d/pieces.js
+++ b/games/chess3d/pieces.js
@@ -1,0 +1,73 @@
+import * as THREE from './lib/three.module.js';
+import { squareToPosition } from './board.js';
+
+const pieces = [];
+
+export function createPieces(scene) {
+  const whiteMaterial = new THREE.MeshStandardMaterial({ color: 0xffffff });
+  const blackMaterial = new THREE.MeshStandardMaterial({ color: 0x000000 });
+  const pawnGeo = new THREE.CylinderGeometry(0.4, 0.4, 0.8, 32);
+  const pieceGeo = new THREE.ConeGeometry(0.5, 1, 32);
+
+  for (let i = 0; i < 8; i++) {
+    const file = String.fromCharCode(97 + i);
+    let square = file + '2';
+    let mesh = new THREE.Mesh(pawnGeo, whiteMaterial);
+    mesh.position.copy(squareToPosition(square));
+    scene.add(mesh);
+    pieces.push({ id: `wP${i}`, mesh, square });
+
+    square = file + '7';
+    mesh = new THREE.Mesh(pawnGeo, blackMaterial);
+    mesh.position.copy(squareToPosition(square));
+    scene.add(mesh);
+    pieces.push({ id: `bP${i}`, mesh, square });
+  }
+
+  const order = ['R', 'N', 'B', 'Q', 'K', 'B', 'N', 'R'];
+  for (let i = 0; i < 8; i++) {
+    const file = String.fromCharCode(97 + i);
+    let square = file + '1';
+    let mesh = new THREE.Mesh(pieceGeo, whiteMaterial);
+    mesh.position.copy(squareToPosition(square));
+    scene.add(mesh);
+    pieces.push({ id: `w${order[i]}${i}`, mesh, square });
+
+    square = file + '8';
+    mesh = new THREE.Mesh(pieceGeo, blackMaterial);
+    mesh.position.copy(squareToPosition(square));
+    scene.add(mesh);
+    pieces.push({ id: `b${order[i]}${i}`, mesh, square });
+  }
+}
+
+export function movePiece(id, to, animate = false) {
+  const piece = pieces.find((p) => p.id === id);
+  if (!piece) return;
+  const target = squareToPosition(to);
+  if (animate) {
+    const start = piece.mesh.position.clone();
+    const duration = 300;
+    const startTime = performance.now();
+    function step(time) {
+      const t = Math.min((time - startTime) / duration, 1);
+      piece.mesh.position.lerpVectors(start, target, t);
+      if (t < 1) {
+        requestAnimationFrame(step);
+      }
+    }
+    requestAnimationFrame(step);
+  } else {
+    piece.mesh.position.copy(target);
+  }
+  piece.square = to;
+}
+
+export function findBySquare(square) {
+  return pieces.find((p) => p.square === square);
+}
+
+export function listPieces() {
+  return pieces.slice();
+}
+


### PR DESCRIPTION
## Summary
- add board.js for creating chess board and coordinate conversions
- add pieces.js with piece creation, movement, and lookup utilities
- build main.js to set up Three.js scene and initialize board/pieces

## Testing
- `npm test` *(fails: Unable to find an element with the text: Bulk Award)*

------
https://chatgpt.com/codex/tasks/task_e_68ba77a622f483278a628cd7dfa4bff4