### PR TITLE
refactor calendar day counts

### DIFF
--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -81,16 +81,25 @@ export default function CalendarView({ vacancies }: Props) {
         {days.map((d) => {
           const iso = isoDate(d.date);
           const allEvents = (eventsByDate[iso] || []) as any[];
-          const events = showFilled
-            ? allEvents
-            : allEvents.filter(
-                (e) => (e as any).status !== "Filled" && (e as any).status !== "Awarded",
-              );
-          const open = events.filter((e) => (e as any).status === "Open").length;
-          const pending = events.filter((e) => (e as any).status === "Pending").length;
-          const filled = allEvents.filter(
-            (e) => (e as any).status === "Filled" || (e as any).status === "Awarded",
-          ).length;
+
+          const { open, pending, filled, visible } = React.useMemo(
+            () =>
+              allEvents.reduce(
+                (acc, e) => {
+                  const status =
+                    (e as any).status === "Awarded" ? "Filled" : (e as any).status;
+                  if (status === "Open") acc.open++;
+                  else if (status === "Pending") acc.pending++;
+                  else if (status === "Filled") acc.filled++;
+                  if (status !== "Filled") acc.visible.push(e);
+                  return acc;
+                },
+                { open: 0, pending: 0, filled: 0, visible: [] as any[] },
+              ),
+            [allEvents],
+          );
+
+          const events = showFilled ? allEvents : visible;
           return (
             <div
               key={iso}


### PR DESCRIPTION
## Summary
- use a single reduce in `CalendarView` to gather open/pending/filled counts
- memoize day counts and reuse them for badge rendering

## Testing
- `npm test` *(fails: Unable to find an element with the text: Bulk Award)*

------
https://chatgpt.com/codex/tasks/task_e_68bb345a4b708327a2a3479a2afa6aa5