### PR TITLE
fix: resolve TypeScript errors in bid modals

### DIFF
--- a/src/components/RangeBidDialog.tsx
+++ b/src/components/RangeBidDialog.tsx
@@ -45,10 +45,15 @@ export default function RangeBidDialog({ open, onClose, range, employees, onSubm
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef, onClose);
   return (
-    <div className="modal-overlay">
+    <div className="modal-overlay" onClick={onClose}>
       <BodyLock />
-       onClick={onClose}>>
-      <div role="dialog" aria-modal="true" className="modal" ref={dialogRef} onClick={(e) => e.stopPropagation()}">
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="modal"
+        ref={dialogRef}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-lg font-semibold">Enter Bid for Multi‑day Vacancy</h2>
           <button onClick={onClose} className="px-2 py-1 rounded-md border">Close</button>
@@ -57,9 +62,17 @@ export default function RangeBidDialog({ open, onClose, range, employees, onSubm
         <div className="space-y-3">
           <label className="flex flex-col gap-1">
             <span className="text-sm font-medium">Bidder</span>
-            <select value={employeeId} onChange={e=>setEmployeeId(e.target.value)} className="border rounded-md px-2 py-1">
+            <select
+              value={employeeId}
+              onChange={e => setEmployeeId(e.target.value)}
+              className="border rounded-md px-2 py-1"
+            >
               <option value="">Select employee…</option>
-              {empOpts.map(e => <option key={e.id} value={e.id}>{e.seniorityRank}. {e.lastName}, {e.firstName} — {e.classification}</option>)}
+              {empOpts.map(e => (
+                <option key={e.id} value={e.id}>
+                  {e.seniorityRank}. {e.lastName}, {e.firstName} — {e.classification}
+                </option>
+              ))}
             </select>
           </label>
 

--- a/src/optional/MultiBidModal.tsx
+++ b/src/optional/MultiBidModal.tsx
@@ -1,4 +1,4 @@
-import BodyLock from "./BodyLock";
+import BodyLock from "../components/BodyLock";
 import { useFocusTrap } from "../hooks/useFocusTrap";
 
 import React, { useRef,  useMemo, useState } from "react";
@@ -43,6 +43,9 @@ export default function MultiBidModal({
 
   if (!open) return null;
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, onClose);
+
   function toggle(id: string) {
     setChosenIds(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]);
   }
@@ -86,10 +89,15 @@ export default function MultiBidModal({
   }, [applyToBundles, selectedVacancyIds, allVacancies]);
 
   return (
-    <div className="modal-overlay">
+    <div className="modal-overlay" onClick={onClose}>
       <BodyLock />
-       onClick={onClose}>>
-      <div role="dialog" aria-modal="true" className="modal" ref={dialogRef} onClick={(e) => e.stopPropagation()}">
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="modal"
+        ref={dialogRef}
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-lg font-semibold">Bulk Bid</h2>
           <button onClick={onClose} className="px-2 py-1 rounded-md border">Close</button>


### PR DESCRIPTION
## Summary
- fix overlay markup in RangeBidDialog and MultiBidModal
- add missing imports and focus trap setup in MultiBidModal
- format option list rendering in RangeBidDialog

## Testing
- `npm run typecheck`
- `npm test` *(fails: Unable to find an element with the text: Bulk Award)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2cd066bc8327b571386369c43ace