### PR TITLE
Use injected handlers in VacancyDetail and add tests

### DIFF
--- a/src/components/VacancyDetail.js
+++ b/src/components/VacancyDetail.js
@@ -1,27 +1,16 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import OfferingControls from "./OfferingControls";
 import ConfirmDialog from "./ui/ConfirmDialog";
 import { useOfferingRound } from "../offering/useOfferingRound";
-// Dummy store placeholder for demo/testing
-function useVacancyStore() {
-    return {
-        updateVacancy: (_id, _patch) => { },
-        deleteVacancy: (_id) => { },
-        currentUser: "demo-user",
-    };
-}
-export default function VacancyDetail({ vacancy, onDelete, readOnly = false }) {
-    const { updateVacancy, deleteVacancy, currentUser } = useVacancyStore();
+export default function VacancyDetail({ vacancy, onUpdate, onDelete, currentUser = "system", readOnly = false }) {
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-    const round = useOfferingRound(vacancy, (patch) => updateVacancy(vacancy.id, patch), currentUser);
+    const handleUpdate = useCallback((patch) => {
+        onUpdate(vacancy.id, patch);
+    }, [onUpdate, vacancy.id]);
+    const round = useOfferingRound(vacancy, handleUpdate, currentUser);
     const handleDelete = () => {
-        if (onDelete) {
-            onDelete(vacancy.id);
-        }
-        else {
-            deleteVacancy(vacancy.id);
-        }
+        onDelete(vacancy.id);
         setShowDeleteConfirm(false);
     };
     return (_jsxs("div", { children: [_jsxs("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }, children: [_jsx("h2", { children: "Vacancy Detail" }), !readOnly && (_jsx("button", { className: "btn danger", onClick: () => setShowDeleteConfirm(true), title: "Delete vacancy permanently", "aria-label": "Delete vacancy", children: "Delete" }))] }), _jsxs("div", { style: { marginBottom: 16 }, children: [_jsxs("p", { children: [_jsx("strong", { children: "Date:" }), " ", vacancy.shiftDate] }), _jsxs("p", { children: [_jsx("strong", { children: "Time:" }), " ", vacancy.shiftStart, " - ", vacancy.shiftEnd] }), _jsxs("p", { children: [_jsx("strong", { children: "Classification:" }), " ", vacancy.classification] }), _jsxs("p", { children: [_jsx("strong", { children: "Wing:" }), " ", vacancy.wing || 'N/A'] }), _jsxs("p", { children: [_jsx("strong", { children: "Status:" }), " ", vacancy.status] }), _jsxs("p", { children: [_jsx("strong", { children: "Reason:" }), " ", vacancy.reason] })] }), _jsx(OfferingControls, { vacancy: vacancy, round: round }), _jsx(ConfirmDialog, { open: showDeleteConfirm, title: "Delete vacancy?", body: "This action permanently deletes the vacancy. This cannot be undone.", onConfirm: handleDelete, onCancel: () => setShowDeleteConfirm(false) })] }));

--- a/src/components/VacancyDetail.tsx
+++ b/src/components/VacancyDetail.tsx
@@ -1,39 +1,37 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import OfferingControls from "./OfferingControls";
 import ConfirmDialog from "./ui/ConfirmDialog";
 import { useOfferingRound } from "../offering/useOfferingRound";
 import type { Vacancy } from "../types";
 
-// Dummy store placeholder for demo/testing
-function useVacancyStore() {
-  return {
-    updateVacancy: (_id: string, _patch: Partial<Vacancy>) => {},
-    deleteVacancy: (_id: string) => {},
-    currentUser: "demo-user",
-  };
-}
-
 interface VacancyDetailProps {
   vacancy: Vacancy;
-  onDelete?: (id: string) => void;
+  onUpdate: (id: string, patch: Partial<Vacancy>) => void;
+  onDelete: (id: string) => void;
+  currentUser?: string;
   readOnly?: boolean;
 }
 
-export default function VacancyDetail({ vacancy, onDelete, readOnly = false }: VacancyDetailProps) {
-  const { updateVacancy, deleteVacancy, currentUser } = useVacancyStore();
+export default function VacancyDetail({
+  vacancy,
+  onUpdate,
+  onDelete,
+  currentUser = "system",
+  readOnly = false,
+}: VacancyDetailProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const round = useOfferingRound(
-    vacancy,
-    (patch) => updateVacancy(vacancy.id, patch),
-    currentUser,
+
+  const handleUpdate = useCallback(
+    (patch: Partial<Vacancy>) => {
+      onUpdate(vacancy.id, patch);
+    },
+    [onUpdate, vacancy.id],
   );
 
+  const round = useOfferingRound(vacancy, handleUpdate, currentUser);
+
   const handleDelete = () => {
-    if (onDelete) {
-      onDelete(vacancy.id);
-    } else {
-      deleteVacancy(vacancy.id);
-    }
+    onDelete(vacancy.id);
     setShowDeleteConfirm(false);
   };
 

--- a/tests/components/VacancyDetail.test.tsx
+++ b/tests/components/VacancyDetail.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import VacancyDetail from "../../src/components/VacancyDetail";
+import type { Vacancy } from "../../src/types";
+
+const baseVacancy: Vacancy = {
+  id: "vac-1",
+  date: "2024-05-01",
+  shiftDate: "2024-05-01",
+  shiftStart: "07:00",
+  shiftEnd: "15:00",
+  reason: "Illness",
+  classification: "RN",
+  wing: "Shamrock",
+  status: "Open",
+  knownAt: "2024-04-30T12:00:00.000Z",
+  offeringTier: "CASUALS",
+  offeringRoundStartedAt: "2024-04-30T12:00:00.000Z",
+  offeringRoundMinutes: 120,
+  offeringAutoProgress: true,
+  offeringStep: "Casuals",
+};
+
+describe("VacancyDetail", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("calls onUpdate when offering controls change", () => {
+    vi.useFakeTimers();
+    const handleUpdate = vi.fn();
+    const handleDelete = vi.fn();
+
+    render(
+      <VacancyDetail
+        vacancy={baseVacancy}
+        onUpdate={handleUpdate}
+        onDelete={handleDelete}
+        currentUser="tester"
+      />,
+    );
+
+    const checkbox = screen.getByLabelText(/auto-advance/i);
+    expect((checkbox as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(checkbox);
+
+    expect(handleUpdate).toHaveBeenCalled();
+    expect(handleUpdate).toHaveBeenCalledWith(baseVacancy.id, {
+      offeringAutoProgress: false,
+    });
+  });
+
+  it("calls onDelete when the user confirms deletion", async () => {
+    const handleUpdate = vi.fn();
+    const handleDelete = vi.fn();
+
+    render(
+      <VacancyDetail
+        vacancy={baseVacancy}
+        onUpdate={handleUpdate}
+        onDelete={handleDelete}
+      />,
+    );
+
+    const [deleteButton] = screen.getAllByRole("button", {
+      name: /delete vacancy/i,
+    });
+    fireEvent.click(deleteButton);
+
+    const dialog = await screen.findByTestId("confirm-delete-modal");
+    const confirmButton = within(dialog).getByRole("button", { name: /^delete$/i });
+    fireEvent.click(confirmButton);
+
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+    expect(handleDelete).toHaveBeenCalledWith(baseVacancy.id);
+  });
+});


### PR DESCRIPTION
## Summary
- remove the placeholder vacancy store from `VacancyDetail` and accept injected update/delete handlers
- align the compiled JS version with the new props and round handler wiring
- add a component test that verifies offering updates and delete confirmations call the supplied callbacks

## Testing
- npm test *(fails: Award Bundle UI tests unable to locate "Award Bundle" button in jsdom)*
- npx vitest run tests/components/VacancyDetail.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c9b177e030832785ba15e8c107ef4e