### PR TITLE
Fix coverage tab layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -947,7 +947,7 @@ export default function App() {
 
           
           <CoverageRangesPanel />
-          <div className="grid grid2">
+          <div className="grid">
             <div className="card">
               <div className="card-h">
                 Add Vacation (auto-creates daily vacancies)


### PR DESCRIPTION
## Summary
- restore coverage tab to single-column grid to avoid side-by-side layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3230acac8327a184e5d8dd15dfc7