### PR TITLE
Virtualize vacancy list rendering with react-window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react": "^18.3.1",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.23.0"
+        "react-router-dom": "^6.23.0",
+        "react-window": "^2.1.1"
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
@@ -7161,6 +7162,16 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.1.1.tgz",
+      "integrity": "sha512-Wx5yHri8G1nFxImnJRkEEKtRTnG3cWaqknUJyYvgisQtl1mw/d8LQmLXfuKxpn2dY8IwDn5mCIuxm2NVyIvgVQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react": "^18.3.1",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "react-window": "^2.1.1"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/src/components/VacancyList.tsx
+++ b/src/components/VacancyList.tsx
@@ -6,6 +6,10 @@ import { useVacancyFilters } from "../hooks/useVacancyFilters";
 import { WINGS, SHIFT_PRESETS } from "../types";
 import { deadlineFor, pickWindowMinutes } from "../lib/vacancy";
 import { minutesBetween } from "../lib/dates";
+import { List, type RowComponentProps } from "react-window";
+
+const ROW_HEIGHT = 220;
+const MAX_LIST_HEIGHT = 600;
 
 interface Props {
   vacancies: Vacancy[];
@@ -101,6 +105,40 @@ export default function VacancyList({
     setSelectedVacancyIds(checked ? filteredVacancies.map((v) => v.id) : []);
   };
 
+  const listHeight = useMemo(() => {
+    if (filteredVacancies.length === 0) return 0;
+    return Math.min(
+      MAX_LIST_HEIGHT,
+      Math.max(filteredVacancies.length, 1) * ROW_HEIGHT,
+    );
+  }, [filteredVacancies.length]);
+
+  const rowProps = useMemo<VacancyListRowProps>(() => {
+    return {
+      items: filteredVacancies,
+      employees,
+      recommendations,
+      selectedVacancyIds,
+      setSelectedVacancyIds,
+      awardVacancy,
+      resetKnownAt,
+      deleteVacancy,
+      settings,
+      dueNextId,
+    };
+  }, [
+    filteredVacancies,
+    employees,
+    recommendations,
+    selectedVacancyIds,
+    setSelectedVacancyIds,
+    awardVacancy,
+    resetKnownAt,
+    deleteVacancy,
+    settings,
+    dueNextId,
+  ]);
+
   return (
     <div className="card">
       <div className="card-h">Open Vacancies</div>
@@ -170,10 +208,14 @@ export default function VacancyList({
             </button>
           </div>
         )}
-        <table className="vac-table responsive-table">
-          <thead>
-            <tr>
-              <th>
+        <div
+          className="vac-table virtual-vac-table responsive-table"
+          role="table"
+          aria-label="Open vacancies"
+        >
+          <div className="vac-table__header" role="rowgroup">
+            <div className="vac-table__header-row" role="row">
+              <div className="vac-table__header-cell" role="columnheader">
                 <input
                   type="checkbox"
                   aria-label="Select all vacancies"
@@ -183,45 +225,95 @@ export default function VacancyList({
                   }
                   onChange={(e) => toggleAllVacancies(e.target.checked)}
                 />
-              </th>
-              <th>Details</th>
-              <th>Countdown</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredVacancies.map((v) => {
-              const isDueNext = dueNextId === v.id;
-              return (
-                <VacancyRow
-                  key={v.id}
-                  v={v}
-                  recommendation={recommendations[v.id]}
-                  employees={employees}
-                  selected={selectedVacancyIds.includes(v.id)}
-                  onToggleSelect={() =>
-                    setSelectedVacancyIds((ids: string[]) =>
-                      ids.includes(v.id)
-                        ? ids.filter((id) => id !== v.id)
-                        : [...ids, v.id],
-                    )
-                  }
-                  isDueNext={!!isDueNext}
-                  awardVacancy={(payload) => awardVacancy(v.id, payload)}
-                  resetKnownAt={() => resetKnownAt(v.id)}
-                  onDelete={deleteVacancy}
-                  settings={settings}
-                />
-              );
-            })}
-          </tbody>
-        </table>
-        {filteredVacancies.length === 0 && (
-          <div className="subtitle" style={{ marginTop: 8 }}>
-            No open vacancies 🎉
+              </div>
+              <div className="vac-table__header-cell" role="columnheader">
+                Details
+              </div>
+              <div className="vac-table__header-cell" role="columnheader">
+                Countdown
+              </div>
+              <div className="vac-table__header-cell" role="columnheader">
+                Actions
+              </div>
+            </div>
           </div>
-        )}
+          {filteredVacancies.length > 0 && listHeight > 0 ? (
+            <List
+              className="vac-table__body vac-table__scroller"
+              style={{ height: listHeight, width: "100%" }}
+              rowCount={filteredVacancies.length}
+              rowHeight={ROW_HEIGHT}
+              overscanCount={4}
+              rowComponent={VirtualVacancyRow}
+              rowProps={rowProps}
+              role="rowgroup"
+            />
+          ) : (
+            <div className="vac-table__empty" role="row">
+              <div className="vac-table__cell" role="cell">
+                No open vacancies 🎉
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
 }
+
+type VacancyListRowProps = {
+  items: Vacancy[];
+  employees: Employee[];
+  recommendations: Record<string, Recommendation>;
+  selectedVacancyIds: string[];
+  setSelectedVacancyIds: (fn: any) => void;
+  awardVacancy: Props["awardVacancy"];
+  resetKnownAt: Props["resetKnownAt"];
+  deleteVacancy: NonNullable<Props["deleteVacancy"]>;
+  settings: Settings;
+  dueNextId: string | null;
+};
+
+const VirtualVacancyRow = ({
+  ariaAttributes,
+  index,
+  style,
+  items,
+  employees,
+  recommendations,
+  selectedVacancyIds,
+  setSelectedVacancyIds,
+  awardVacancy,
+  resetKnownAt,
+  deleteVacancy,
+  settings,
+  dueNextId,
+}: RowComponentProps<VacancyListRowProps>) => {
+  const vacancy = items[index];
+  if (!vacancy) return null;
+  const { role: _role, ...restAria } = ariaAttributes ?? {};
+  const isDueNext = dueNextId === vacancy.id;
+  return (
+    <VacancyRow
+      as="div"
+      style={{ ...style, width: "100%" }}
+      ariaProps={restAria}
+      v={vacancy}
+      recommendation={recommendations[vacancy.id]}
+      employees={employees}
+      selected={selectedVacancyIds.includes(vacancy.id)}
+      onToggleSelect={() =>
+        setSelectedVacancyIds((ids: string[]) =>
+          ids.includes(vacancy.id)
+            ? ids.filter((id) => id !== vacancy.id)
+            : [...ids, vacancy.id],
+        )
+      }
+      isDueNext={!!isDueNext}
+      awardVacancy={(payload) => awardVacancy(vacancy.id, payload)}
+      resetKnownAt={() => resetKnownAt(vacancy.id)}
+      onDelete={deleteVacancy}
+      settings={settings}
+    />
+  );
+};

--- a/src/components/VacancyRow.tsx
+++ b/src/components/VacancyRow.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import type { CSSProperties } from "react";
 import { formatDateLong, formatDowShort } from "../lib/dates";
 import type { Vacancy, Employee, Settings } from "../types";
 import { OVERRIDE_REASONS } from "../types";
@@ -25,6 +26,9 @@ export default function VacancyRow({
   onDelete,
   coveredName,
   settings,
+  as = "tr",
+  style,
+  ariaProps,
 }: {
   v: Vacancy;
   recommendation?: Recommendation;
@@ -41,6 +45,9 @@ export default function VacancyRow({
   onDelete: (id: string) => void;
   coveredName?: string;
   settings: Settings;
+  as?: "tr" | "div";
+  style?: CSSProperties;
+  ariaProps?: Record<string, string | number | undefined>;
 }) {
   const [choice, setChoice] = useState<string>("");
   const [choiceManual, setChoiceManual] = useState<boolean>(false);
@@ -125,20 +132,34 @@ export default function VacancyRow({
     setChoiceManual(false);
   };
 
+  const RowComponent = (as === "div" ? "div" : "tr") as keyof JSX.IntrinsicElements;
+  const cellComponent = as === "div" ? "div" : "td";
+  const rowClassName = `${as === "div" ? "vac-table__row " : ""}${
+    isDueNext ? "due-next " : ""
+  }${selected ? "selected" : ""}`
+    .replace(/\s+/g, " ")
+    .trim();
+
+  const sanitizedAriaProps = { ...(ariaProps ?? {}) };
+  delete sanitizedAriaProps.role;
+  const rowExtraProps = as === "div" ? { role: "row", ...sanitizedAriaProps } : {};
+
   return (
-    <tr
-      className={`${isDueNext ? "due-next " : ""}${
-        selected ? "selected" : ""
-      }`.trim()}
+    <RowComponent
+      className={rowClassName}
       aria-selected={selected}
       tabIndex={0}
+      style={style}
+      {...rowExtraProps}
     >
       <CellSelect
+        component={cellComponent}
         checked={selected}
         onChange={onToggleSelect}
         ariaLabel={`Select vacancy ${v.id}`}
       />
       <CellDetails
+        component={cellComponent}
         title={
           <div
             style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
@@ -203,8 +224,8 @@ export default function VacancyRow({
           </div>
         }
       />
-      <CellCountdown source={v} settings={settings} />
-      <CellActions>
+      <CellCountdown component={cellComponent} source={v} settings={settings} />
+      <CellActions component={cellComponent}>
         {isBundleChild ? (
           <div className="action-grid">
             <button className="btn btn-sm" onClick={resetKnownAt}>
@@ -311,7 +332,7 @@ export default function VacancyRow({
           </div>
         )}
       </CellActions>
-    </tr>
+    </RowComponent>
   );
 }
 

--- a/src/components/rows/RowCells.tsx
+++ b/src/components/rows/RowCells.tsx
@@ -1,14 +1,51 @@
 import React from "react";
 import type { Vacancy, Settings } from "../../types";
 import { fmtCountdown, deadlineFor, pickWindowMinutes } from "../../lib/vacancy";
-import { combineDateTime, minutesBetween } from "../../lib/dates";
+import { minutesBetween } from "../../lib/dates";
 
-export function CellSelect({checked,onChange,ariaLabel="Select row"}:{checked:boolean;onChange:()=>void;ariaLabel?:string}) {
-  return <td className="cell-select"><input type="checkbox" checked={checked} onChange={onChange} aria-label={ariaLabel} /></td>;
+export type CellComponent = "td" | "div";
+
+function cellClass(component: CellComponent, base: string) {
+  return component === "div" ? `vac-table__cell ${base}` : base;
 }
-export function CellDetails({title,subtitle,rightTag}:{title:React.ReactNode;subtitle?:React.ReactNode;rightTag?:React.ReactNode;}) {
+
+function cellRole(component: CellComponent, role: "cell" | "columnheader" = "cell") {
+  return component === "div" ? role : undefined;
+}
+
+export function CellSelect({
+  checked,
+  onChange,
+  ariaLabel = "Select row",
+  component = "td",
+}: {
+  checked: boolean;
+  onChange: () => void;
+  ariaLabel?: string;
+  component?: CellComponent;
+}) {
+  const Element = component as keyof JSX.IntrinsicElements;
   return (
-    <td className="cell-details">
+    <Element className={cellClass(component, "cell-select")} role={cellRole(component)}>
+      <input type="checkbox" checked={checked} onChange={onChange} aria-label={ariaLabel} />
+    </Element>
+  );
+}
+
+export function CellDetails({
+  title,
+  subtitle,
+  rightTag,
+  component = "td",
+}: {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  rightTag?: React.ReactNode;
+  component?: CellComponent;
+}) {
+  const Element = component as keyof JSX.IntrinsicElements;
+  return (
+    <Element className={cellClass(component, "cell-details")} role={cellRole(component)}>
       <div className="cell-details__wrap">
         <div className="cell-details__left">
           <div className="cell-details__title">{title}</div>
@@ -16,19 +53,59 @@ export function CellDetails({title,subtitle,rightTag}:{title:React.ReactNode;sub
         </div>
         {rightTag && <div className="cell-details__tag">{rightTag}</div>}
       </div>
-    </td>
+    </Element>
   );
 }
-export function CellCountdown({source,settings}:{source:Vacancy;settings:Settings}) {
+
+export function CellCountdown({
+  source,
+  settings,
+  component = "td",
+}: {
+  source: Vacancy;
+  settings: Settings;
+  component?: CellComponent;
+}) {
   const now = Date.now();
   const deadline = deadlineFor(source, settings).getTime();
   const msLeft = deadline - now;
   const winMin = pickWindowMinutes(source, settings);
   const sinceKnownMin = minutesBetween(new Date(), new Date(source.knownAt));
   const pct = Math.max(0, Math.min(1, (winMin - sinceKnownMin) / winMin));
-  let cdClass = "cd-green"; if (msLeft <= 0) cdClass = "cd-red"; else if (pct < 0.25) cdClass = "cd-yellow";
-  return <td className="cell-countdown" style={{whiteSpace:"nowrap",textAlign:"center",verticalAlign:"middle"}}><div className={`countdown ${cdClass}`}>{fmtCountdown(msLeft)}</div></td>;
+  let cdClass = "cd-green";
+  if (msLeft <= 0) cdClass = "cd-red";
+  else if (pct < 0.25) cdClass = "cd-yellow";
+  const Element = component as keyof JSX.IntrinsicElements;
+  return (
+    <Element
+      className={cellClass(component, "cell-countdown")}
+      role={cellRole(component)}
+      style={
+        component === "td"
+          ? { whiteSpace: "nowrap", textAlign: "center", verticalAlign: "middle" }
+          : undefined
+      }
+    >
+      <div className={`countdown ${cdClass}`}>{fmtCountdown(msLeft)}</div>
+    </Element>
+  );
 }
-export function CellActions({children}:{children:React.ReactNode}) {
-  return <td className="cell-actions" style={{textAlign:"center",verticalAlign:"middle"}}>{children}</td>;
+
+export function CellActions({
+  children,
+  component = "td",
+}: {
+  children: React.ReactNode;
+  component?: CellComponent;
+}) {
+  const Element = component as keyof JSX.IntrinsicElements;
+  return (
+    <Element
+      className={cellClass(component, "cell-actions")}
+      role={cellRole(component)}
+      style={component === "td" ? { textAlign: "center", verticalAlign: "middle" } : undefined}
+    >
+      {children}
+    </Element>
+  );
 }

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -184,3 +184,115 @@
   background: rgba(239,68,68,.12);
 }
 
+.virtual-vac-table {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--stroke);
+  overflow: hidden;
+}
+
+.virtual-vac-table .vac-table__header {
+  background: var(--card);
+  border-bottom: 1px solid var(--stroke);
+}
+
+.virtual-vac-table .vac-table__header-row,
+.virtual-vac-table .vac-table__row {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) 160px 220px;
+  align-items: stretch;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.virtual-vac-table .vac-table__header-row {
+  padding: 12px 8px;
+  font-weight: 600;
+}
+
+.virtual-vac-table .vac-table__header-cell,
+.virtual-vac-table .vac-table__cell {
+  padding: 0 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.virtual-vac-table .vac-table__header-cell:first-child,
+.virtual-vac-table .vac-table__cell.cell-select {
+  justify-content: center;
+}
+
+.virtual-vac-table .vac-table__row {
+  padding: 12px 8px;
+  background: var(--card);
+  border-bottom: 1px solid var(--stroke);
+}
+
+.virtual-vac-table .vac-table__row:nth-of-type(even) {
+  background: var(--table-row-alt);
+}
+
+.virtual-vac-table .vac-table__row .cell-countdown,
+.virtual-vac-table .vac-table__row .cell-actions {
+  justify-content: center;
+}
+
+.virtual-vac-table .vac-table__row .cell-actions .action-grid {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.virtual-vac-table .vac-table__body,
+.virtual-vac-table .vac-table__scroller {
+  width: 100% !important;
+}
+
+.virtual-vac-table .vac-table__empty {
+  padding: 24px;
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .virtual-vac-table {
+    border: none;
+  }
+
+  .virtual-vac-table .vac-table__header {
+    display: none;
+  }
+
+  .virtual-vac-table .vac-table__row {
+    display: flex;
+    flex-direction: column;
+    position: relative !important;
+    height: auto !important;
+    top: auto !important;
+    left: auto !important;
+    right: auto !important;
+    width: 100% !important;
+    padding: 12px;
+    margin-bottom: 10px;
+    border: 1px solid var(--stroke);
+    border-radius: 10px;
+    background: var(--card);
+  }
+
+  .virtual-vac-table .vac-table__cell {
+    justify-content: space-between;
+    padding: 6px 0;
+    width: 100%;
+  }
+
+  .virtual-vac-table .vac-table__cell.cell-actions {
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-start;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add the react-window dependency and use it to virtualize vacancy rows with a custom List renderer
- extend VacancyRow and supporting cells to render as div-based rows so virtualization preserves table semantics
- add styling for the virtualized table body so the layout and mobile experience match the existing design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d314af01308327a88683a88687eb77