### PR TITLE
Add search filter coverage for UI and API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "globals": "^15.6.0",
         "jsdom": "^24.0.0",
         "prettier": "^3.3.3",
+        "supertest": "^7.1.1",
         "tsx": "^4.19.0",
         "typescript": "^5.4.0",
         "vite": "^5.2.0",
@@ -1190,6 +1191,19 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1226,6 +1240,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2454,6 +2478,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2929,6 +2960,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2988,6 +3029,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -3304,6 +3352,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dfa": {
@@ -4192,6 +4251,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4365,6 +4431,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -5910,6 +5994,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -5922,6 +6016,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -7863,6 +7970,41 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "globals": "^15.6.0",
     "vite": "^5.2.0",
     "vitest": "^1.6.0",
-    "depcheck": "^1.4.7"
+    "depcheck": "^1.4.7",
+    "supertest": "^7.1.1"
   },
   "engines": {
     "node": "18.20.8"

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,7 @@ import { createCsv } from "./analyticsFormats/csv.js";
 import { createPdf } from "./analyticsFormats/pdf.js";
 import { parseNumberParam } from "./parseNumberParam.js";
 
-const app = express();
+export const app = express();
 app.use(cors());
 
 app.get("/api/search", (req, res) => {
@@ -102,7 +102,11 @@ app.get("/api/analytics/export", requireAuth, (req, res) => {
   }
 });
 
-const port = process.env.PORT || 3001;
-app.listen(port, "localhost", () => {
-  console.log(`Analytics server running on port ${port}`);
-});
+if (process.env.NODE_ENV !== "test") {
+  const port = process.env.PORT || 3001;
+  app.listen(port, "localhost", () => {
+    console.log(`Analytics server running on port ${port}`);
+  });
+}
+
+export default app;

--- a/tests/searchApi.test.ts
+++ b/tests/searchApi.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import { app } from "../server/index.js";
+import { sampleVacancies } from "../server/metrics.js";
+
+describe("GET /api/search", () => {
+  it("filters by q parameter", async () => {
+    const res = await request(app).get("/api/search").query({ q: "2024-03-03" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      sampleVacancies.find((v) => v.date === "2024-03-03"),
+    ]);
+  });
+
+  it("filters by category parameter", async () => {
+    const res = await request(app).get("/api/search").query({ category: "awarded" });
+    expect(res.status).toBe(200);
+    expect(res.body.every((v: any) => v.status === "awarded")).toBe(true);
+  });
+
+  it("respects start and end parameters", async () => {
+    const res = await request(app).get("/api/search").query({ start: 2, end: 4 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(sampleVacancies.slice(2, 4));
+  });
+});
+

--- a/tests/searchFiltering.test.tsx
+++ b/tests/searchFiltering.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import OpenVacanciesRedesign from "../src/components/OpenVacanciesRedesign.tsx";
+
+vi.mock("../src/hooks/useVacancyFilters", async () => {
+  return await import("../src/hooks/useVacancyFilters.ts");
+});
+
+const settings = {
+  responseWindows: {
+    lt2h: 0,
+    h2to4: 0,
+    h4to24: 0,
+    h24to72: 0,
+    gt72: 0,
+  },
+};
+
+const vacancies = [
+  {
+    id: "v1",
+    reason: "Shift A",
+    classification: "RN",
+    wing: "Alpha",
+    date: "2024-01-01",
+    start: "08:00",
+    end: "16:00",
+    shiftDate: "2024-01-01",
+    shiftStart: "08:00",
+    shiftEnd: "16:00",
+    knownAt: "2024-01-01T00:00:00.000Z",
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+  },
+  {
+    id: "v2",
+    reason: "Shift B",
+    classification: "LPN",
+    wing: "Beta",
+    date: "2024-02-01",
+    start: "08:00",
+    end: "16:00",
+    shiftDate: "2024-02-01",
+    shiftStart: "08:00",
+    shiftEnd: "16:00",
+    knownAt: "2024-01-01T00:00:00.000Z",
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+  },
+];
+
+function renderComponent() {
+  return render(
+    <OpenVacanciesRedesign
+      vacancies={vacancies}
+      employees={[]}
+      vacations={[]}
+      settings={settings}
+      selectedIds={[]}
+      dueNextId={null}
+      onToggleSelect={() => {}}
+      onToggleSelectMany={() => {}}
+      onDelete={() => {}}
+      onDeleteMany={() => {}}
+      awardVacancy={() => {}}
+      resetKnownAt={() => {}}
+      recommendations={{}}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+describe("OpenVacanciesRedesign filters", () => {
+  it("filters by keyword", () => {
+    renderComponent();
+    const input = screen.getByPlaceholderText("Search...");
+    fireEvent.change(input, { target: { value: "Alpha" } });
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.queryByText("Beta")).toBeNull();
+  });
+
+  it("filters by category", () => {
+    renderComponent();
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "RN" } });
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.queryByText("Beta")).toBeNull();
+  });
+
+  it("filters by date range", () => {
+    const { container } = renderComponent();
+    const [start, end] = container.querySelectorAll('input[type="date"]');
+    fireEvent.change(start, { target: { value: "2024-01-15" } });
+    expect(screen.queryByText("Alpha")).toBeNull();
+    expect(screen.getByText("Beta")).toBeTruthy();
+    fireEvent.change(end, { target: { value: "2024-01-31" } });
+    expect(screen.queryByText("Beta")).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- test OpenVacanciesRedesign keyword, category, and date-range filtering
- add supertest tests ensuring `/api/search` respects q, category, start, and end parameters
- export Express app for testing

## Testing
- `npm test` *(fails: existing awardBundle and awardVacancy tests)*
- `npx vitest run tests/searchFiltering.test.tsx tests/searchApi.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1c7a688e88327907bd30ad4e7fe49