### PR TITLE
Redesign vacancy filter bar with bundle mode controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -990,6 +990,18 @@ const [showRangeForm, setShowRangeForm] = useState(false);
         .title{font-size:22px;font-weight:800}
         .subtitle{color:var(--muted);font-size:13px}
         .toolbar{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+        .smart-filter-bar{flex-wrap:nowrap;overflow-x:auto;padding:4px 0}
+        .smart-filter-bar>*{flex-shrink:0}
+        .smart-filter-bar input:not([type="checkbox"]){width:auto}
+        .smart-filter-bar input[type="text"]{min-width:180px}
+        .smart-filter-bar .date-range{display:flex;gap:4px;flex-wrap:nowrap}
+        .smart-filter-bar .date-range input{min-width:140px}
+        .smart-filter-bar .chip-group{display:flex;gap:4px;flex-wrap:nowrap}
+        .smart-filter-bar .pill-toggle{background:var(--chipBg);color:var(--chipText);border:1px solid var(--stroke);border-radius:999px;padding:6px 10px;font-size:12px;font-weight:600;cursor:pointer;white-space:nowrap;transition:background .2s,color .2s,border-color .2s}
+        .smart-filter-bar .pill-toggle[data-active="true"]{background:var(--brand);color:#fff;border-color:var(--brand)}
+        .smart-filter-bar .active-filter-chips{display:flex;gap:4px;align-items:center;flex-wrap:nowrap}
+        .smart-filter-bar .active-filter-chip{display:inline-flex;align-items:center;gap:6px;cursor:pointer;white-space:nowrap}
+        .smart-filter-bar .active-filter-chip:hover{border-color:var(--brand);color:var(--brand)}
         .btn{background:var(--cardAlt);border:1px solid var(--stroke);padding:9px 12px;border-radius:12px;color:var(--text);cursor:pointer;font-weight:600;transition:background .2s,transform .2s,box-shadow .2s}
         .btn:hover{border-color:var(--brand);background:var(--brand);color:#fff;box-shadow:0 2px 4px rgba(0,0,0,.1);transform:translateY(-1px)}
         .btn-sm{padding:4px 8px;font-size:12px}

--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -45,6 +45,8 @@ export default function OpenVacanciesRedesign(props: Props) {
     setEnd,
     filterClass,
     setFilterClass,
+    bundleMode,
+    setBundleMode,
   } = useVacancyFilters();
   const employeesById = useMemo(() => {
     const map: Record<string, Employee> = {};
@@ -82,10 +84,10 @@ export default function OpenVacanciesRedesign(props: Props) {
     if (filters?.wing) list = list.filter((v) => (v.wing || "") === filters!.wing);
     if (filters?.classification)
       list = list.filter((v) => v.classification === filters!.classification);
-    if (filters?.bundlesOnly) list = list.filter((v) => v.bundleId);
-    if (filters?.singlesOnly) list = list.filter((v) => !v.bundleId);
+    if (bundleMode === "bundles") list = list.filter((v) => v.bundleId);
+    if (bundleMode === "singles") list = list.filter((v) => !v.bundleId);
     return list;
-  }, [vacancies, search, filterClass, start, end, filters, vacNameById]);
+  }, [vacancies, search, filterClass, start, end, filters, vacNameById, bundleMode]);
 
   const [groupByBundle, setGroupByBundle] = useState(true);
 
@@ -148,16 +150,18 @@ export default function OpenVacanciesRedesign(props: Props) {
         startDate={start}
         endDate={end}
         category={filterClass}
-        categories={["RCA", "LPN", "RN"]}
         onQueryChange={setSearch}
         onStartDateChange={setStart}
         onEndDateChange={setEnd}
-        onCategoryChange={(v) => setFilterClass(v as any)}
+        onCategoryChange={(value) => setFilterClass(value)}
+        bundleMode={bundleMode}
+        onBundleModeChange={(mode) => setBundleMode(mode)}
         onClear={() => {
           setSearch("");
           setStart("");
           setEnd("");
           setFilterClass("");
+          setBundleMode("all");
         }}
       />
       <div style={{ marginBottom: 8 }}>

--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -1,28 +1,35 @@
 import { ChangeEvent } from "react";
+import type { Classification } from "../types";
+
+type BundleMode = "all" | "bundles" | "singles";
 
 interface Props {
   query: string;
   startDate: string;
   endDate: string;
-  category: string;
-  categories: string[];
+  category: Classification | "";
+  bundleMode: BundleMode;
   onQueryChange: (value: string) => void;
   onStartDateChange: (value: string) => void;
   onEndDateChange: (value: string) => void;
-  onCategoryChange: (value: string) => void;
+  onCategoryChange: (value: Classification | "") => void;
+  onBundleModeChange: (value: BundleMode) => void;
   onClear?: () => void;
 }
+
+const CLASSIFICATIONS: Classification[] = ["RCA", "LPN", "RN"];
 
 export default function SearchFilterBar({
   query,
   startDate,
   endDate,
   category,
-  categories,
+  bundleMode,
   onQueryChange,
   onStartDateChange,
   onEndDateChange,
   onCategoryChange,
+  onBundleModeChange,
   onClear,
 }: Props) {
   const clear = () => {
@@ -30,41 +37,141 @@ export default function SearchFilterBar({
     onStartDateChange("");
     onEndDateChange("");
     onCategoryChange("");
+    onBundleModeChange("all");
     onClear?.();
   };
 
+  const toggleClassification = (value: Classification) => {
+    if (category === value) {
+      onCategoryChange("");
+    } else {
+      onCategoryChange(value);
+    }
+  };
+
+  const toggleBundleMode = (value: BundleMode) => {
+    if (value === "all") {
+      onBundleModeChange("all");
+      return;
+    }
+    if (bundleMode === value) {
+      onBundleModeChange("all");
+    } else {
+      onBundleModeChange(value);
+    }
+  };
+
+  const activeFilters: Array<{ key: string; label: string; onRemove: () => void }> = [];
+  if (query.trim()) {
+    activeFilters.push({ key: "search", label: `Search: “${query.trim()}”`, onRemove: () => onQueryChange("") });
+  }
+  if (category) {
+    activeFilters.push({ key: "category", label: `Class: ${category}`, onRemove: () => onCategoryChange("") });
+  }
+  if (startDate || endDate) {
+    const startLabel = startDate || "Any";
+    const endLabel = endDate || "Any";
+    activeFilters.push({
+      key: "dates",
+      label: `Dates: ${startLabel} → ${endLabel}`,
+      onRemove: () => {
+        onStartDateChange("");
+        onEndDateChange("");
+      },
+    });
+  }
+  if (bundleMode !== "all") {
+    activeFilters.push({
+      key: "bundle",
+      label: bundleMode === "bundles" ? "Bundles only" : "Singles only",
+      onRemove: () => onBundleModeChange("all"),
+    });
+  }
+
   return (
-    <div className="toolbar search-filter-bar">
-      <input
-        type="text"
-        placeholder="Search..."
-        value={query}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => onQueryChange(e.target.value)}
-      />
-      <input
-        type="date"
-        value={startDate}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => onStartDateChange(e.target.value)}
-      />
-      <input
-        type="date"
-        value={endDate}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => onEndDateChange(e.target.value)}
-      />
-      <select
-        value={category}
-        onChange={(e: ChangeEvent<HTMLSelectElement>) => onCategoryChange(e.target.value)}
-      >
-        <option value="">All Categories</option>
-        {categories.map((c) => (
-          <option key={c} value={c}>
+    <div className="toolbar smart-filter-bar search-filter-bar">
+      <div style={{ minWidth: 180, flexShrink: 0 }}>
+        <input
+          type="text"
+          placeholder="Search..."
+          value={query}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onQueryChange(e.target.value)}
+        />
+      </div>
+      <div className="chip-group" aria-label="Classification filters">
+        {CLASSIFICATIONS.map((c) => (
+          <button
+            key={c}
+            type="button"
+            className="pill pill-toggle"
+            data-active={category === c}
+            aria-pressed={category === c}
+            onClick={() => toggleClassification(c)}
+          >
             {c}
-          </option>
+          </button>
         ))}
-      </select>
-      <button className="btn" onClick={clear}>
+      </div>
+      <div className="date-range" aria-label="Date range filters">
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onStartDateChange(e.target.value)}
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onEndDateChange(e.target.value)}
+        />
+      </div>
+      <div className="chip-group" aria-label="Bundle filters">
+        <button
+          type="button"
+          className="pill pill-toggle"
+          data-active={bundleMode === "all"}
+          aria-pressed={bundleMode === "all"}
+          onClick={() => toggleBundleMode("all")}
+        >
+          All
+        </button>
+        <button
+          type="button"
+          className="pill pill-toggle"
+          data-active={bundleMode === "bundles"}
+          aria-pressed={bundleMode === "bundles"}
+          onClick={() => toggleBundleMode("bundles")}
+        >
+          Bundles only
+        </button>
+        <button
+          type="button"
+          className="pill pill-toggle"
+          data-active={bundleMode === "singles"}
+          aria-pressed={bundleMode === "singles"}
+          onClick={() => toggleBundleMode("singles")}
+        >
+          Singles only
+        </button>
+      </div>
+      <button className="btn" onClick={clear} type="button">
         Clear
       </button>
+      {activeFilters.length > 0 && (
+        <div className="active-filter-chips">
+          {activeFilters.map((chip) => (
+            <button
+              key={chip.key}
+              type="button"
+              className="pill active-filter-chip"
+              onClick={chip.onRemove}
+              aria-label={`Remove ${chip.label}`}
+            >
+              <span>{chip.label}</span>
+              <span aria-hidden="true">×</span>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useVacancyFilters.ts
+++ b/src/hooks/useVacancyFilters.ts
@@ -9,6 +9,7 @@ export function useVacancyFilters() {
   const [start, setStart] = useState<string>("");
   const [end, setEnd] = useState<string>("");
   const [search, setSearch] = useState<string>("");
+  const [bundleMode, setBundleMode] = useState<"all" | "bundles" | "singles">("all");
   const [filtersOpen, setFiltersOpen] = useState(false);
   return {
     filterWing,
@@ -25,6 +26,8 @@ export function useVacancyFilters() {
     setEnd,
     search,
     setSearch,
+    bundleMode,
+    setBundleMode,
     filtersOpen,
     setFiltersOpen,
   };


### PR DESCRIPTION
## Summary
- add bundle mode state to the vacancy filter hook and apply it in the open vacancies redesign list
- rebuild the search filter bar with chip-based class and bundle selectors plus active filter clearers
- update toolbar styling so the redesigned filter bar stays on a single horizontal line

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6d2dded188327b49daee0ff055c17