### PR TITLE
refactor: preserve selected vacancies when selecting all

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2334,7 +2334,12 @@ export function BidsPage({
                   onClick={() =>
                     setNewBid((b) => ({
                       ...b,
-                      selectedVacancyIds: filteredVacancyOptions.map((o) => o.id),
+                      selectedVacancyIds: Array.from(
+                        new Set([
+                          ...b.selectedVacancyIds,
+                          ...filteredVacancyOptions.map((o) => o.id),
+                        ]),
+                      ),
                     }))
                   }
                 >
@@ -2467,22 +2472,19 @@ export function BidsPage({
                       targetIds.add(vac.id);
                     }
                   }
-                  setBids((prev: Bid[]) => {
-                    const arr = [...prev];
-                    for (const id of targetIds) {
-                      arr.push({
-                        vacancyId: id,
-                        bidderEmployeeId: newBid.bidderEmployeeId!,
-                        bidderName: newBid.bidderName ?? "",
-                        bidderStatus: (newBid.bidderStatus ?? "Casual") as Status,
-                        bidderClassification: (newBid.bidderClassification ??
-                          "RCA") as Classification,
-                        bidTimestamp: ts,
-                        notes: newBid.notes ?? "",
-                      });
-                    }
-                    return arr;
-                  });
+                  setBids((prev: Bid[]) => [
+                    ...prev,
+                    ...Array.from(targetIds).map((id) => ({
+                      vacancyId: id,
+                      bidderEmployeeId: newBid.bidderEmployeeId!,
+                      bidderName: newBid.bidderName ?? "",
+                      bidderStatus: (newBid.bidderStatus ?? "Casual") as Status,
+                      bidderClassification: (newBid.bidderClassification ??
+                        "RCA") as Classification,
+                      bidTimestamp: ts,
+                      notes: newBid.notes ?? "",
+                    })),
+                  ]);
                   setNewBid({ selectedVacancyIds: [] });
                   setVacancyFilter("");
                   setBidFormKey((prev) => prev + 1);


### PR DESCRIPTION
## Summary
- keep previously chosen vacancies when hitting Select All
- streamline bid creation from selected vacancies

## Testing
- `npm test` *(fails: Failed to resolve import "supertest" from tests/searchApi.test.ts; several tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68c2505a505083279147987a1e127740