### PR TITLE
Check bundle conflicts before award

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -624,14 +624,18 @@ const [showRangeForm, setShowRangeForm] = useState(false);
         ),
       )
       .map((v) => formatDateLong(v.shiftDate));
+    let reason: string | undefined;
     if (conflictDays.length) {
-      console.warn(
-        `Employee already assigned on ${conflictDays.join(", ")}.`,
-      );
+      const msg =
+        `Employee already assigned on:\n${conflictDays.join("\n")}\nOverride and award bundle?`;
+      if (!window.confirm(msg)) return;
+      const rc = window.prompt("Enter reason code for override")?.trim();
+      if (!rc) return;
+      reason = rc;
     }
     const snapshot = kids.map((k) => ({ ...k }));
     ensureBundleBids(kids, employeeId);
-    applyAwardBundle(bundleId, employeeId, "Bundle award");
+    applyAwardBundle(bundleId, employeeId, reason || "Bundle award");
     archiveBids(kids.map((v) => v.id));
 
     const emp = employeesById[employeeId];

--- a/tests/awardBundle.test.tsx
+++ b/tests/awardBundle.test.tsx
@@ -73,7 +73,9 @@ describe("bundle award", () => {
       </MemoryRouter>,
     );
 
-    fireEvent.click(screen.getAllByLabelText("Group by bundle")[0]);
+    screen
+      .getAllByLabelText("Group by bundle")
+      .forEach((cb) => fireEvent.click(cb));
 
     const awardBtn = await screen.findByText("Award Bundle");
     fireEvent.click(awardBtn);
@@ -96,6 +98,97 @@ describe("bundle award", () => {
     expect(v2.status).toBe("Awarded");
     expect(v1.awardedTo).toBe("e1");
     expect(v2.awardedTo).toBe("e1");
+  });
+
+  test("prompts on conflicts and allows override with reason", async () => {
+    const reason = "Manager discretion";
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.spyOn(window, "prompt").mockReturnValue(reason);
+
+    localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({
+        ...baseState,
+        vacancies: [
+          {
+            id: "v1",
+            reason: "Test",
+            classification: "RN",
+            shiftDate: "2024-01-01",
+            shiftStart: "08:00",
+            shiftEnd: "16:00",
+            knownAt: "2024-01-01T00:00:00.000Z",
+            offeringTier: "CASUALS",
+            offeringStep: "Casuals",
+            status: "Open",
+            bundleId: "b1",
+            bundleMode: "one-person",
+          },
+          {
+            id: "v2",
+            reason: "Test",
+            classification: "RN",
+            shiftDate: "2024-01-01",
+            shiftStart: "16:00",
+            shiftEnd: "23:00",
+            knownAt: "2024-01-01T00:00:00.000Z",
+            offeringTier: "CASUALS",
+            offeringStep: "Casuals",
+            status: "Open",
+            bundleId: "b1",
+            bundleMode: "one-person",
+          },
+          {
+            id: "c1",
+            reason: "Existing",
+            classification: "RN",
+            shiftDate: "2024-01-01",
+            shiftStart: "08:00",
+            shiftEnd: "16:00",
+            knownAt: "2024-01-01T00:00:00.000Z",
+            offeringTier: "CASUALS",
+            offeringStep: "Casuals",
+            status: "Awarded",
+            awardedTo: "e1",
+          },
+        ],
+      }),
+    );
+
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>,
+    );
+
+    screen
+      .getAllByLabelText("Group by bundle")
+      .forEach((cb) => fireEvent.click(cb));
+
+    const awardBtn = await screen.findByText("Award Bundle");
+    fireEvent.click(awardBtn);
+
+    const pick = await screen.findByRole("button", { name: /Alice A/ });
+    fireEvent.click(pick);
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem(LS_KEY)!);
+      const statuses = stored.vacancies
+        .filter((v: any) => v.bundleId === "b1")
+        .map((v: any) => v.status);
+      if (!statuses.every((s: string) => s === "Awarded")) {
+        throw new Error("not yet");
+      }
+    });
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(window.prompt).toHaveBeenCalled();
+
+    const stored = JSON.parse(localStorage.getItem(LS_KEY)!);
+    const v1 = stored.vacancies.find((v: any) => v.id === "v1");
+    const v2 = stored.vacancies.find((v: any) => v.id === "v2");
+    expect(v1.awardReason).toBe(reason);
+    expect(v2.awardReason).toBe(reason);
   });
 });
 


### PR DESCRIPTION
## Summary
- confirm and gather override reason when employee has conflicts across bundle days
- test bundle award conflict handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb63fa28388327bb543696d3672cdf