### PR TITLE
feat: add stockfish ai wrapper

### DIFF
--- a/games/chess3d/ai/ai.js
+++ b/games/chess3d/ai/ai.js
@@ -1,0 +1,75 @@
+let worker;
+let readyPromise;
+let readyResolver;
+let searchResolver;
+let busy = false;
+
+function spawnWorker() {
+  worker = new Worker(new URL('./stockfish.worker.js', import.meta.url));
+  worker.addEventListener('message', (e) => {
+    const msg = e.data || {};
+    if (msg.type === 'ready') {
+      if (readyResolver) {
+        readyResolver();
+        readyResolver = null;
+      }
+    } else if (msg.type === 'bestmove') {
+      busy = false;
+      if (searchResolver) {
+        searchResolver({ uci: msg.uci, move: uciToMove(msg.uci) });
+        searchResolver = null;
+      }
+    }
+  });
+}
+
+function uciToMove(uci) {
+  const from = uci.slice(0, 2);
+  const to = uci.slice(2, 4);
+  const promo = uci.length > 4 ? uci.slice(4) : undefined;
+  const move = { from, to };
+  if (promo) move.promo = promo;
+  return move;
+}
+
+export async function initEngine() {
+  if (!worker) {
+    spawnWorker();
+  }
+  if (!readyPromise) {
+    readyPromise = new Promise((resolve) => {
+      readyResolver = resolve;
+    });
+    worker.postMessage({ type: 'init' });
+  }
+  return readyPromise;
+}
+
+export async function requestBestMove(fen, { depth = 12, skill = 4 } = {}) {
+  if (busy) {
+    cancel();
+  }
+  await initEngine();
+  busy = true;
+  worker.postMessage({ type: 'position', fen });
+  worker.postMessage({ type: 'go', depth, skill });
+  return new Promise((resolve) => {
+    searchResolver = resolve;
+  });
+}
+
+export function cancel() {
+  if (worker) {
+    worker.terminate();
+  }
+  worker = null;
+  readyPromise = null;
+  readyResolver = null;
+  searchResolver = null;
+  busy = false;
+  spawnWorker();
+  readyPromise = new Promise((resolve) => {
+    readyResolver = resolve;
+  });
+  worker.postMessage({ type: 'init' });
+}


### PR DESCRIPTION
## Summary
- add async wrapper around Stockfish worker for 3D chess demo

## Testing
- `npm test` (fails: TestingLibraryElementError: Unable to find an element with the text: Bulk Award)
- `npm run lint`
- `node -e "import('./games/chess3d/ai/ai.js').then(async m=>{await m.initEngine(); const r=await m.requestBestMove('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'); console.log(r);}).catch(e=>{console.error(e);});"` (fails: ReferenceError: Worker is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68bb023fec88832786e9483e0b603145