### PR TITLE
chore(ci): add UI scan + autofix workflows and tools

### DIFF
--- a/.github/workflows/ui-autofix.yml
+++ b/.github/workflows/ui-autofix.yml
@@ -1,0 +1,43 @@
+name: UI AutoFix (Open PR)
+on:
+  workflow_dispatch: {}
+  schedule: [ { cron: "0 13 * * *" } ] # daily 6am PT
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    permissions: { contents: write, pull-requests: write }
+    env:
+      BASE_URL: http://127.0.0.1:5173
+      NODE_ENV: development
+      VITE_API_URL: ${{ secrets.VITE_API_URL }}
+      VITE_AUTH_TOKEN: ${{ secrets.VITE_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 18 }
+      - run: |
+          npm ci || npm i
+          npm i -D @axe-core/playwright @playwright/test playwright
+          npx playwright install --with-deps
+      - name: Start dev server (Vite on :5173)
+        run: |
+          nohup npm run dev -- --host 0.0.0.0 --port 5173 --strictPort > /dev/null 2>&1 &
+          sleep 20
+      - name: Run scan
+        run: node tools/ai-ui-autofix/scan.mjs || true
+      - name: Apply codemods (auto-fix common UI issues)
+        run: node tools/ai-ui-autofix/fixers.mjs
+      - name: Create PR with changes
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: chore/ui-autofix
+          delete-branch: true
+          title: "fix(ui): automated pass for overlaps, modals, z-index, responsiveness"
+          commit-message: "fix(ui): automated pass for overlaps, modals, z-index, responsiveness"
+          body: |
+            This automated PR applies codemods based on the latest UI scan.
+            - Adds/ensures ui-sanity.css helpers for overflow/wrapping/z-index
+            - Ensures global import
+            - Adds modal body-scroll lock fallback and dialog aria attributes
+            - Writes scan summary
+            Re-run **UI Scan (Text Only)** after merge.

--- a/.github/workflows/ui-scan.yml
+++ b/.github/workflows/ui-scan.yml
@@ -1,46 +1,33 @@
 name: UI Scan (Text Only)
-
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_dispatch: {}
-
 jobs:
   ui-scan:
     runs-on: ubuntu-latest
     env:
-      # We’ll run the dev server on 5173 and point the scanner at it.
       BASE_URL: http://127.0.0.1:5173
       NODE_ENV: development
-
+      # ← Codex: keep these references; user will add the actual secrets in repo Settings:
+      VITE_API_URL: ${{ secrets.VITE_API_URL }}
+      VITE_AUTH_TOKEN: ${{ secrets.VITE_AUTH_TOKEN }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
-      - name: Install dependencies
-        run: |
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 18 }
+      - run: |
           npm ci || npm i
           npm i -D @axe-core/playwright @playwright/test playwright
           npx playwright install --with-deps
-
-      # Use the dev server (more reliable than preview in CI)
       - name: Start dev server (Vite on :5173)
         run: |
           nohup npm run dev -- --host 0.0.0.0 --port 5173 --strictPort > /dev/null 2>&1 &
-          # Give Vite time to compile/start
           sleep 20
-
       - name: Run scan (writes tools/ai-ui-autofix/report.json)
-        run: |
-          node tools/ai-ui-autofix/scan.mjs || true
-
+        run: node tools/ai-ui-autofix/scan.mjs || true
       - name: Upload JSON report
         uses: actions/upload-artifact@v4
         with:

--- a/docs/ui-audit.md
+++ b/docs/ui-audit.md
@@ -1,0 +1,6 @@
+# UI Audit
+
+## Checklist
+- [ ] Run **UI Scan (Text Only)** in GitHub Actions
+- [ ] Review `tools/ai-ui-autofix/report.json`
+- [ ] Address outstanding UI issues

--- a/tools/ai-ui-autofix/fixers.mjs
+++ b/tools/ai-ui-autofix/fixers.mjs
@@ -1,0 +1,78 @@
+import fs from 'fs';
+import path from 'path';
+
+const log = (...args) => console.log('[autofix]', ...args);
+const read = p => fs.existsSync(p) ? fs.readFileSync(p,'utf8') : '';
+const write = (p,s) => { fs.mkdirSync(path.dirname(p), { recursive:true }); fs.writeFileSync(p,s,'utf8'); };
+
+// 1) Ensure ui-sanity.css helpers
+const uiCssPath = path.join('src','styles','ui-sanity.css');
+if (!fs.existsSync(uiCssPath)) {
+  write(uiCssPath, `/* auto helpers */ 
+:root{ --stickyOffset: 56px; }
+.container{ max-width:min(100%,1600px); margin-inline:auto; padding-inline:12px; }
+.truncate{ overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.wrap-anywhere{ overflow-wrap:anywhere; word-break:break-word; }
+img,svg,canvas,video{ max-width:100%; height:auto; }
+.table-responsive{ width:100%; overflow:auto; }
+.table-responsive > table{ width:max(640px,100%); border-collapse:collapse; }
+.modal-overlay{ position:fixed; inset:0; background:rgba(0,0,0,.35); z-index: 900; display:flex; align-items:center; justify-content:center; }
+.modal{ max-width:min(92vw, 720px); width:100%; max-height:90vh; overflow:auto; background:#fff; border-radius:12px; padding:16px; box-shadow:0 10px 30px rgba(0,0,0,.25); z-index: 1000; }
+.menu{ position:absolute; z-index:1100; }`);
+  log('created', uiCssPath);
+}
+
+// 2) Ensure global import + modal body-lock fallback
+const mainCandidates = ['src/main.tsx','src/main.ts','src/index.tsx'];
+const mainPath = mainCandidates.find(p => fs.existsSync(p));
+if (mainPath) {
+  let src = read(mainPath);
+  if (!src.includes('ui-sanity.css')) {
+    src = 'import "./styles/ui-sanity.css";\n' + src;
+    log('added ui-sanity import to', mainPath);
+  }
+  if (!src.includes('/* auto: modal body-lock observer */')) {
+    src = src.replace(/createRoot\([^)]*\)\.render\([^)]*\);?/, m => m + `
+/* auto: modal body-lock observer */
+(function(){
+  const s = document.createElement('style'); s.textContent='body.__modal_lock{overflow:hidden !important;}'; document.head.appendChild(s);
+  const observer = new MutationObserver(()=>{
+    const openModal = document.querySelector('.modal');
+    document.body.classList.toggle('__modal_lock', !!openModal);
+  });
+  observer.observe(document.body, { childList:true, subtree:true, attributes:true, attributeFilter:['class'] });
+})();`);
+    log('injected modal body-lock observer in', mainPath);
+  }
+  write(mainPath, src);
+}
+
+// 3) Ensure role/aria on modal containers
+function walk(dir, hit=[]) {
+  for (const name of fs.readdirSync(dir)) {
+    const p = path.join(dir,name); const st=fs.statSync(p);
+    if (st.isDirectory()) walk(p, hit);
+    else if (/[.](tsx|jsx|ts|js)$/.test(p)) hit.push(p);
+  } return hit;
+}
+for (const f of walk('src', [])) {
+  let s = read(f);
+  if (s.includes('className="modal"') && !s.includes('role="dialog"')) {
+    s = s.replace('className="modal"', 'role="dialog" aria-modal="true" className="modal"');
+    write(f, s); log('added role/aria to', f);
+  }
+}
+
+// 4) Write short scan summary for PR body, if report exists
+const reportPath = path.join('tools','ai-ui-autofix','report.json');
+if (fs.existsSync(reportPath)) {
+  const report = JSON.parse(read(reportPath));
+  const counts = {};
+  for (const i of report.issues) counts[i.type]=(counts[i.type]||0)+1;
+  write(path.join('tools','ai-ui-autofix','report-summary.md'),
+    '# Latest UI Scan\n' +
+    'Base: ' + report.baseUrl + '\n' +
+    'Issues: ' + report.issuesTotal + '\n' +
+    'Counts: ' + JSON.stringify(counts, null, 2) + '\n');
+  log('wrote scan summary');
+}

--- a/tools/ai-ui-autofix/scan.mjs
+++ b/tools/ai-ui-autofix/scan.mjs
@@ -1,55 +1,44 @@
-/* tools/ai-ui-autofix/scan.mjs
-   Text-only UI scanner for Playwright + axe-core.
-   No screenshots. Outputs JSON report at tools/ai-ui-autofix/report.json
-*/
 import { chromium } from 'playwright';
 import AxeBuilder from '@axe-core/playwright';
 import fs from 'fs';
 import path from 'path';
-
-// In CI we set BASE_URL via the workflow env; locally you can override too.
 const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
 
-// Adjust these to match your app routes
-const ROUTES = ['/', '/dashboard', '/analytics', '/audit-log'];
-
-// Viewport widths to check (mobile, tablet, desktop)
+// Codex: set routes to match this project. Start with these; keep extensible/commented:
+const ROUTES = ['/', '/dashboard', '/analytics', '/audit-log']; // add '/vacancies','/schedule','/admin/settings' if they exist
 const WIDTHS = [360, 768, 1280];
 
 const outDir = path.resolve('tools/ai-ui-autofix');
 const outPath = path.join(outDir, 'report.json');
 await fs.promises.mkdir(outDir, { recursive: true });
 
-function pushIssue(arr, route, width, type, details) {
-  arr.push({ route, width, type, details });
-}
+function pushIssue(arr, route, width, type, details){ arr.push({ route, width, type, details }); }
 
 const browser = await chromium.launch();
 const page = await browser.newPage();
-
 const issues = [];
 
 for (const w of WIDTHS) {
   await page.setViewportSize({ width: w, height: 900 });
-
   for (const r of ROUTES) {
     const url = new URL(r, BASE_URL).toString();
-
     try {
       const messages = [];
       page.on('console', (m) => { if (m.type() === 'error') messages.push(m.text()); });
+      page.on('response', (res) => {
+        if (res.status() >= 400) console.log('[scan] HTTP', res.status(), res.url());
+      });
 
-      // Try to navigate
       await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
 
-      // Run axe-core a11y analysis
+      // a11y
       let axeViolations = [];
       try {
         const axe = await new AxeBuilder({ page }).analyze();
         axeViolations = axe.violations.map(v => ({ id: v.id, impact: v.impact, help: v.help }));
       } catch {}
 
-      // Heuristics for common UI problems
+      // layout heuristics
       const data = await page.evaluate(() => {
         const vw = window.innerWidth;
         const docScrollW = document.documentElement.scrollWidth;
@@ -74,7 +63,7 @@ for (const w of WIDTHS) {
           const b = el.getBoundingClientRect();
           if (!Number.isFinite(b.left) || !Number.isFinite(b.right)) continue;
           if (b.left < -4 || b.right > vw + 4) {
-            offscreen.push({ tag: el.tagName.toLowerCase(), class: (el.className || '').toString().slice(0, 60) });
+            offscreen.push({ tag: el.tagName.toLowerCase(), class: (el.className || '').toString().slice(0,60) });
             if (offscreen.length > 15) break;
           }
         }
@@ -82,9 +71,7 @@ for (const w of WIDTHS) {
         const modal = document.querySelector('.modal');
         const hasOverlay = document.querySelector('.modal-overlay');
         let bodyScrollLocked = true;
-        if (modal) {
-          bodyScrollLocked = getComputedStyle(document.body).overflow === 'hidden';
-        }
+        if (modal) bodyScrollLocked = getComputedStyle(document.body).overflow === 'hidden';
         const modalHasRole = modal ? (modal.getAttribute('role') === 'dialog' && modal.getAttribute('aria-modal') === 'true') : null;
 
         const menus = Array.from(document.querySelectorAll('.menu'));
@@ -93,37 +80,24 @@ for (const w of WIDTHS) {
           const hb = header.getBoundingClientRect();
           for (const m of menus) {
             const mb = m.getBoundingClientRect();
-            if (hb.bottom > mb.top && hb.top < mb.bottom) {
-              menuCovered = true;
-              break;
-            }
+            if (hb.bottom > mb.top && hb.top < mb.bottom) { menuCovered = true; break; }
           }
         }
 
-        return {
-          vw,
-          overflowX,
-          headerOverlap,
-          offscreen,
-          modalOpen: !!modal,
-          hasOverlay: !!hasOverlay,
-          bodyScrollLocked,
-          modalHasRole,
-          menuCovered,
-        };
+        return { vw, overflowX, headerOverlap, offscreen, modalOpen: !!modal, hasOverlay: !!hasOverlay, bodyScrollLocked, modalHasRole, menuCovered };
       });
 
       if (messages.length) pushIssue(issues, r, w, 'console-error', { messages });
       if (data.overflowX) pushIssue(issues, r, w, 'overflow-x', {});
       if (data.headerOverlap) pushIssue(issues, r, w, 'header-overlap', {});
-      if (data.offscreen.length) pushIssue(issues, r, w, 'offscreen', { sample: data.offscreen.slice(0, 5) });
+      if (data.offscreen.length) pushIssue(issues, r, w, 'offscreen', { sample: data.offscreen.slice(0,5) });
       if (data.menuCovered) pushIssue(issues, r, w, 'z-index-menu', {});
       if (data.modalOpen) {
         if (!data.bodyScrollLocked) pushIssue(issues, r, w, 'modal-scroll', {});
         if (data.modalHasRole === false) pushIssue(issues, r, w, 'modal-aria', {});
         if (!data.hasOverlay) pushIssue(issues, r, w, 'modal-overlay', {});
       }
-      if (axeViolations.length) pushIssue(issues, r, w, 'a11y', { violations: axeViolations.slice(0, 10) });
+      if (axeViolations.length) pushIssue(issues, r, w, 'a11y', { violations: axeViolations.slice(0,10) });
 
     } catch (err) {
       pushIssue(issues, r, w, 'navigation-failed', { error: String(err) });
@@ -132,15 +106,6 @@ for (const w of WIDTHS) {
 }
 
 await browser.close();
-
-const report = {
-  baseUrl: BASE_URL,
-  routes: ROUTES,
-  widths: WIDTHS,
-  issuesTotal: issues.length,
-  generatedAt: new Date().toISOString(),
-  issues,
-};
-
+const report = { baseUrl: BASE_URL, routes: ROUTES, widths: WIDTHS, issuesTotal: issues.length, generatedAt: new Date().toISOString(), issues };
 await fs.promises.writeFile(outPath, JSON.stringify(report, null, 2), 'utf-8');
 console.log(`Wrote ${outPath} with ${issues.length} issues`);


### PR DESCRIPTION
## Summary
- add UI Scan workflow and autofix workflow
- add playwright-based scan and codemod fixers
- document UI audit process

## Testing
- ❌ `npm test` (fails: Unable to find an element with the text: Bulk Award)

## Checklist
- [ ] Go to Settings → Actions → **Allow all actions**
- [ ] Add **Actions secrets**: `VITE_API_URL`, `VITE_AUTH_TOKEN` (and any others)
- [ ] Merge, then run **UI Scan (Text Only)** in Actions and download ui-report-json → report.json


------
https://chatgpt.com/codex/tasks/task_e_68bb318b339483279b39fd2815803a23