### PR TITLE
feat: add block award option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -425,6 +425,19 @@ export default function App() {
     perDayTimes?: Record<string, { start: string; end: string }>;
     perDayWing?: Record<string, string>;
   } | null>(null);
+  const [awardAsBlock, setAwardAsBlock] = useState(true);
+
+  const dayCount = useMemo(() => {
+    if (!newVacay.startDate || !newVacay.endDate) return 0;
+    const allDays = dateRangeInclusive(newVacay.startDate, newVacay.endDate);
+    const chosen =
+      coverage?.selectedDates?.length ? coverage.selectedDates : allDays;
+    return chosen.length;
+  }, [newVacay.startDate, newVacay.endDate, coverage]);
+
+  useEffect(() => {
+    if (dayCount >= 2) setAwardAsBlock(true);
+  }, [dayCount]);
 
   // Actions
   const addVacationAndGenerate = (
@@ -460,7 +473,7 @@ export default function App() {
     const allDays = dateRangeInclusive(v.startDate!, v.endDate!);
     const chosenDays =
       coverage?.selectedDates?.length ? coverage.selectedDates : allDays;
-    const isBundle = chosenDays.length >= 2;
+    const isBundle = awardAsBlock && chosenDays.length >= 2;
     const bid = isBundle ? crypto.randomUUID() : undefined;
     if (bid) console.debug("[bundle] created", bid, { days: chosenDays.length });
     const nowISO = new Date().toISOString();
@@ -498,8 +511,8 @@ export default function App() {
     setMultiDay(false);
   };
 
-  const handleSaveRange = (range: VacancyRange) => {
-    const vxs = expandRangeToVacancies(range);
+  const handleSaveRange = (range: VacancyRange, awardAsBlock: boolean) => {
+    const vxs = expandRangeToVacancies(range, awardAsBlock);
     setVacancies((prev) => [...vxs, ...prev]);
   };
 
@@ -1095,6 +1108,22 @@ export default function App() {
                     >
                       Edit coverage days
                     </button>
+                  )}
+                  {dayCount >= 2 && (
+                    <label
+                      style={{ gridColumn: "1 / -1" }}
+                      className="flex items-center gap-2"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={awardAsBlock}
+                        onChange={(e) => setAwardAsBlock(e.target.checked)}
+                      />
+                      <span>
+                        Award this whole vacancy (all {dayCount} days) to one
+                        person
+                      </span>
+                    </label>
                   )}
                   <div>
                     <label>Shift</label>

--- a/src/components/VacancyRangeForm.tsx
+++ b/src/components/VacancyRangeForm.tsx
@@ -7,7 +7,7 @@ import { formatDateLong } from "../lib/dates";
 type Props = {
   open: boolean;
   onClose: () => void;
-  onSave: (range: VacancyRange) => void;
+  onSave: (range: VacancyRange, awardAsBlock: boolean) => void;
   defaultClassification?: Classification;
   defaultWing?: string;
   existingVacancies?: Vacancy[];
@@ -35,6 +35,7 @@ export default function VacancyRangeForm({
   const [perDayTimes, setPerDayTimes] = useState<Record<string, { start: string; end: string }>>({});
   const [perDayWings, setPerDayWings] = useState<Record<string, string>>({});
   const [showCoverageModal, setShowCoverageModal] = useState(false);
+  const [awardAsBlock, setAwardAsBlock] = useState(true);
 
   const allDays = useMemo(() => {
     if (!startDate || !endDate) return [];
@@ -55,6 +56,12 @@ export default function VacancyRangeForm({
       setPerDayWings({});
     }
   }, [allDays]);
+
+  const dayCount = workingDays.length;
+
+  React.useEffect(() => {
+    if (dayCount >= 2) setAwardAsBlock(true);
+  }, [dayCount]);
 
   function save() {
     if (!startDate || !endDate || workingDays.length === 0) return;
@@ -99,7 +106,7 @@ export default function VacancyRangeForm({
       offeringStep: "Casuals",
       status: "Open",
     };
-    onSave(range);
+    onSave(range, awardAsBlock);
     onClose();
   }
 
@@ -169,6 +176,19 @@ export default function VacancyRangeForm({
               )}
             </div>
           </div>
+        )}
+
+        {dayCount >= 2 && (
+          <label className="mt-4 flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={awardAsBlock}
+              onChange={(e) => setAwardAsBlock(e.target.checked)}
+            />
+            <span>
+              Award this whole vacancy (all {dayCount} days) to one person
+            </span>
+          </label>
         )}
 
         <div className="mt-4 flex justify-end gap-2">

--- a/src/lib/expandRange.ts
+++ b/src/lib/expandRange.ts
@@ -4,13 +4,16 @@ import type { Vacancy, VacancyRange } from "../types";
  * Expand a VacancyRange into individual Vacancy objects that the
  * application already understands.
  */
-export function expandRangeToVacancies(range: VacancyRange): Vacancy[] {
+export function expandRangeToVacancies(
+  range: VacancyRange,
+  awardAsBlock = true,
+): Vacancy[] {
   const nowISO = new Date().toISOString();
   const sortedDays = [...range.workingDays].sort();
   const coverageDates =
     range.startDate === range.endDate ? undefined : sortedDays;
   const days = sortedDays.length;
-  const bundleId = days > 1 ? crypto.randomUUID() : undefined;
+  const bundleId = awardAsBlock && days > 1 ? crypto.randomUUID() : undefined;
   if (bundleId) console.debug("[bundle] created", bundleId, { days });
 
   return sortedDays.map<Vacancy>((d) => ({

--- a/tests/expandRangeToVacancies.test.ts
+++ b/tests/expandRangeToVacancies.test.ts
@@ -73,5 +73,25 @@ describe("expandRangeToVacancies", () => {
     expect(vxs).toHaveLength(1);
     expect(vxs[0].coverageDates).toBeUndefined();
   });
+
+  it("does not bundle vacancies when awardAsBlock is false", () => {
+    const range: VacancyRange = {
+      id: "r3",
+      reason: "Backfill",
+      classification: "RCA",
+      startDate: "2025-01-10",
+      endDate: "2025-01-11",
+      knownAt: "2025-01-01T00:00:00Z",
+      workingDays: ["2025-01-10", "2025-01-11"],
+      shiftStart: "06:30",
+      shiftEnd: "14:30",
+      offeringStep: "Casuals",
+      status: "Open",
+    };
+
+    const vxs = expandRangeToVacancies(range, false);
+    expect(vxs).toHaveLength(2);
+    expect(vxs.every((v) => v.bundleId === undefined)).toBe(true);
+  });
 });
 


### PR DESCRIPTION
## Summary
- allow bundling multi-day vacancy ranges via "Award this whole vacancy" checkbox
- conditionally bundle ranges in vacancy expansion
- test non-bundled range expansion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5236b0e0832783631dc7fa695666