### PR TITLE
Enforce TypeScript modules in src

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,5 +21,19 @@ module.exports = {
     "react/prop-types": "off",
     "no-ex-assign": "off",
     "@typescript-eslint/no-non-null-asserted-optional-chain": "off"
-  }
+  },
+  overrides: [
+    {
+      files: ["src/**/*.{js,jsx}"],
+      rules: {
+        "no-restricted-syntax": [
+          "error",
+          {
+            selector: "Program",
+            message: "Modules in src/ must be written in TypeScript (.ts/.tsx)."
+          }
+        ]
+      }
+    }
+  ]
 };


### PR DESCRIPTION
## Summary
- add an ESLint override that forbids JavaScript/JSX sources under src from being linted as valid modules
- block modules written in src/**/*.js or src/**/*.jsx via a no-restricted-syntax rule

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d31407144c83279ac30bf9a91591dc