### PR TITLE
Update wing options

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,9 +45,10 @@ const WINGS = [
     "Shamrock",
     "Bluebell",
     "Rosewood",
-    "Front",
+    "Recreation",
     "Float",
     "Receptionist",
+    "1 on 1",
 ];
 const SHIFT_PRESETS = [
     { label: "Day", start: "06:30", end: "14:30" },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,9 +160,10 @@ const WINGS = [
   "Shamrock",
   "Bluebell",
   "Rosewood",
-  "Front",
+  "Recreation",
   "Float",
   "Receptionist",
+  "1 on 1",
 ] as const;
 
 const SHIFT_PRESETS = [

--- a/src/types.js
+++ b/src/types.js
@@ -2,9 +2,10 @@ export const WINGS = [
     "Shamrock",
     "Bluebell",
     "Rosewood",
-    "Front",
+    "Recreation",
     "Float",
     "Receptionist",
+    "1 on 1",
 ];
 export const SHIFT_PRESETS = [
     { label: "Day", start: "06:30", end: "14:30" },

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,9 +108,10 @@ export const WINGS = [
   "Shamrock",
   "Bluebell",
   "Rosewood",
-  "Front",
+  "Recreation",
   "Float",
   "Receptionist",
+  "1 on 1",
 ] as const;
 
 export const SHIFT_PRESETS = [


### PR DESCRIPTION
## Summary
- rename the Front wing option to Recreation in the shared dropdown lists
- add the new "1 on 1" wing choice across the app and type definitions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2e794c7248327ba7ca0cef729eb00