### PR TITLE
feat: prioritize employee selection for bid creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2277,6 +2277,23 @@ export function BidsPage({
     [openVacancyOptions, vacancyFilter],
   );
 
+  const isEligible = (v: Vacancy, emp: Employee) => {
+    if (v.classification !== emp.classification) return false;
+    if (v.offeringStep === "Casuals") return emp.status === "Casual";
+    if (v.offeringStep === "OT-Full-Time")
+      return emp.status === "FT" || emp.status === "PT";
+    if (v.offeringStep === "OT-Casuals") return emp.status === "Casual";
+    return true;
+  };
+
+  const eligibleVacancyIds = useMemo(() => {
+    const emp = employeesById[newBid.bidderEmployeeId ?? ""];
+    if (!emp) return new Set<string>();
+    const set = new Set<string>();
+    for (const v of openVacancies) if (isEligible(v, emp)) set.add(v.id);
+    return set;
+  }, [openVacancies, newBid.bidderEmployeeId, employeesById]);
+
   const activeBids = bids.filter((b) => {
     const v = vacancies.find((x) => x.id === b.vacancyId);
     return !v || v.status !== "Awarded";
@@ -2313,6 +2330,37 @@ export function BidsPage({
         <div className="card-c">
           <div className="row cols2">
             <div style={{ gridColumn: "1 / -1" }}>
+              <label>Employee</label>
+              <EmployeeCombo
+                key={bidFormKey}
+                employees={employees}
+                onSelect={(id) => {
+                  const e = employeesById[id];
+                  if (e) {
+                    const ineligible = newBid.selectedVacancyIds.filter((vacId) => {
+                      const v = vacancies.find((x) => x.id === vacId);
+                      return v ? !isEligible(v, e) : false;
+                    });
+                    if (ineligible.length) {
+                      (window as any).appShowAlert?.(
+                        `Selected employee may be ineligible for ${ineligible.length} chosen vacancy${ineligible.length > 1 ? "ies" : ""}`,
+                      );
+                    }
+                  }
+                  setNewBid((b) => ({
+                    ...b,
+                    bidderEmployeeId: id,
+                    bidderName: e ? `${e.firstName} ${e.lastName}` : "",
+                    bidderStatus: e?.status,
+                    bidderClassification: e?.classification,
+                  }));
+                }}
+              />
+              <div className="subtitle" style={{ marginTop: 4 }}>
+                Select an employee to highlight matching vacancies.
+              </div>
+            </div>
+            <div style={{ gridColumn: "1 / -1" }}>
               <label>Vacancies</label>
               <input
                 type="text"
@@ -2320,6 +2368,9 @@ export function BidsPage({
                 value={vacancyFilter}
                 onChange={(e) => setVacancyFilter(e.target.value)}
               />
+              <div className="subtitle" style={{ margin: "4px 0" }}>
+                Eligible vacancies are bolded.
+              </div>
               <div
                 style={{
                   display: "flex",
@@ -2365,7 +2416,13 @@ export function BidsPage({
               >
                 {filteredVacancyOptions.length ? (
                   filteredVacancyOptions.map((opt) => (
-                    <label key={opt.id} style={{ display: "block" }}>
+                    <label
+                      key={opt.id}
+                      style={{
+                        display: "block",
+                        fontWeight: eligibleVacancyIds.has(opt.id) ? 700 : undefined,
+                      }}
+                    >
                       <input
                         type="checkbox"
                         checked={newBid.selectedVacancyIds.includes(opt.id)}
@@ -2385,23 +2442,6 @@ export function BidsPage({
                   <div style={{ padding: 4 }}>No open vacancies</div>
                 )}
               </div>
-            </div>
-            <div>
-              <label>Employee</label>
-              <EmployeeCombo
-                key={bidFormKey}
-                employees={employees}
-                onSelect={(id) => {
-                  const e = employeesById[id];
-                  setNewBid((b) => ({
-                    ...b,
-                    bidderEmployeeId: id,
-                    bidderName: e ? `${e.firstName} ${e.lastName}` : "",
-                    bidderStatus: e?.status,
-                    bidderClassification: e?.classification,
-                  }));
-                }}
-              />
             </div>
             {/* clicking wrapper triggers picker; use same pattern for future date fields */}
             <div onClick={() => bidDateRef.current?.showPicker()}>

--- a/tests/awardVacancy.test.tsx
+++ b/tests/awardVacancy.test.tsx
@@ -70,9 +70,9 @@ describe("award vacancy UI", () => {
 
     const rows = screen
       .getAllByRole("row")
-      .filter((r) => within(r).queryByText("Allow class override"));
-    const cb1 = within(rows[0]).getAllByRole("checkbox")[0];
-    const cb2 = within(rows[1]).getAllByRole("checkbox")[0];
+      .filter((r) => within(r).queryByRole("checkbox"));
+    const cb1 = within(rows[0]).getByRole("checkbox");
+    const cb2 = within(rows[1]).getByRole("checkbox");
     fireEvent.click(cb1);
     fireEvent.click(cb2);
 
@@ -141,7 +141,8 @@ describe("award vacancy UI", () => {
 
     const row = screen
       .getAllByRole("row")
-      .find((r) => within(r).queryByText("Allow class override"))!;
+      .filter((r) => within(r).queryByRole("checkbox"))[0];
+    fireEvent.click(within(row).getByText("Award"));
     const input = within(row).getByPlaceholderText(/Type name or ID/);
     fireEvent.change(input, { target: { value: "Bob" } });
     const option = (await screen.findAllByText(/Bob B/))[0];
@@ -149,7 +150,7 @@ describe("award vacancy UI", () => {
 
     fireEvent.click(within(row).getByLabelText("Allow class override"));
 
-    fireEvent.click(within(row).getByText("Award"));
+    fireEvent.click(within(row).getByText("Confirm Award"));
 
     expect(alertMock).toHaveBeenCalledWith(
       "Please select a reason for this override.",

--- a/tests/bidsPage.test.tsx
+++ b/tests/bidsPage.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import React from "react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { render, screen, fireEvent } from "@testing-library/react";
 import {
@@ -8,7 +8,7 @@ import {
   applyAwardVacancy,
   type Vacancy,
   type Bid,
-} from "../src/App";
+} from "../src/App.tsx";
 
 // test verifying that awarded vacancies are excluded from the dropdown
 
@@ -38,9 +38,10 @@ describe("BidsPage vacancy dropdown", () => {
         vacations={[]}
         employees={[]}
         employeesById={{}}
+        archivedBids={{}}
       />,
     );
-    expect(beforeHtml).toContain('value="v1"');
+    expect(beforeHtml).toContain("January 01, 2024");
 
     const awarded = applyAwardVacancy([vac], "v1", { empId: "e1" });
     expect(awarded[0].awardReason).toBeUndefined();
@@ -52,9 +53,9 @@ describe("BidsPage vacancy dropdown", () => {
         vacations={[]}
         employees={[]}
         employeesById={{}}
-      />, 
+        archivedBids={{}}
+      />,
     );
-    expect(afterHtml).not.toContain('value="v1"');
     expect(afterHtml).toContain("No open vacancies");
   });
 });
@@ -81,6 +82,7 @@ describe("BidsPage delete button", () => {
           vacations={[]}
           employees={[]}
           employeesById={{}}
+          archivedBids={{}}
         />
       );
     }


### PR DESCRIPTION
## Summary
- reorder BidsPage to pick employee before vacancies
- highlight eligible vacancies and warn on mismatched selections
- update tests for revised bid workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c25186ed44832792605343e5ec8dbb