### PR TITLE
Add bundle helpers and block/single list component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,8 +25,7 @@ import OpenVacanciesRedesign from "./components/OpenVacanciesRedesign";
 import { appConfig } from "./config";
 import type { VacancyRange, VacancyStatus, BundleMode } from "./types";
 export { OVERRIDE_REASONS } from "./types";
-import { expandRangeToVacancies } from "./lib/expandRange";
-import { bundleContiguousVacanciesByRef } from "./lib/bundles";
+import { createVacanciesFromRange, bundleContiguousVacanciesByRef } from "./lib/bundles";
 import Toast from "./components/ui/Toast";
 
 /**
@@ -535,8 +534,8 @@ const [showRangeForm, setShowRangeForm] = useState(false);
     setMultiDay(false);
   };
 
-  const handleSaveRange = (range: VacancyRange, awardAsBlock: boolean) => {
-    const vxs = expandRangeToVacancies(range, awardAsBlock);
+  const handleSaveRange = (range: VacancyRange, _awardAsBlock: boolean) => {
+    const vxs = createVacanciesFromRange(range);
     setVacancies((prev) => [...vxs, ...prev]);
   };
 

--- a/src/components/BlocksAndSingles.tsx
+++ b/src/components/BlocksAndSingles.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from "react";
+import type { Vacancy } from "../types";
+
+interface Props {
+  vacancies: Vacancy[];
+  onAwardBundle: (bundleId: string) => void;
+  onDeleteBundle: (bundleId: string) => void;
+  onDeleteSingle: (id: string) => void;
+}
+
+export default function BlocksAndSingles({
+  vacancies,
+  onAwardBundle,
+  onDeleteBundle,
+  onDeleteSingle,
+}: Props) {
+  const { blocks, singles } = useMemo(() => {
+    const groups = new Map<string, Vacancy[]>();
+    const singles: Vacancy[] = [];
+    for (const v of vacancies) {
+      if (v.bundleId) {
+        const arr = groups.get(v.bundleId) || [];
+        arr.push(v);
+        groups.set(v.bundleId, arr);
+      } else {
+        singles.push(v);
+      }
+    }
+    const blocks = Array.from(groups.entries()).filter(([, arr]) => arr.length >= 2);
+    for (const [id, arr] of groups) {
+      if (arr.length < 2) singles.push(...arr);
+    }
+    blocks.sort((a, b) => a[1][0].shiftDate.localeCompare(b[1][0].shiftDate));
+    singles.sort((a, b) =>
+      a.shiftDate === b.shiftDate
+        ? a.shiftStart.localeCompare(b.shiftStart)
+        : a.shiftDate.localeCompare(b.shiftDate)
+    );
+    return { blocks, singles };
+  }, [vacancies]);
+
+  return (
+    <table className="vacancies">
+      <tbody>
+        {blocks.map(([id, items]) => (
+          <tr key={id}>
+            <td>
+              <strong>
+                Block: {items[0].shiftDate} – {items[items.length - 1].shiftDate}
+              </strong>{" "}
+              ({items.length} days)
+            </td>
+            <td>
+              <button className="btn btn-sm" onClick={() => onAwardBundle(id)}>
+                Award
+              </button>
+              <button
+                className="btn btn-sm danger"
+                onClick={() => onDeleteBundle(id)}
+                style={{ marginLeft: 8 }}
+              >
+                Delete
+              </button>
+            </td>
+          </tr>
+        ))}
+        {singles.map((v) => (
+          <tr key={v.id}>
+            <td>
+              {v.shiftDate} • {v.shiftStart}–{v.shiftEnd} • {v.classification}
+            </td>
+            <td>
+              <button
+                className="btn btn-sm danger"
+                onClick={() => onDeleteSingle(v.id)}
+              >
+                Delete
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/lib/bundles.ts
+++ b/src/lib/bundles.ts
@@ -1,4 +1,6 @@
-import type { Vacancy } from "../types";
+import type { Vacancy, VacancyRange } from "../types";
+import { expandRangeToVacancies } from "./expandRange";
+import { applyAwardBundle } from "./vacancy";
 
 export function ensureBundleId<T extends { bundleId?: string }>(v: T): string {
   if (!v.bundleId) v.bundleId = crypto.randomUUID();
@@ -50,4 +52,25 @@ export function bundleContiguousVacanciesByRef(vacs: Vacancy[]): Vacancy[] {
   }
 
   return vacs;
+}
+
+/** Expand a multi-day range into individual vacancies.
+ * Automatically assigns a single bundleId when the range spans two or more days.
+ */
+export function createVacanciesFromRange(range: VacancyRange): Vacancy[] {
+  return expandRangeToVacancies(range, true);
+}
+
+/** Award every vacancy within a bundle to the given employee. */
+export function awardBundle(
+  vacs: Vacancy[],
+  bundleId: string,
+  employeeId: string,
+): Vacancy[] {
+  return applyAwardBundle(vacs, bundleId, { empId: employeeId });
+}
+
+/** Remove all vacancies belonging to the given bundle. */
+export function deleteBundle(vacs: Vacancy[], bundleId: string): Vacancy[] {
+  return vacs.filter((v) => v.bundleId !== bundleId);
 }

--- a/src/optional/README-Bundles-Blocks.md
+++ b/src/optional/README-Bundles-Blocks.md
@@ -1,0 +1,28 @@
+# Bundles & Blocks
+
+This project supports automatic bundling of multi‑day vacancy ranges. When a range spans two or more days a single `bundleId` is assigned and the UI treats the group as one **Block**.
+
+## Creating vacancies
+
+Use `createVacanciesFromRange` to expand a date range into individual vacancies. The helper automatically assigns a `bundleId` when appropriate:
+
+```ts
+import { createVacanciesFromRange } from "../lib/bundles";
+const vacancies = createVacanciesFromRange(fields);
+setVacancies(prev => [...prev, ...vacancies]);
+```
+
+## Listing vacancies
+
+The `BlocksAndSingles` component renders bundled blocks first and then single day vacancies. It accepts callbacks for awarding or deleting entire bundles and for deleting individual vacancies:
+
+```tsx
+<BlocksAndSingles
+  vacancies={vacancies}
+  onAwardBundle={(id) => awardBundle(id)}
+  onDeleteBundle={(id) => deleteBundle(id)}
+  onDeleteSingle={(id) => remove(id)}
+/>
+```
+
+`awardBundle` and `deleteBundle` helpers are available from `lib/bundles`.


### PR DESCRIPTION
## Summary
- add bundle utilities: `createVacanciesFromRange`, `awardBundle`, and `deleteBundle`
- introduce `BlocksAndSingles` component to display bundled blocks before single vacancies
- document bundle and block usage in optional README
- use new helper in multi-day save handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6f42c0948327b545a4f5abbffd43