### PR TITLE
feat: add bundle grouping toggle

### DIFF
--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -54,7 +54,6 @@ export default function BundleRow({
 
   const wingText = primary.wing ?? "Wing";
   const coverText = coveredName ? ` • Covering ${coveredName}` : "";
-  const title = `${items.length} days • ${wingText} • ${primary.classification}${coverText}`;
   const dateList = sorted.map((v) => formatDateLong(v.shiftDate)).join(", ");
 
   const rec = recommendations[primary.id];
@@ -85,7 +84,15 @@ export default function BundleRow({
           ariaLabel="Select bundle"
         />
         <CellDetails
-          title={<div style={{ fontWeight: 600 }}>{title}</div>}
+          title={
+            <div style={{ fontWeight: 600, display: "flex", alignItems: "center", gap: 8 }}>
+              <span className="pill">{items.length} days</span>
+              <span>
+                {wingText} • {primary.classification}
+                {coverText}
+              </span>
+            </div>
+          }
           subtitle={
             <div
               style={{

--- a/tests/awardBundle.test.tsx
+++ b/tests/awardBundle.test.tsx
@@ -77,6 +77,8 @@ describe("bundle award", () => {
       </MemoryRouter>,
     );
 
+    fireEvent.click(screen.getAllByLabelText("Group by bundle")[0]);
+
     const row = screen
       .getAllByRole("row")
       .find((r) => within(r).queryByText("Allow class override"))!;

--- a/tests/openVacancies.test.tsx
+++ b/tests/openVacancies.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import OpenVacancies from "../src/components/OpenVacancies";
 import useVacancies from "../src/state/useVacancies";
 
@@ -15,6 +15,7 @@ function setupLocalStorage(vacancies: any[] = [], auditLog: any[] = []) {
   beforeEach(() => {
     localStorage.clear();
   });
+  afterEach(cleanup);
 
   it("renders delete buttons with tooltip", () => {
     const vacancies = [
@@ -185,7 +186,7 @@ function setupLocalStorage(vacancies: any[] = [], auditLog: any[] = []) {
       }
 
       const { container } = render(<Wrapper />);
-
+      fireEvent.click(screen.getAllByLabelText("Group by bundle")[0]);
       const buttons = container.querySelectorAll('[data-testid^="vacancy-delete-"]');
       expect(buttons.length).toBe(1);
     });


### PR DESCRIPTION
## Summary
- add 'Group by bundle' toggle to vacancy lists
- show bundled rows with day count chip and expand/collapse
- update bundle row chip styling and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb57d7408883278ce8aaa137e42d43