### PR TITLE
Ensure Modal component uses explicit prop interface

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useRef } from "react";
 
-export function Modal({ open, title, children, onClose, footer }: { open: boolean; title?: string; children: React.ReactNode; onClose: () => void; footer?: React.ReactNode }) {
+interface ModalProps {
+  open: boolean;
+  title?: string;
+  children: React.ReactNode;
+  onClose: () => void;
+  footer?: React.ReactNode;
+}
+
+export function Modal({ open, title, children, onClose, footer }: ModalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const previouslyFocused = useRef<HTMLElement | null>(null);
 


### PR DESCRIPTION
## Summary
- define a dedicated `ModalProps` interface for the Modal component
- ensure the overlay, children, and footer rendering remain unchanged during the refactor

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6d0b984ac8327a154360488275115