### PR TITLE
Move recommended name to right in vacancy rows

### DIFF
--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -102,23 +102,27 @@ export default function BundleRow({
               >
                 {dateList}
               </span>
+            </div>
+          }
+          rightTag={
+            <>
               {recId ? (
                 <span
                   className="pill"
-                  style={{ cursor: "pointer" }}
+                  style={{ cursor: "pointer", marginRight: 8 }}
                   onClick={() => onAwardBundle?.(recId)}
                 >
                   {recName}
                 </span>
               ) : (
-                <span className="subtitle">—</span>
+                <span className="subtitle" style={{ marginRight: 8 }}>
+                  —
+                </span>
               )}
-            </div>
-          }
-          rightTag={
-            <>
               {multipleWings && (
-                <span className="pill" title={distinctWings.join(", ")}>Multiple wings</span>
+                <span className="pill" title={distinctWings.join(", ")}>
+                  Multiple wings
+                </span>
               )}
               {recWhy.map((w, i) => (
                 <span key={i} className="pill">

--- a/src/components/VacancyRow.tsx
+++ b/src/components/VacancyRow.tsx
@@ -110,14 +110,20 @@ export default function VacancyRow({
             {v.wing && <span className="pill">{v.wing}</span>}
             <span className="pill">{v.classification}</span>
             <span className="pill">{v.offeringStep}</span>
-            <span>{recName}</span>
           </div>
         }
-        rightTag={recWhy.map((w, i) => (
-          <span key={i} className="pill">
-            {w}
-          </span>
-        ))}
+        rightTag={
+          <>
+            <span className="subtitle" style={{ marginRight: 8 }}>
+              {recName}
+            </span>
+            {recWhy.map((w, i) => (
+              <span key={i} className="pill">
+                {w}
+              </span>
+            ))}
+          </>
+        }
       />
       <CellCountdown source={v} settings={settings} />
       <CellActions>


### PR DESCRIPTION
## Summary
- Place recommended employee name beside recommendation tags on the right side of vacancy rows
- Do the same for bundle rows to keep the layout consistent

## Testing
- `npm test` *(fails: Unable to find an element with the text "Bulk Award")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb07aac2ec8327be832ab0fde3e317