### PR TITLE
Improve vacancy creation and reward process

### DIFF
--- a/src/lib/expandRange.ts
+++ b/src/lib/expandRange.ts
@@ -27,7 +27,7 @@ export function expandRangeToVacancies(
       : {}),
     reason: range.reason,
     classification: range.classification,
-    wing: range.wing,
+    wing: range.perDayWings?.[d] ?? range.wing,
     date: d,
     start: range.perDayTimes?.[d]?.start ?? range.shiftStart ?? "06:30",
     end: range.perDayTimes?.[d]?.end ?? range.shiftEnd ?? "14:30",


### PR DESCRIPTION
Apply per-day wing selections when expanding multi-day vacancy ranges to correctly reflect user-specific daily choices.

Previously, multi-day vacancies would use a single wing for all days, even if per-day wing selections were provided. This change ensures that individual day-specific wing choices are applied when the vacancy range is expanded, allowing for accurate per-day customization while maintaining the ability to bundle and award the entire multi-day vacancy as a single unit.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba492a6a-0805-48e7-b222-d8b5856c036b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba492a6a-0805-48e7-b222-d8b5856c036b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

