### PR TITLE
Fix group-by-bundle checkbox toggle logic

### DIFF
--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -165,7 +165,9 @@ export default function OpenVacanciesRedesign(props: Props) {
           <input
             type="checkbox"
             checked={groupByBundle}
-            onChange={() => setGroupByBundle(true)}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              setGroupByBundle(event.target.checked)
+            }
           />
           Group by bundle
         </label>


### PR DESCRIPTION
## Summary
- update the group-by-bundle checkbox handler so it reflects the current checked state instead of always enabling the grouping

## Testing
- not run (UI verification unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6d0596b3c83279bff820778bcc44b