### PR TITLE
Bundle multi-day vacancies with single-award flag

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -461,14 +461,13 @@ export default function App() {
     const chosenDays =
       coverage?.selectedDates?.length ? coverage.selectedDates : allDays;
     const isBundle = chosenDays.length >= 2;
-    const bundleId = isBundle
-      ? `BND-${Math.random().toString(36).slice(2, 8).toUpperCase()}`
-      : undefined;
+    const bid = isBundle ? crypto.randomUUID() : undefined;
+    if (bid) console.debug("[bundle] created", bid, { days: chosenDays.length });
     const nowISO = new Date().toISOString();
     const vxs: Vacancy[] = chosenDays.map((d) => ({
       id: `VAC-${Math.random().toString(36).slice(2, 7).toUpperCase()}`,
       vacationId: vac.id,
-      ...(bundleId ? { bundleId } : {}),
+      ...(bid ? { bundleId: bid, bundleMode: "one-person" } : {}),
       reason: "Vacation Backfill",
       classification: vac.classification,
       wing: coverage?.perDayWing?.[d] ?? v.wing!,

--- a/src/lib/bundles.ts
+++ b/src/lib/bundles.ts
@@ -1,0 +1,4 @@
+export function ensureBundleId<T extends { bundleId?: string }>(v: T): string {
+  if (!v.bundleId) v.bundleId = crypto.randomUUID();
+  return v.bundleId;
+}

--- a/src/lib/expandRange.ts
+++ b/src/lib/expandRange.ts
@@ -9,14 +9,13 @@ export function expandRangeToVacancies(range: VacancyRange): Vacancy[] {
   const sortedDays = [...range.workingDays].sort();
   const coverageDates =
     range.startDate === range.endDate ? undefined : sortedDays;
-  const bundleId =
-    sortedDays.length > 1
-      ? `BND-${Math.random().toString(36).slice(2, 7).toUpperCase()}`
-      : undefined;
+  const days = sortedDays.length;
+  const bundleId = days > 1 ? crypto.randomUUID() : undefined;
+  if (bundleId) console.debug("[bundle] created", bundleId, { days });
 
   return sortedDays.map<Vacancy>((d) => ({
     id: `VAC-${Math.random().toString(36).slice(2, 7).toUpperCase()}`,
-    ...(bundleId ? { bundleId } : {}),
+    ...(bundleId ? { bundleId, bundleMode: "one-person" } : {}),
     reason: range.reason,
     classification: range.classification,
     wing: range.wing,

--- a/src/optional/bulk-utils.ts
+++ b/src/optional/bulk-utils.ts
@@ -1,3 +1,4 @@
+import { ensureBundleId } from "../lib/bundles";
 
 export type Bid = { employeeId: string; rank?: number; note?: string };
 export type Vacancy = {
@@ -8,23 +9,16 @@ export type Vacancy = {
   status?: "Open" | "Awarded" | "Filled";
 };
 
-export function ensureBundleId(v: Vacancy, genId: () => string): string {
-  if (v.bundleId) return v.bundleId;
-  v.bundleId = genId();
-  return v.bundleId;
-}
-
 /** Attach a set of vacancy ids into the target vacancy's bundle (create if missing). */
 export function attachVacanciesToTargetBundle(
   all: Vacancy[],
   targetVacancyId: string,
-  attachIds: string[],
-  genId: () => string
+  attachIds: string[]
 ): Vacancy[] {
   const byId = new Map(all.map(v => [v.id, v]));
   const target = byId.get(targetVacancyId);
   if (!target) return all;
-  const bid = ensureBundleId(target, genId);
+  const bid = ensureBundleId(target);
   for (const id of attachIds) {
     if (id === targetVacancyId) continue;
     const v = byId.get(id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export type Vacancy = {
   id: string;
   vacationId?: string;
   bundleId?: string; // identifier linking multi-day vacancy children
+  bundleMode?: "one-person" | "per-day";
   reason: string;
   classification: Classification;
   wing?: string;


### PR DESCRIPTION
## Summary
- generate a single bundle id for multi-day vacancy submissions
- track bundleMode `"one-person"` on bundled vacancies
- add helper to ensure bundle ids and log bundle creation

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Parameter 'e' implicitly has an 'any' type in CalendarView.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4cdf15ec83279217170a01e63d6b