### PR TITLE
refactor chess3d move list to accept game instance

### DIFF
--- a/games/chess3d/main.js
+++ b/games/chess3d/main.js
@@ -8,6 +8,7 @@ import {
   movePieceByUci,
 } from './pieces.js';
 import { mountHud } from './ui/hud.js';
+import { mountMoveList } from './ui/moveList.js';
 import { getMode, getDifficulty } from './ui/modeBar.js';
 import { initEngine, requestBestMove, cancel } from './ai/ai.js';
 import { Chess } from 'https://cdn.jsdelivr.net/npm/chess.js@1.0.0/+esm';
@@ -36,7 +37,8 @@ const dirLight = new THREE.DirectionalLight(0xffffff, 0.5);
 dirLight.position.set(10, 10, 0);
 scene.add(dirLight);
 
-const rules = new Chess();
+// Construct the chess game before mounting any UI that depends on it
+const game = new Chess();
 
 createBoard(scene);
 await createPieces(scene, THREE, { squareToPosition });
@@ -45,6 +47,8 @@ document.querySelector('#status')?.textContent = 'Pieces ready';
 
 await initEngine();
 mountHud({ onModeChange });
+// Mount the move list UI with the current game instance
+mountMoveList(game);
 let searchToken = 0;
 
 function onModeChange() {
@@ -54,23 +58,24 @@ function onModeChange() {
 }
 
 function gameOver() {
-  return (rules.game_over && rules.game_over()) || (rules.isGameOver && rules.isGameOver());
+  return (game.game_over && game.game_over()) || (game.isGameOver && game.isGameOver());
 }
 
 async function maybeAIMove() {
   if (gameOver()) return;
   const mode = getMode();
   const aiColor = mode === 'ai-white' ? 'b' : mode === 'ai-black' ? 'w' : null;
-  if (!aiColor || rules.turn() !== aiColor) return;
+  if (!aiColor || game.turn() !== aiColor) return;
   const token = ++searchToken;
-  const fen = rules.fen();
+  const fen = game.fen();
   const depth = getDifficulty();
   const { uci } = await requestBestMove(fen, { depth });
   if (token !== searchToken) return;
   const move = { from: uci.slice(0, 2), to: uci.slice(2, 4) };
   if (uci.length > 4) move.promotion = uci.slice(4);
-  if (!rules.move(move)) return;
+  if (!game.move(move)) return;
   await movePieceByUci(uci);
+  mountMoveList(game);
 }
 
 function humanMove(move) {
@@ -78,9 +83,10 @@ function humanMove(move) {
     typeof move === 'string'
       ? { from: move.slice(0, 2), to: move.slice(2, 4), promotion: move.slice(4) || undefined }
       : move;
-  const result = rules.move(m);
+  const result = game.move(m);
   if (!result) return false;
   movePieceByUci(result.from + result.to + (result.promotion || ''));
+  mountMoveList(game);
   searchToken++;
   maybeAIMove();
   return true;

--- a/games/chess3d/rules.js
+++ b/games/chess3d/rules.js
@@ -1,0 +1,5 @@
+export function historySAN(game) {
+  // Return the history of moves in standard algebraic notation for the given game
+  if (!game) return [];
+  return game.history();
+}

--- a/games/chess3d/ui/moveList.js
+++ b/games/chess3d/ui/moveList.js
@@ -1,0 +1,16 @@
+import { historySAN } from '../rules.js';
+
+// Mount or update the move list UI using the provided game instance
+export function mountMoveList(game) {
+  const container = document.getElementById('move-list');
+  if (!container) return;
+  const moves = historySAN(game);
+  container.innerHTML = '';
+  const list = document.createElement('ol');
+  moves.forEach((san) => {
+    const item = document.createElement('li');
+    item.textContent = san;
+    list.appendChild(item);
+  });
+  container.appendChild(list);
+}


### PR DESCRIPTION
## Summary
- instantiate Chess game before mounting move list
- expose `historySAN(game)` helper and move list UI that accepts a game instance

## Testing
- `npm test` *(fails: TestingLibraryElementError: Unable to find an element with the text: Award Bundle ...)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf460edf748327b183ac90cb87da3d