### PR TITLE
Add bundle award tests and adjust tsconfig for Vitest

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ export type Vacancy = {
   id: string;
   vacationId?: string;
   bundleId?: string;
+  bundleMode?: "one-person" | "per-day";
   reason: string; // e.g. Vacation Backfill
   classification: Classification;
   wing?: string;

--- a/src/__tests__/bundles.test.ts
+++ b/src/__tests__/bundles.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { expandRangeToVacancies } from "../lib/expandRange";
+import { applyAwardBundle } from "../lib/vacancy";
+import { getDatesInRange } from "../utils/date";
+import type { VacancyRange } from "../types";
+
+const makeRange = (start: string, end: string): VacancyRange => ({
+  id: "r1",
+  reason: "Test",
+  classification: "RCA",
+  startDate: start,
+  endDate: end,
+  knownAt: "2025-09-01T00:00:00Z",
+  workingDays: getDatesInRange(start, end),
+  shiftStart: "06:30",
+  shiftEnd: "14:30",
+  offeringStep: "Casuals",
+  status: "Open",
+});
+
+describe("bundles", () => {
+  it("creates one bundleId for 2+ day ranges when awardAsBlock=true", () => {
+    const vs = expandRangeToVacancies(makeRange("2025-09-10", "2025-09-12"), true);
+    const ids = new Set(vs.map(v => v.bundleId));
+    expect(ids.size).toBe(1);
+    expect(vs.every(v => v.bundleMode === "one-person")).toBe(true);
+  });
+
+  it("awards all days in bundle with one call", () => {
+    let vs = expandRangeToVacancies(makeRange("2025-09-10", "2025-09-12"), true);
+    const bid = vs[0].bundleId!;
+    vs = applyAwardBundle(vs, bid, { empId: "emp-123" });
+    expect(vs.every(v => v.status === "Awarded" && v.awardedTo === "emp-123")).toBe(true);
+  });
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
   "include": [
     "src",
     "src/**/*.d.ts"
-  ]
+  ],
+  "exclude": ["src/__tests__"]
 }

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest"]
+  },
+  "include": ["src/__tests__", "tests"]
+}


### PR DESCRIPTION
## Summary
- add Vitest coverage for bundled vacancy ranges and award propagation
- exclude test sources from production builds
- ensure tests compile with Node and Vitest types
- type App Vacancy with bundle mode for build stability

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb5e572c1483279547757dbf6467be