### PR TITLE
feat: show covered employee on open vacancies

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1182,6 +1182,7 @@ export default function App() {
                   <OpenVacanciesRedesign
                     vacancies={vacancies}
                     employees={employees}
+                    vacations={vacations}
                     settings={settings}
                     selectedIds={selectedVacancyIds}
                     dueNextId={dueNextId}

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import type { Employee } from "./App";
+import type { Employee, Vacation } from "./App";
 import CalendarView from "./components/CalendarView";
 import OpenVacancies from "./components/OpenVacancies";
 import useVacancies from "./state/useVacancies";
@@ -26,11 +26,12 @@ const loadState = () => {
 
 type State = {
   employees: Employee[];
+  vacations: Vacation[];
 };
 
 export default function Dashboard() {
-  const data: State = loadState() || { employees: [] };
-  const { employees } = data;
+  const data: State = loadState() || { employees: [], vacations: [] };
+  const { employees, vacations } = data;
   const { vacancies, stageDelete, undoDelete, staged } = useVacancies();
 
   const [view, setView] = useState<"list" | "calendar">("list");
@@ -112,6 +113,7 @@ export default function Dashboard() {
               <h2>Open Shifts</h2>
               <OpenVacancies
                 vacancies={vacancies}
+                vacations={vacations}
                 stageDelete={stageDelete}
                 undoDelete={undoDelete}
                 staged={staged}

--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -23,6 +23,7 @@ type Props = {
   onAwardBundle?: (employeeId: string) => void;     // optional hook
   onEditCoverage?: (bundleId: string) => void;
   dueNextId: string | null;
+  coveredName?: string;
 };
 
 export default function BundleRow({
@@ -38,6 +39,7 @@ export default function BundleRow({
   onAwardBundle,
   onEditCoverage,
   dueNextId,
+  coveredName,
 }: Props) {
   const sorted = React.useMemo(() =>
     [...items].sort((a,b) =>
@@ -51,7 +53,8 @@ export default function BundleRow({
   const isDueNext = dueNextId ? childIds.includes(dueNextId) : false;
 
   const wingText = primary.wing ?? "Wing";
-  const title = `${items.length} days • ${wingText} • ${primary.classification}`;
+  const coverText = coveredName ? ` • Covering ${coveredName}` : "";
+  const title = `${items.length} days • ${wingText} • ${primary.classification}${coverText}`;
   const dateList = sorted.map((v) => formatDateLong(v.shiftDate)).join(", ");
 
   const rec = recommendations[primary.id];

--- a/src/components/EmployeePickerModal.tsx
+++ b/src/components/EmployeePickerModal.tsx
@@ -28,7 +28,7 @@ export default function EmployeePickerModal({ open, employees, classification, o
   if (!open) return null;
   return (
     <div className="modal-overlay">
-      <BodyLock />>
+      <BodyLock />
       <div role="dialog" aria-modal="true" className="modal" ref={dialogRef}>
         <div className="modal-h">Select employee</div>
         <input

--- a/src/components/OpenVacancies.tsx
+++ b/src/components/OpenVacancies.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import type { Vacancy } from "../types";
+import { useState, useMemo } from "react";
+import type { Vacancy, Vacation } from "../types";
 import ConfirmDialog from "./ui/ConfirmDialog";
 import Toast from "./ui/Toast";
 import { TrashIcon } from "./ui/Icon";
@@ -7,6 +7,7 @@ import CoverageChip from "./ui/CoverageChip";
 
 interface Props {
   vacancies: Vacancy[];
+  vacations?: Vacation[];
   stageDelete: (ids: string[]) => void;
   undoDelete: () => void;
   staged: Vacancy[] | null;
@@ -15,6 +16,7 @@ interface Props {
 
 export default function OpenVacancies({
   vacancies,
+  vacations = [],
   stageDelete,
   undoDelete,
   staged,
@@ -22,6 +24,12 @@ export default function OpenVacancies({
 }: Props) {
   const [selected, setSelected] = useState<string[]>([]);
   const [pending, setPending] = useState<string[] | null>(null);
+
+  const vacNameById = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const v of vacations) m[v.id] = v.employeeName;
+    return m;
+  }, [vacations]);
 
   const toggleSelect = (id: string) => {
     setSelected((ids) =>
@@ -104,6 +112,7 @@ export default function OpenVacancies({
               />
             </th>
             <th>Role</th>
+            <th>Covering</th>
             <th>Date</th>
             <th>Time</th>
             <th style={{ textAlign: "right", minWidth: 60 }}>Actions</th>
@@ -121,6 +130,7 @@ export default function OpenVacancies({
                 />
               </td>
               <td>{v.classification}</td>
+              <td>{vacNameById[v.vacationId ?? ""] || "—"}</td>
               <td>
                 <div
                   style={{
@@ -173,7 +183,7 @@ export default function OpenVacancies({
           ))}
           {openVacancies.length === 0 && (
             <tr>
-              <td colSpan={5} style={{ textAlign: "center" }}>
+              <td colSpan={6} style={{ textAlign: "center" }}>
                 No vacancies
               </td>
             </tr>

--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import type { Vacancy, Employee, Settings } from "../types";
+import type { Vacancy, Employee, Settings, Vacation } from "../types";
 import type { Recommendation } from "../recommend";
 import BundleRow from "./BundleRow";
 import VacancyRow from "./VacancyRow";
@@ -8,6 +8,7 @@ import { combineDateTime } from "../lib/dates";
 type Props = {
   vacancies: Vacancy[];
   employees: Employee[];
+  vacations: Vacation[];
   settings: Settings;
   selectedIds: string[];
   dueNextId: string | null;
@@ -30,7 +31,7 @@ type Props = {
 };
 
 export default function OpenVacanciesRedesign(props: Props) {
-  const { vacancies, filters, settings, employees, recommendations } = props;
+  const { vacancies, vacations, filters, settings, employees, recommendations } = props;
   const employeesById = useMemo(() => {
     const map: Record<string, Employee> = {};
     employees.forEach((e) => {
@@ -38,6 +39,13 @@ export default function OpenVacanciesRedesign(props: Props) {
     });
     return map;
   }, [employees]);
+  const vacNameById = useMemo(() => {
+    const map: Record<string, string> = {};
+    vacations.forEach((v) => {
+      map[v.id] = v.employeeName;
+    });
+    return map;
+  }, [vacations]);
   const filtered = useMemo(() => {
     let list = vacancies.filter(
       (v) => v.status !== "Filled" && v.status !== "Awarded",
@@ -105,6 +113,7 @@ export default function OpenVacanciesRedesign(props: Props) {
             const rendered: React.ReactNode[] = [];
             for (const [key, arr] of groups) {
               if (arr.length < 2) continue;
+              const coveredName = vacNameById[arr[0].vacationId ?? ""];
               rendered.push(
                 <BundleRow
                   key={`bundle-${key}-${date}`}
@@ -120,6 +129,7 @@ export default function OpenVacanciesRedesign(props: Props) {
                   onEditCoverage={props.onEditCoverage}
                   onAwardBundle={(eid) => props.awardBundle?.(key, eid)}
                   dueNextId={props.dueNextId}
+                  coveredName={coveredName}
                 />,
               );
             }
@@ -134,6 +144,7 @@ export default function OpenVacanciesRedesign(props: Props) {
                   }`.trim()
                 : "—";
               const recWhy = rec?.why ?? [];
+              const coveredName = vacNameById[v.vacationId ?? ""];
               rendered.push(
                 <VacancyRow
                   key={v.id}
@@ -148,6 +159,7 @@ export default function OpenVacanciesRedesign(props: Props) {
                   resetKnownAt={() => props.resetKnownAt(v.id)}
                   onDelete={props.onDelete}
                   isDueNext={props.dueNextId === v.id}
+                  coveredName={coveredName}
                   settings={settings}
                 />,
               );

--- a/tests/openVacancies.test.tsx
+++ b/tests/openVacancies.test.tsx
@@ -44,9 +44,10 @@ describe("OpenVacancies", () => {
     setupLocalStorage(vacancies);
 
     let vacState: ReturnType<typeof useVacancies>;
+    const vacations: any[] = [];
     function Wrapper() {
       vacState = useVacancies();
-      return <OpenVacancies {...vacState} />;
+      return <OpenVacancies {...vacState} vacations={vacations} />;
     }
 
     render(<Wrapper />);
@@ -84,9 +85,10 @@ describe("OpenVacancies", () => {
     setupLocalStorage(vacancies);
 
     let vacState: ReturnType<typeof useVacancies>;
+    const vacations: any[] = [];
     function Wrapper() {
       vacState = useVacancies();
-      return <OpenVacancies {...vacState} />;
+      return <OpenVacancies {...vacState} vacations={vacations} />;
     }
 
     render(<Wrapper />);
@@ -109,6 +111,37 @@ describe("OpenVacancies", () => {
     expect(persisted.auditLog[0].payload.userAction).toBe("bulk");
 
     vi.useRealTimers();
+  });
+
+  it("shows covered employee name when linked to a vacation", () => {
+    const vacancies = [
+      {
+        id: "v1",
+        classification: "RN",
+        shiftDate: "2024-01-01",
+        shiftStart: "08:00",
+        shiftEnd: "16:00",
+        knownAt: "2024-01-01T00:00:00.000Z",
+        offeringTier: "CASUALS",
+        offeringStep: "Casuals",
+        status: "Open",
+        vacationId: "vac1",
+      },
+    ];
+    const vacations = [
+      { id: "vac1", employeeName: "John Doe" },
+    ];
+    setupLocalStorage(vacancies);
+
+    let vacState: ReturnType<typeof useVacancies>;
+    function Wrapper() {
+      vacState = useVacancies();
+      return <OpenVacancies {...vacState} vacations={vacations} />;
+    }
+
+    render(<Wrapper />);
+
+    expect(screen.getByText("John Doe")).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary
- show the covered employee in the open vacancies table
- surface coverage names in redesigned vacancy list and bundle rows
- fix stray character in EmployeePickerModal JSX

## Testing
- `npm test` *(fails: tests/awardVacancy.test.tsx > award vacancy UI > bulk awards selected vacancies with identical details)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2b6406c48327a5864a1ed586905a