### PR TITLE
Add chess3d mode bar UI

### DIFF
--- a/games/chess3d/ui/hud.js
+++ b/games/chess3d/ui/hud.js
@@ -1,0 +1,17 @@
+import { mountModeBar } from './modeBar.js';
+
+export function mountHud({ onModeChange } = {}) {
+  const hud = document.createElement('div');
+  hud.className = 'hud';
+  document.body.appendChild(hud);
+
+  const top = document.createElement('div');
+  top.className = 'hud-top';
+  hud.appendChild(top);
+
+  const modeContainer = document.createElement('div');
+  hud.appendChild(modeContainer);
+  mountModeBar(modeContainer, { onChange: onModeChange });
+
+  return hud;
+}

--- a/games/chess3d/ui/modeBar.js
+++ b/games/chess3d/ui/modeBar.js
@@ -1,0 +1,76 @@
+const MODE_KEY = 'chess3d.mode';
+const DIFF_KEY = 'chess3d.diff';
+
+const MODES = [
+  { id: 'pvp', label: 'PvP' },
+  { id: 'ai-white', label: 'Vs AI (Human White)' },
+  { id: 'ai-black', label: 'Vs AI (Human Black)' }
+];
+
+export function getMode() {
+  return localStorage.getItem(MODE_KEY) || 'pvp';
+}
+
+export function getDifficulty() {
+  const value = parseInt(localStorage.getItem(DIFF_KEY), 10);
+  return Number.isNaN(value) ? 1 : Math.min(Math.max(value, 1), 8);
+}
+
+export function mountModeBar(container, { onChange } = {}) {
+  const bar = document.createElement('div');
+  bar.className = 'mode-bar';
+
+  const label = document.createElement('span');
+  label.textContent = 'Mode: ';
+  bar.appendChild(label);
+
+  const buttons = [];
+  MODES.forEach((m) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = m.label;
+    btn.dataset.mode = m.id;
+    btn.className = 'mode-option';
+    if (m.id === getMode()) {
+      btn.classList.add('active');
+    }
+    btn.addEventListener('click', () => {
+      buttons.forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      localStorage.setItem(MODE_KEY, m.id);
+      if (onChange) onChange(getMode(), getDifficulty());
+    });
+    bar.appendChild(btn);
+    buttons.push(btn);
+  });
+
+  const diffLabel = document.createElement('label');
+  diffLabel.className = 'difficulty-label';
+  diffLabel.textContent = ' Difficulty: ';
+
+  const slider = document.createElement('input');
+  slider.type = 'range';
+  slider.min = '1';
+  slider.max = '8';
+  slider.step = '1';
+  slider.value = getDifficulty();
+
+  const valueSpan = document.createElement('span');
+  valueSpan.textContent = slider.value;
+
+  slider.addEventListener('input', () => {
+    localStorage.setItem(DIFF_KEY, slider.value);
+    valueSpan.textContent = slider.value;
+    if (onChange) onChange(getMode(), getDifficulty());
+  });
+
+  diffLabel.appendChild(slider);
+  diffLabel.appendChild(valueSpan);
+  bar.appendChild(diffLabel);
+
+  container.appendChild(bar);
+
+  if (onChange) {
+    onChange(getMode(), getDifficulty());
+  }
+}


### PR DESCRIPTION
## Summary
- add ModeBar component for chess3d with play mode buttons and difficulty slider
- persist chess3d mode and difficulty in localStorage
- mount ModeBar from HUD module

## Testing
- `npm test` *(fails: Unable to find an element with the text: Bulk Award)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0502c60c83278c939e1dea7657a9