### PR TITLE
feat: track archived vacancies and bids

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,9 @@ export type Vacancy = {
   awardedAt?: string; // ISO datetime
   awardReason?: string; // audit note when overriding recommendation or class
   overrideUsed?: boolean; // true if class override was toggled
+
+  archived?: boolean;
+  archivedAt?: string; // ISO datetime
 };
 
 export type Bid = {
@@ -591,6 +594,14 @@ const [showRangeForm, setShowRangeForm] = useState(false);
   };
 
   const archiveBids = (vacancyIds: string[]) => {
+    const now = new Date().toISOString();
+    setVacancies((prev) =>
+      prev.map((v) =>
+        vacancyIds.includes(v.id)
+          ? { ...v, archived: true, archivedAt: now }
+          : v,
+      ),
+    );
     setBids((prev) => {
       const remaining: Bid[] = [];
       const archiveMap: Record<string, Bid[]> = {};
@@ -1663,7 +1674,9 @@ const [showRangeForm, setShowRangeForm] = useState(false);
           <EmployeesPage employees={employees} setEmployees={setEmployees} />
         )}
 
-        {tab === "archive" && <ArchivePage vacations={vacations} />}
+        {tab === "archive" && (
+          <ArchivePage vacancies={vacancies} archivedBids={archivedBids} />
+        )}
 
         {tab === "alerts" && (
           <div className="grid">
@@ -1956,40 +1969,68 @@ function EmployeesPage({
   );
 }
 
-function ArchivePage({ vacations }: { vacations: Vacation[] }) {
-  const archived = vacations.filter((v) => v.archived);
+export function ArchivePage({
+  vacancies,
+  archivedBids,
+}: {
+  vacancies: Vacancy[];
+  archivedBids: Record<string, Bid[]>;
+}) {
+  const archived = vacancies.filter((v) => v.archived);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   return (
     <div className="grid">
       <div className="card">
-        <div className="card-h">Archived Vacations (fully covered)</div>
+        <div className="card-h">Archived Vacancies</div>
         <div className="card-c">
           <table className="responsive-table">
-            <thead>
-              <tr>
-                <th>Employee</th>
-                <th>Wing</th>
-                <th>From</th>
-                <th>To</th>
-                <th>Archived</th>
-              </tr>
-            </thead>
             <tbody>
               {archived.map((v) => (
-                <tr key={v.id}>
-                  <td>{v.employeeName}</td>
-                  <td>{v.wing}</td>
-                  <td>{formatDateLong(v.startDate)}</td>
-                  <td>{formatDateLong(v.endDate)}</td>
-                  <td>{new Date(v.archivedAt || "").toLocaleString()}</td>
-                </tr>
+                <Fragment key={v.id}>
+                  <tr
+                    onClick={() =>
+                      setExpanded((prev) => ({ ...prev, [v.id]: !prev[v.id] }))
+                    }
+                    style={{ cursor: "pointer", background: "var(--cardAlt)" }}
+                  >
+                    <td colSpan={5}>{displayVacancyLabel(v)}</td>
+                  </tr>
+                  {expanded[v.id] && (
+                    <Fragment>
+                      <tr>
+                        <th style={{ paddingLeft: 24 }}>Employee</th>
+                        <th>Class</th>
+                        <th>Status</th>
+                        <th>Bid at</th>
+                        <th>Notes</th>
+                      </tr>
+                      {archivedBids[v.id]?.map((b, i) => (
+                        <tr key={i}>
+                          <td style={{ paddingLeft: 24 }}>{b.bidderName}</td>
+                          <td>{b.bidderClassification}</td>
+                          <td>{b.bidderStatus}</td>
+                          <td>{new Date(b.bidTimestamp).toLocaleString()}</td>
+                          <td>{b.notes}</td>
+                        </tr>
+                      ))}
+                      {!(archivedBids[v.id] && archivedBids[v.id].length) && (
+                        <tr>
+                          <td style={{ paddingLeft: 24 }} colSpan={5}>
+                            No bids
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  )}
+                </Fragment>
               ))}
+              {!archived.length && (
+                <tr>
+                  <td>No archived vacancies</td>
+                </tr>
+              )}
             </tbody>
           </table>
-          {!archived.length && (
-            <div className="subtitle" style={{ marginTop: 8 }}>
-              Nothing here yet.
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/src/hooks/useSchedulerState.ts
+++ b/src/hooks/useSchedulerState.ts
@@ -30,7 +30,13 @@ export function useSchedulerState() {
   const [employees, setEmployees] = useState<Employee[]>(persisted?.employees ?? []);
   const [vacations, setVacations] = useState<Vacation[]>(persisted?.vacations ?? []);
   const seededVacancies = bundleContiguousVacanciesByRef(
-    persisted?.vacancies ? [...persisted.vacancies] : [],
+    persisted?.vacancies
+      ? persisted.vacancies.map((v) => ({
+          ...v,
+          archived: v.archived ?? false,
+          archivedAt: v.archivedAt ?? undefined,
+        }))
+      : [],
   );
   const [vacancies, setVacancies] = useState<Vacancy[]>(seededVacancies);
   const [bids, setBids] = useState<Bid[]>(persisted?.bids ?? []);

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,10 @@ export type Vacancy = {
   awardedAt?: string;
   awardReason?: string;
   overrideUsed?: boolean;
-  
+
+  archived?: boolean;
+  archivedAt?: string;
+
   // For multi-day vacancies converted from VacancyRange
   startDate?: string;     // YYYY-MM-DD (when this is part of a range)
   endDate?: string;       // YYYY-MM-DD (when this is part of a range)

--- a/tests/archiveVacancies.test.tsx
+++ b/tests/archiveVacancies.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  ArchivePage,
+  applyAwardVacancy,
+  archiveBidsForVacancy,
+  type Vacancy,
+  type Bid,
+} from "../src/App.tsx";
+import { formatDateLong } from "../src/lib/dates";
+
+const labelFor = (v: Vacancy) =>
+  `${formatDateLong(v.shiftDate)} • ${v.shiftStart}–${v.shiftEnd} • ${v.wing ?? ""} • ${v.classification}`.replace(
+    /\s+•\s+$/,
+    "",
+  );
+
+describe("ArchivePage", () => {
+  it("lists archived vacancies with their bids", () => {
+    const vacancy: Vacancy = {
+      id: "v1",
+      reason: "Test",
+      classification: "RN",
+      date: "2024-01-01",
+      start: "08:00",
+      end: "16:00",
+      shiftDate: "2024-01-01",
+      shiftStart: "08:00",
+      shiftEnd: "16:00",
+      knownAt: "2024-01-01T00:00:00Z",
+      offeringTier: "CASUALS" as any,
+      offeringStep: "Casuals",
+      status: "Open",
+    };
+    const bid: Bid = {
+      vacancyId: "v1",
+      bidderEmployeeId: "e1",
+      bidderName: "Alice",
+      bidderStatus: "FT",
+      bidderClassification: "RN",
+      bidTimestamp: "2024-01-01T00:00:00Z",
+      notes: "hi",
+    };
+
+    const awarded = applyAwardVacancy([vacancy], "v1", { empId: "e1" });
+    const { archivedBids } = archiveBidsForVacancy([bid], {}, "v1");
+    awarded[0].archived = true;
+    awarded[0].archivedAt = "2024-01-02T00:00:00Z";
+
+    render(<ArchivePage vacancies={awarded} archivedBids={archivedBids} />);
+
+    fireEvent.click(screen.getByText(/January 01, 2024/));
+    expect(screen.getByText("Alice")).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add archived metadata to `Vacancy`
- persist archived vacancies and show them with their bids on Archive page
- add regression test for archived vacancies

## Testing
- `npx vitest run tests/archiveVacancies.test.tsx`
- `npm test` *(fails: Unable to find element with text "Award Bundle")*

------
https://chatgpt.com/codex/tasks/task_e_68c1b1a7ef288327b716bc44be616f19