### PR TITLE
Add undo toast for bid deletion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2311,9 +2311,28 @@ export function BidsPage({
   });
   const awardedVacancies = vacancies.filter((v) => v.status === "Awarded");
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [bidUndo, setBidUndo] = useState<
+    { bid: Bid; index: number; timeout: number } | null
+  >(null);
 
   const removeBid = (index: number) => {
-    setBids((prev: Bid[]) => prev.filter((_, idx) => idx !== index));
+    const toDelete = bids[index];
+    const remaining = bids.filter((_, idx) => idx !== index);
+    setBids(remaining);
+    if (bidUndo?.timeout) clearTimeout(bidUndo.timeout);
+    const timeout = window.setTimeout(() => setBidUndo(null), 5000);
+    setBidUndo({ bid: toDelete, index, timeout });
+  };
+
+  const undoBidDelete = () => {
+    if (!bidUndo) return;
+    clearTimeout(bidUndo.timeout);
+    setBids((prev) => {
+      const next = [...prev];
+      next.splice(bidUndo.index, 0, bidUndo.bid);
+      return next;
+    });
+    setBidUndo(null);
   };
 
   const setNow = () => {
@@ -2718,6 +2737,12 @@ export function BidsPage({
           </table>
         </div>
       </div>
+      <Toast
+        open={!!bidUndo}
+        message="Bid deleted."
+        actionLabel="Undo"
+        onAction={undoBidDelete}
+      />
     </div>
   );
 }

--- a/tests/bidsPage.test.tsx
+++ b/tests/bidsPage.test.tsx
@@ -61,7 +61,8 @@ describe("BidsPage vacancy dropdown", () => {
 });
 
 describe("BidsPage delete button", () => {
-  it("removes bid when Delete clicked", () => {
+  it("shows undo toast and restores bid on undo", () => {
+    vi.useFakeTimers();
     const initialBid: Bid = {
       vacancyId: "v1",
       bidderEmployeeId: "e1",
@@ -91,5 +92,11 @@ describe("BidsPage delete button", () => {
     expect(screen.queryByText("Alice")).not.toBeNull();
     fireEvent.click(screen.getByText("Delete"));
     expect(screen.queryByText("Alice")).toBeNull();
+    expect(screen.getByTestId("undo-delete-toast")).toBeTruthy();
+    fireEvent.click(screen.getByText("Undo"));
+    expect(screen.queryByText("Alice")).not.toBeNull();
+    expect(screen.queryByTestId("undo-delete-toast")).toBeNull();
+    vi.runAllTimers();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- allow undoing bid deletions via 5s toast
- test bid deletion undo flow

## Testing
- `npm test` *(fails: tests/awardBundle.test.tsx > bundle award > awards all days when confirming, tests/awardVacancy.test.tsx > award vacancy UI > bulk awards selected vacancies with identical details)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8863704dc83278645f3de44aca643