### PR TITLE
Add bundle-aware award flow and support awarding bundles

### DIFF
--- a/src/lib/vacancy.ts
+++ b/src/lib/vacancy.ts
@@ -95,7 +95,7 @@ export const applyAwardVacancy = (
     v.id === vacId
       ? {
           ...v,
-          status: "Filled",
+          status: "Awarded",
           awardedTo: empId,
           awardedAt: new Date().toISOString(),
           awardReason: payload.reason,
@@ -111,6 +111,26 @@ export const applyAwardVacancies = (
   payload: { empId?: string; reason?: string; overrideUsed?: boolean },
 ): Vacancy[] => {
   return vacIds.reduce((prev, id) => applyAwardVacancy(prev, id, payload), vacs);
+};
+
+export const applyAwardBundle = (
+  vacs: Vacancy[],
+  bundleId: string,
+  payload: { empId?: string; reason?: string; overrideUsed?: boolean },
+): Vacancy[] => {
+  const empId = payload.empId === "EMPTY" ? undefined : payload.empId;
+  return vacs.map<Vacancy>((v) =>
+    v.bundleId === bundleId
+      ? {
+          ...v,
+          status: "Awarded",
+          awardedTo: empId,
+          awardedAt: new Date().toISOString(),
+          awardReason: payload.reason,
+          overrideUsed: !!payload.overrideUsed,
+        }
+      : v,
+  );
 };
 
 export const archiveBidsForVacancy = (

--- a/tests/awardBundle.test.tsx
+++ b/tests/awardBundle.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import App from "../src/App";
+
+const LS_KEY = "maplewood-scheduler-v3";
+
+const baseState = {
+  employees: [
+    {
+      id: "e1",
+      firstName: "Alice",
+      lastName: "A",
+      classification: "RN",
+      status: "FT",
+      seniorityRank: 1,
+      active: true,
+    },
+  ],
+  vacations: [],
+  bids: [],
+  settings: {},
+};
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("bundle award", () => {
+  test("awards all days when confirming", async () => {
+    localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({
+        ...baseState,
+        vacancies: [
+          {
+            id: "v1",
+            reason: "Test",
+            classification: "RN",
+            shiftDate: "2024-01-01",
+            shiftStart: "08:00",
+            shiftEnd: "16:00",
+            knownAt: "2024-01-01T00:00:00.000Z",
+            offeringTier: "CASUALS",
+            offeringStep: "Casuals",
+            status: "Open",
+            bundleId: "b1",
+            bundleMode: "one-person",
+          },
+          {
+            id: "v2",
+            reason: "Test",
+            classification: "RN",
+            shiftDate: "2024-01-02",
+            shiftStart: "08:00",
+            shiftEnd: "16:00",
+            knownAt: "2024-01-01T00:00:00.000Z",
+            offeringTier: "CASUALS",
+            offeringStep: "Casuals",
+            status: "Open",
+            bundleId: "b1",
+            bundleMode: "one-person",
+          },
+        ],
+      }),
+    );
+
+    const confirmMock = vi
+      .spyOn(window, "confirm")
+      .mockImplementation(() => true);
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    const row = screen
+      .getAllByRole("row")
+      .find((r) => within(r).queryByText("Allow class override"))!;
+    const input = within(row).getByPlaceholderText(/Type name or ID/);
+    fireEvent.change(input, { target: { value: "Alice" } });
+    const option = await screen.findByText(/Alice A/);
+    fireEvent.click(option);
+    fireEvent.click(within(row).getByText("Award"));
+
+    expect(confirmMock).toHaveBeenCalledWith(
+      "Award all days in this bundle to Alice A? (2 days)",
+    );
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem(LS_KEY)!);
+      const statuses = stored.vacancies.map((v: any) => v.status);
+      if (!statuses.every((s: string) => s === "Awarded")) {
+        throw new Error("not yet");
+      }
+    });
+
+    const stored = JSON.parse(localStorage.getItem(LS_KEY)!);
+    const v1 = stored.vacancies.find((v: any) => v.id === "v1");
+    const v2 = stored.vacancies.find((v: any) => v.id === "v2");
+    expect(v1.status).toBe("Awarded");
+    expect(v2.status).toBe("Awarded");
+    expect(v1.awardedTo).toBe("e1");
+    expect(v2.awardedTo).toBe("e1");
+  });
+});
+

--- a/tests/awardVacancy.test.ts
+++ b/tests/awardVacancy.test.ts
@@ -16,7 +16,7 @@ describe("applyAwardVacancy", () => {
       status: "Open",
     };
     const updated = applyAwardVacancy([vac], "v1", { empId: "EMPTY" });
-    expect(updated[0].status).toBe("Filled");
+    expect(updated[0].status).toBe("Awarded");
     expect(updated[0].awardedTo).toBeUndefined();
     expect(updated[0].awardReason).toBeUndefined();
   });
@@ -74,8 +74,8 @@ describe("applyAwardVacancy", () => {
     const v2 = updated.find((v) => v.id === "v2")!;
     const v3 = updated.find((v) => v.id === "v3")!;
 
-    expect(v1.status).toBe("Filled");
-    expect(v2.status).toBe("Filled");
+    expect(v1.status).toBe("Awarded");
+    expect(v2.status).toBe("Awarded");
     expect(v1.awardedTo).toBeUndefined();
     expect(v2.awardedTo).toBeUndefined();
     expect(v1.awardedTo).toBe(v2.awardedTo);

--- a/tests/awardVacancy.test.tsx
+++ b/tests/awardVacancy.test.tsx
@@ -86,14 +86,14 @@ describe("award vacancy UI", () => {
     await waitFor(() => {
       const stored = JSON.parse(localStorage.getItem(LS_KEY)!);
       const v1 = stored.vacancies.find((v: any) => v.id === "v1");
-      if (v1?.status !== "Filled") throw new Error("not yet");
+      if (v1?.status !== "Awarded") throw new Error("not yet");
     });
 
     const stored = JSON.parse(localStorage.getItem(LS_KEY)!);
     const v1 = stored.vacancies.find((v: any) => v.id === "v1");
     const v2 = stored.vacancies.find((v: any) => v.id === "v2");
-    expect(v1.status).toBe("Filled");
-    expect(v2.status).toBe("Filled");
+    expect(v1.status).toBe("Awarded");
+    expect(v2.status).toBe("Awarded");
     expect(v1.awardedTo).toBe("e1");
     expect(v2.awardedTo).toBe("e1");
     expect(v1.awardReason).toBe(reason);

--- a/tests/bulkAwardVacancies.test.ts
+++ b/tests/bulkAwardVacancies.test.ts
@@ -17,8 +17,8 @@ describe("applyAwardVacancies", () => {
     };
     const vac2: Vacancy = { ...vac1, id: "v2" };
     const updated = applyAwardVacancies([vac1, vac2], ["v1", "v2"], { empId: "e1" });
-    expect(updated[0].status).toBe("Filled");
-    expect(updated[1].status).toBe("Filled");
+    expect(updated[0].status).toBe("Awarded");
+    expect(updated[1].status).toBe("Awarded");
     expect(updated[0].awardedTo).toBe("e1");
     expect(updated[1].awardedTo).toBe("e1");
     expect(updated[0].awardReason).toBeUndefined();


### PR DESCRIPTION
## Summary
- Mark awarded vacancies with status `Awarded` instead of `Filled`
- Prompt and apply awards across one-person bundles with new `applyAwardBundle`
- Add regression tests for bundle award and update existing award tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb56a137ec8327bbd8ef56ca4f04ce