### PR TITLE
feat: add theme toggle and css variables

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,18 +1,8 @@
-
 import React from "react";
+import { useTheme } from "../theme";
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = React.useState<"light" | "dark">(() => {
-    if (typeof document !== "undefined") {
-      return (document.documentElement.getAttribute("data-theme") as any) ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light");
-    }
-    return "light";
-  });
-
-  React.useEffect(() => {
-    document.documentElement.setAttribute("data-theme", theme);
-  }, [theme]);
-
+  const { theme, setTheme } = useTheme();
   return (
     <label className="theme-toggle" title="Toggle theme">
       <input

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,20 +5,37 @@ import App from "./App";
 import Analytics from "./Analytics";
 import Dashboard from "./Dashboard";
 import AuditLog from "./AuditLog";
+import { ThemeProvider, Theme } from "./theme";
+import "./styles/theme.css";
 import "./styles/responsive.css";
 import "./styles/ui-sanity.css";
 import "./styles/color-map.css";
 import "./styles/vacancies-redesign.css";
 
+const initialTheme: Theme = (() => {
+  if (typeof window === "undefined") return "light";
+  const stored = localStorage.getItem("theme");
+  if (stored === "light" || stored === "dark") {
+    document.documentElement.setAttribute("data-theme", stored);
+    return stored;
+  }
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const theme = prefersDark ? "dark" : "light";
+  document.documentElement.setAttribute("data-theme", theme);
+  return theme;
+})();
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="/analytics" element={<Analytics />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-        <Route path="/audit-log" element={<AuditLog />} />
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider initialTheme={initialTheme}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<App />} />
+          <Route path="/analytics" element={<Analytics />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/audit-log" element={<AuditLog />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/src/styles/branding.css
+++ b/src/styles/branding.css
@@ -1,25 +1,3 @@
-:root {
-  --bg1: #f0fdf4;
-  --bg2: #ffffff;
-  --card: #ffffff;
-  --stroke: #d1fae5;
-  --text: #064e3b;
-  --brand: #047857;
-  --accent: #10b981;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg1: #0f172a;
-    --bg2: #1f2937;
-    --card: #1e293b;
-    --stroke: #334155;
-    --text: #f1f5f9;
-    --brand: #0d9488;
-    --accent: #34d399;
-  }
-}
-
 .dashboard {
   min-height: 100vh;
   background: linear-gradient(180deg, var(--bg1), var(--bg2));
@@ -75,13 +53,13 @@ h2 {
 }
 
 .shift-card.awarded {
-  background: #d1fae5;
+  background: var(--shift-awarded-bg);
   border-left-color: var(--accent);
 }
 
 .shift-card.open {
-  background: #fef9c3;
-  border-left-color: #f59e0b;
+  background: var(--shift-open-bg);
+  border-left-color: var(--shift-open-border);
 }
 
 .employee-list table {
@@ -96,5 +74,5 @@ h2 {
 }
 
 .employee-list tr.recent td {
-  background: #fef9c3;
+  background: var(--employee-recent-bg);
 }

--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -5,22 +5,6 @@
 */
 
 :root { --header-height: 0px; }
-
-/* Light/Dark manual theme override (optional) */
-:root[data-theme="light"] {
-  color-scheme: light;
-}
-:root[data-theme="dark"] {
-  --bg1: #0f172a;
-  --bg2: #111827;
-  --card: #1f2937;
-  --stroke: #293449;
-  --text: #e5e7eb;
-  --brand: #0ea5e9;
-  --accent: #22d3ee;
-  color-scheme: dark;
-}
-
 /* App shell */
 .app-shell {
   min-height: 100dvh;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -65,9 +65,9 @@
     margin-bottom: 10px;
     border-bottom: 1px solid var(--stroke);
     padding-bottom: 6px;
-    background: #fff;
+    background: var(--card);
   }
-  .responsive-table tr:nth-child(odd) { background: #fafafa; }
+  .responsive-table tr:nth-child(odd) { background: var(--table-row-alt); }
   .responsive-table td {
     display: flex;
     justify-content: space-between;
@@ -130,16 +130,16 @@
 }
 
 .modal-overlay{ position:fixed; inset:0; background:rgba(0,0,0,.4); z-index:9999; display:flex; align-items:flex-start; justify-content:center; padding-top:5vh;}
-.modal{ background:#fff; border-radius:12px; box-shadow:0 10px 30px rgba(0,0,0,.25); width:min(800px, 95vw); padding:16px;}
+.modal{ background: var(--card); border-radius:12px; box-shadow:0 10px 30px rgba(0,0,0,.25); width:min(800px, 95vw); padding:16px;}
 .modal-h{ font-weight:600; margin-bottom:8px; }
 .calendar{ display:grid; grid-template-columns: repeat(7, 1fr); gap:6px; user-select:none; margin-bottom:8px;}
 .cal-head{ font-size:12px; opacity:.7; text-align:center; }
-.day{ border:1px solid #ddd; border-radius:8px; padding:8px; text-align:center; cursor:pointer; background:#fafafa; }
-.day.selected{ outline:2px solid #333; background:#fff; }
+.day{ border:1px solid var(--table-row-border); border-radius:8px; padding:8px; text-align:center; cursor:pointer; background: var(--table-row-alt); }
+.day.selected{ outline:2px solid var(--text); background: var(--card); }
 .day.disabled{ opacity:.35; pointer-events:none; }
 .btn{ cursor:pointer; }
 .btn.btn-sm{ padding:4px 8px; font-size:12px; }
-.btn.primary{ background:#0b5; color:#fff; border:none; }
+.btn.primary{ background: var(--brand); color: var(--button-text-on-brand); border:none; }
 
 /* vacancy row shared cells */
 .cell-select {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,61 @@
+:root {
+  --bg1: #f0fdf4;
+  --bg2: #ffffff;
+  --card: #ffffff;
+  --stroke: #d1fae5;
+  --text: #064e3b;
+  --brand: #047857;
+  --accent: #10b981;
+  --table-head-bg: var(--card);
+  --table-row-border: #e9e9e9;
+  --table-row-alt: #fafafa;
+  --table-row-hover: #f6faff;
+  --badge-bg: #eef2f7;
+  --badge-text: #334155;
+  --badge-wing-bg: #eefaf3;
+  --badge-wing-text: #206341;
+  --badge-class-bg: #eef2ff;
+  --badge-class-text: #42389d;
+  --section-bg: var(--card);
+  --section-text: #364152;
+  --shift-awarded-bg: #d1fae5;
+  --shift-open-bg: #fef9c3;
+  --shift-open-border: #f59e0b;
+  --employee-recent-bg: #fef9c3;
+  --countdown-red: #b30000;
+  --countdown-yellow: #925f00;
+  --countdown-green: #266a2e;
+  --button-text-on-brand: #fff;
+  color-scheme: light;
+}
+
+[data-theme="dark"] {
+  --bg1: #0f172a;
+  --bg2: #1f2937;
+  --card: #1e293b;
+  --stroke: #334155;
+  --text: #f1f5f9;
+  --brand: #0d9488;
+  --accent: #34d399;
+  --table-head-bg: var(--card);
+  --table-row-border: #334155;
+  --table-row-alt: #0f172a;
+  --table-row-hover: #1f2937;
+  --badge-bg: #334155;
+  --badge-text: #f1f5f9;
+  --badge-wing-bg: #155e75;
+  --badge-wing-text: #ecfeff;
+  --badge-class-bg: #4c1d95;
+  --badge-class-text: #f1f5f9;
+  --section-bg: var(--card);
+  --section-text: #f1f5f9;
+  --shift-awarded-bg: #064e3b;
+  --shift-open-bg: #78350f;
+  --shift-open-border: #d97706;
+  --employee-recent-bg: #78350f;
+  --countdown-red: #f87171;
+  --countdown-yellow: #fde047;
+  --countdown-green: #4ade80;
+  --button-text-on-brand: #fff;
+  color-scheme: dark;
+}

--- a/src/styles/vacancies-redesign.css
+++ b/src/styles/vacancies-redesign.css
@@ -1,9 +1,9 @@
 table.vacancies { width:100%; border-collapse:separate; border-spacing:0; }
-table.vacancies thead th { position:sticky; top:0; background:#fff; z-index:2; text-align:left; font-weight:600; padding:10px 12px; border-bottom:1px solid #e9e9e9; }
-table.vacancies tbody tr { border-bottom:1px solid #f0f0f0; }
-table.vacancies tbody tr:nth-child(odd) { background:#fafafa; }
+table.vacancies thead th { position:sticky; top:0; background: var(--table-head-bg); z-index:2; text-align:left; font-weight:600; padding:10px 12px; border-bottom:1px solid var(--table-row-border); }
+table.vacancies tbody tr { border-bottom:1px solid var(--table-row-border); }
+table.vacancies tbody tr:nth-child(odd) { background: var(--table-row-alt); }
 table.vacancies td { padding: 8px 10px; }
-table.vacancies tbody tr:hover { background:#f6faff; }
+table.vacancies tbody tr:hover { background: var(--table-row-hover); }
 
 td.cell-select { width:40px; padding:10px 12px; }
 td.cell-details { padding:10px 12px; }
@@ -13,9 +13,9 @@ td.cell-details { padding:10px 12px; }
 .cell-details__tag { white-space:nowrap; font-size:12px; opacity:.85; }
 
 td.cell-countdown { width:140px; padding:10px 12px; }
-.countdown.cd-red { color:#b30000; }
-.countdown.cd-yellow { color:#925f00; }
-.countdown.cd-green { color:#266a2e; }
+.countdown.cd-red { color: var(--countdown-red); }
+.countdown.cd-yellow { color: var(--countdown-yellow); }
+.countdown.cd-green { color: var(--countdown-green); }
 
 td.cell-actions { width:1%; text-align:right; padding:10px 12px; }
 .btn-row { display:grid; grid-template-columns: repeat(2, max-content); gap:6px; justify-content: end; }
@@ -24,14 +24,14 @@ td.cell-actions { width:1%; text-align:right; padding:10px 12px; }
 @media (max-width: 900px) {
   table.vacancies thead { display: none; }
   table.vacancies, table.vacancies tbody, table.vacancies tr, table.vacancies td { display: block; width: 100%; }
-  table.vacancies tr { margin-bottom: 10px; border-bottom: 1px solid #e9e9e9; padding-bottom: 6px; }
+  table.vacancies tr { margin-bottom: 10px; border-bottom: 1px solid var(--table-row-border); padding-bottom: 6px; }
   td.cell-details { padding-bottom: 4px; }
   td.cell-countdown { text-align: left; padding-top: 0; padding-bottom: 6px; }
   td.cell-actions { padding-top: 0; }
   .btn-row { grid-template-columns: repeat(2, 1fr); justify-content: stretch; }
 }
-.badge { display:inline-block; padding:2px 6px; font-size:11px; border-radius:999px; background:#eef2f7; color:#334155; }
-.badge-wing { background:#eefaf3; color:#206341; }
-.badge-class { background:#eef2ff; color:#42389d; }
+.badge { display:inline-block; padding:2px 6px; font-size:11px; border-radius:999px; background: var(--badge-bg); color: var(--badge-text); }
+.badge-wing { background: var(--badge-wing-bg); color: var(--badge-wing-text); }
+.badge-class { background: var(--badge-class-bg); color: var(--badge-class-text); }
 
-.section-h { position:sticky; top:36px; z-index:1; background:#fff; padding:6px 12px; font-weight:600; color:#364152; border-top:1px solid #e9e9e9; border-bottom:1px solid #e9e9e9; }
+.section-h { position:sticky; top:36px; z-index:1; background: var(--section-bg); padding:6px 12px; font-weight:600; color: var(--section-text); border-top:1px solid var(--table-row-border); border-bottom:1px solid var(--table-row-border); }

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ initialTheme, children }: { initialTheme: Theme; children: React.ReactNode }) {
+  const [theme, setTheme] = React.useState<Theme>(initialTheme);
+
+  React.useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+    try {
+      localStorage.setItem("theme", theme);
+    } catch {
+      // ignore write errors
+    }
+  }, [theme]);
+
+  const value = React.useMemo(() => ({ theme, setTheme }), [theme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const ctx = React.useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- define global CSS color variables and switchable dark theme
- add theme context with toggle component and persistent selection
- update styles to consume new variables

## Testing
- `npm run lint`
- `npm test` *(fails: unable to find element "Award Bundle", TypeError in awardVacancy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c8c8810483278768fedfb0e99909