### PR TITLE
feat: add vacancy search filters

### DIFF
--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -4,6 +4,8 @@ import type { Recommendation } from "../recommend";
 import BundleRow from "./BundleRow";
 import VacancyRow from "./VacancyRow";
 import { combineDateTime } from "../lib/dates";
+import SearchFilterBar from "./SearchFilterBar";
+import { useVacancyFilters } from "../hooks/useVacancyFilters";
 
 type Props = {
   vacancies: Vacancy[];
@@ -34,6 +36,16 @@ type Props = {
 
 export default function OpenVacanciesRedesign(props: Props) {
   const { vacancies, vacations, filters, settings, employees, recommendations } = props;
+  const {
+    search,
+    setSearch,
+    start,
+    setStart,
+    end,
+    setEnd,
+    filterClass,
+    setFilterClass,
+  } = useVacancyFilters();
   const employeesById = useMemo(() => {
     const map: Record<string, Employee> = {};
     employees.forEach((e) => {
@@ -52,21 +64,28 @@ export default function OpenVacanciesRedesign(props: Props) {
     let list = vacancies.filter(
       (v) => v.status !== "Filled" && v.status !== "Awarded",
     );
-    if (filters?.search) {
-      const q = filters.search.toLowerCase();
-      list = list.filter(
-        (v) =>
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter((v) => {
+        const employeeName = vacNameById[v.vacationId ?? ""] || "";
+        return (
           (v.reason || "").toLowerCase().includes(q) ||
-          (v.wing || "").toLowerCase().includes(q),
-      );
+          (v.wing || "").toLowerCase().includes(q) ||
+          (v.classification || "").toLowerCase().includes(q) ||
+          employeeName.toLowerCase().includes(q)
+        );
+      });
     }
+    if (filterClass) list = list.filter((v) => v.classification === filterClass);
+    if (start) list = list.filter((v) => v.shiftDate >= start);
+    if (end) list = list.filter((v) => v.shiftDate <= end);
     if (filters?.wing) list = list.filter((v) => (v.wing || "") === filters!.wing);
     if (filters?.classification)
       list = list.filter((v) => v.classification === filters!.classification);
     if (filters?.bundlesOnly) list = list.filter((v) => v.bundleId);
     if (filters?.singlesOnly) list = list.filter((v) => !v.bundleId);
     return list;
-  }, [vacancies, filters]);
+  }, [vacancies, search, filterClass, start, end, filters, vacNameById]);
 
   const [groupByBundle, setGroupByBundle] = useState(true);
 
@@ -124,6 +143,23 @@ export default function OpenVacanciesRedesign(props: Props) {
 
   return (
     <div>
+      <SearchFilterBar
+        query={search}
+        startDate={start}
+        endDate={end}
+        category={filterClass}
+        categories={["RCA", "LPN", "RN"]}
+        onQueryChange={setSearch}
+        onStartDateChange={setStart}
+        onEndDateChange={setEnd}
+        onCategoryChange={(v) => setFilterClass(v as any)}
+        onClear={() => {
+          setSearch("");
+          setStart("");
+          setEnd("");
+          setFilterClass("");
+        }}
+      />
       <div style={{ marginBottom: 8 }}>
         <label style={{ display: "flex", alignItems: "center", gap: 4 }}>
           <input

--- a/src/components/VacancyList.tsx
+++ b/src/components/VacancyList.tsx
@@ -60,10 +60,10 @@ export default function VacancyList({
     setFilterShift,
     filterCountdown,
     setFilterCountdown,
-    filterStart,
-    setFilterStart,
-    filterEnd,
-    setFilterEnd,
+    start,
+    setStart,
+    end,
+    setEnd,
     filtersOpen,
     setFiltersOpen,
   } = useVacancyFilters();
@@ -87,18 +87,18 @@ export default function VacancyList({
         else if (pct < 0.25) cdClass = "yellow";
         if (filterCountdown !== cdClass) return false;
       }
-      if (filterStart && v.shiftDate < filterStart) return false;
-      if (filterEnd && v.shiftDate > filterEnd) return false;
-      return true;
-    });
-  }, [
+      if (start && v.shiftDate < start) return false;
+      if (end && v.shiftDate > end) return false;
+    return true;
+  });
+}, [
     vacancies,
     filterWing,
     filterClass,
     filterShift,
     filterCountdown,
-    filterStart,
-    filterEnd,
+    start,
+    end,
     now,
     settings,
   ]);
@@ -159,8 +159,8 @@ export default function VacancyList({
               <option value="yellow">Yellow</option>
               <option value="red">Red</option>
             </select>
-            <input type="date" value={filterStart} onChange={(e) => setFilterStart(e.target.value)} />
-            <input type="date" value={filterEnd} onChange={(e) => setFilterEnd(e.target.value)} />
+            <input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+            <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
             <button
               className="btn"
               onClick={() => {
@@ -168,8 +168,8 @@ export default function VacancyList({
                 setFilterClass("");
                 setFilterShift("");
                 setFilterCountdown("");
-                setFilterStart("");
-                setFilterEnd("");
+                setStart("");
+                setEnd("");
               }}
             >
               Clear

--- a/src/hooks/useVacancyFilters.ts
+++ b/src/hooks/useVacancyFilters.ts
@@ -6,8 +6,9 @@ export function useVacancyFilters() {
   const [filterClass, setFilterClass] = useState<Classification | "">("");
   const [filterShift, setFilterShift] = useState<string>("");
   const [filterCountdown, setFilterCountdown] = useState<string>("");
-  const [filterStart, setFilterStart] = useState<string>("");
-  const [filterEnd, setFilterEnd] = useState<string>("");
+  const [start, setStart] = useState<string>("");
+  const [end, setEnd] = useState<string>("");
+  const [search, setSearch] = useState<string>("");
   const [filtersOpen, setFiltersOpen] = useState(false);
   return {
     filterWing,
@@ -18,10 +19,12 @@ export function useVacancyFilters() {
     setFilterShift,
     filterCountdown,
     setFilterCountdown,
-    filterStart,
-    setFilterStart,
-    filterEnd,
-    setFilterEnd,
+    start,
+    setStart,
+    end,
+    setEnd,
+    search,
+    setSearch,
     filtersOpen,
     setFiltersOpen,
   };


### PR DESCRIPTION
## Summary
- add search, start, and end fields to vacancy filter hook
- filter open vacancies by search text and date range
- expose date filter names in VacancyList

## Testing
- `npx vitest run --reporter=basic` *(fails: Unable to find an element with the text: Award Bundle)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c2294ae883278f185fd7acb1570f