### PR TITLE
Add vacancy detail modal and open actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import VacancyRangeForm from "./components/VacancyRangeForm";
 import BundleRow from "./components/BundleRow";
 import CoverageDaysModal from "./components/CoverageDaysModal";
 import VacancyRow from "./components/VacancyRow";
+import VacancyDetail from "./components/VacancyDetail";
 import OpenVacanciesRedesign from "./components/OpenVacanciesRedesign";
 import { appConfig } from "./config";
 import type { VacancyRange, VacancyStatus, BundleMode } from "./types";
@@ -327,6 +328,7 @@ export default function App() {
   const [stagedDelete, setStagedDelete] = useState<StagedDeleteSnapshot | null>(
     null,
   );
+  const [activeVacancyId, setActiveVacancyId] = useState<string | null>(null);
   const [showRangeForm, setShowRangeForm] = useState(false);
   // Modal system (confirm/prompt/alert)
   const [confirmState, setConfirmState] = useState<
@@ -432,6 +434,24 @@ export default function App() {
     () => Object.fromEntries(employees.map((e) => [e.id, e])),
     [employees],
   );
+  const activeVacancy = useMemo(
+    () => vacancies.find((v) => v.id === activeVacancyId) ?? null,
+    [vacancies, activeVacancyId],
+  );
+
+  const handleOpenVacancyDetail = (id: string) => {
+    setActiveVacancyId(id);
+  };
+
+  const handleCloseVacancyDetail = () => {
+    setActiveVacancyId(null);
+  };
+
+  const handleVacancyDetailUpdate = (id: string, patch: Partial<Vacancy>) => {
+    setVacancies((prev) =>
+      prev.map((vacancy) => (vacancy.id === id ? { ...vacancy, ...patch } : vacancy)),
+    );
+  };
 
   // Recommendation: choose among eligible bidders with highest seniority (rank 1 best)
   const recommendations = useMemo<Record<string, Recommendation>>(() => {
@@ -838,6 +858,10 @@ export default function App() {
     const previousSelectedIds = [...selectedVacancyIds];
     const toRemove = previousVacancies.filter((v) => uniqueIds.includes(v.id));
     if (!toRemove.length) return;
+
+    setActiveVacancyId((curr) =>
+      curr && uniqueIds.includes(curr) ? null : curr,
+    );
 
     if (stagedDelete?.timeout) {
       clearTimeout(stagedDelete.timeout);
@@ -1542,6 +1566,7 @@ export default function App() {
                       onSplitBundle={splitBundle}
                       resetKnownAt={resetKnownAt}
                       resetBundleKnownAt={resetBundleKnownAt}
+                      onOpenDetail={handleOpenVacancyDetail}
                       recommendations={recommendations}
                     />
                   </>
@@ -1693,6 +1718,7 @@ export default function App() {
                             onDeleteMany={stageDeleteMany}
                             onSplitBundle={splitBundle}
                             onAwardBundle={(empId) => awardBundle(row.key, empId)}
+                            onOpenDetail={handleOpenVacancyDetail}
                             dueNextId={dueNextId}
                           />
                         );
@@ -1723,6 +1749,7 @@ export default function App() {
                             onDelete={deleteVacancy}
                             coveredName={coveredName}
                             settings={settings}
+                            onOpenDetail={() => handleOpenVacancyDetail(v.id)}
                           />
                         );
                     })}
@@ -1821,6 +1848,22 @@ export default function App() {
             existingVacancies={vacancies}
           />
         )}
+        <Modal
+          open={!!activeVacancy}
+          title="Vacancy Detail"
+          onClose={handleCloseVacancyDetail}
+        >
+          {activeVacancy && (
+            <VacancyDetail
+              vacancy={activeVacancy}
+              onUpdate={handleVacancyDetailUpdate}
+              onDelete={(id) => {
+                deleteVacancy(id);
+                handleCloseVacancyDetail();
+              }}
+            />
+          )}
+        </Modal>
         {/* App-level modals */}
         <Modal
           open={!!confirmState}

--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -24,6 +24,7 @@ type Props = {
   onResetBundle?: (bundleId: string) => void;
   dueNextId: string | null;
   coveredName?: string;
+  onOpenDetail?: (id: string) => void;
 };
 
 export default function BundleRow({
@@ -41,6 +42,7 @@ export default function BundleRow({
   onResetBundle,
   dueNextId,
   coveredName,
+  onOpenDetail,
 }: Props) {
   const sorted = useMemo(() =>
     [...items].sort((a,b) =>
@@ -191,42 +193,63 @@ export default function BundleRow({
         <CellCountdown source={primary} settings={settings} />
         <CellActions>
           <div className="action-grid">
-          <button className="btn btn-sm" onClick={()=> setAwardOpen((o)=> !o)}>{awardOpen?"Hide Award":"Award Bundle"}</button>
-          {awardOpen && (
-            <InlineEmployeePicker
-              employees={employees}
-              value={activeCandidate?.id ?? ""}
-              onChange={(id)=> onAwardBundle?.(id)}
-            />
-          )}
-          <button className="btn btn-sm" onClick={() => setOpen((o) => !o)}>
-            {open ? "Hide" : "Expand"}
-          </button>
-          {onEditCoverage && (
+            {onOpenDetail && (
+              <button className="btn btn-sm" onClick={() => onOpenDetail(primary.id)}>
+                Details
+              </button>
+            )}
             <button
               className="btn btn-sm"
-              onClick={() => onEditCoverage(groupId)}
+              onClick={() => setAwardOpen((o) => !o)}
             >
-              Edit coverage
+              {awardOpen ? "Hide Award" : "Award Bundle"}
             </button>
-          )}
-          <button className="btn btn-sm" onClick={async () => { if (await (window as any).appShowConfirm?.(`Split this bundle into ${childIds.length} individual shifts?`, "Split bundle")) onSplitBundle(childIds); }}>
-            Split
-          </button>
-          {onResetBundle && (
-            <button className="btn btn-sm" onClick={() => onResetBundle(groupId)}>
-              Reset timers
+            {awardOpen && (
+              <InlineEmployeePicker
+                employees={employees}
+                value={activeCandidate?.id ?? ""}
+                onChange={(id) => onAwardBundle?.(id)}
+              />
+            )}
+            <button className="btn btn-sm" onClick={() => setOpen((o) => !o)}>
+              {open ? "Hide" : "Expand"}
             </button>
-          )}
-          <button
-            className="btn btn-sm danger"
-            onClick={() => onDeleteMany(childIds)}
-          >
-            Delete
-          </button>
+            {onEditCoverage && (
+              <button
+                className="btn btn-sm"
+                onClick={() => onEditCoverage(groupId)}
+              >
+                Edit coverage
+              </button>
+            )}
+            <button
+              className="btn btn-sm"
+              onClick={async () => {
+                const confirmed = await (window as any).appShowConfirm?.(
+                  `Split this bundle into ${childIds.length} individual shifts?`,
+                  "Split bundle",
+                );
+                if (confirmed) {
+                  onSplitBundle(childIds);
+                }
+              }}
+            >
+              Split
+            </button>
+            {onResetBundle && (
+              <button className="btn btn-sm" onClick={() => onResetBundle(groupId)}>
+                Reset timers
+              </button>
+            )}
+            <button
+              className="btn btn-sm danger"
+              onClick={() => onDeleteMany(childIds)}
+            >
+              Delete
+            </button>
           </div>
         </CellActions>
-      </tr>
+        </tr>
 
       {open && (
         <tr>

--- a/src/components/OpenVacancies.tsx
+++ b/src/components/OpenVacancies.tsx
@@ -21,6 +21,7 @@ interface Props {
   staged: Vacancy[] | null;
   readOnly?: boolean;
   resetBundleKnownAt?: (bundleId: string) => void;
+  onOpenDetail?: (id: string) => void;
 }
 
 export default function OpenVacancies({
@@ -31,6 +32,7 @@ export default function OpenVacancies({
   staged,
   readOnly = false,
   resetBundleKnownAt,
+  onOpenDetail,
 }: Props) {
   const [selected, setSelected] = useState<string[]>([]);
   const [pending, setPending] = useState<string[] | null>(null);
@@ -319,49 +321,66 @@ export default function OpenVacancies({
                         : "Varies"}
                     </td>
                     <td style={{ textAlign: "right" }}>
-                      {!readOnly && (
-                        <>
+                      <div
+                        style={{
+                          display: "inline-flex",
+                          gap: 4,
+                          flexWrap: "wrap",
+                          justifyContent: "flex-end",
+                        }}
+                      >
+                        {onOpenDetail && (
                           <button
                             className="btn btn-sm"
-                            onClick={() =>
-                              setExpanded((prev) => ({
-                                ...prev,
-                                [primary.bundleId!]: !isOpen,
-                              }))
-                            }
+                            onClick={() => onOpenDetail(primary.id)}
                           >
-                            {isOpen ? "Hide" : "Expand"}
+                            Details
                           </button>
-                          {resetBundleKnownAt && (
+                        )}
+                        {!readOnly && (
+                          <>
                             <button
                               className="btn btn-sm"
-                              onClick={() => resetBundleKnownAt(primary.bundleId!)}
+                              onClick={() =>
+                                setExpanded((prev) => ({
+                                  ...prev,
+                                  [primary.bundleId!]: !isOpen,
+                                }))
+                              }
                             >
-                              Reset timers
+                              {isOpen ? "Hide" : "Expand"}
                             </button>
-                          )}
-                          <button
-                            className="btn btn-sm"
-                            title="Delete vacancy"
-                            aria-label="Delete vacancy"
-                            data-testid={`vacancy-delete-${primary.id}`}
-                            tabIndex={0}
-                            onClick={() => confirmDelete(ids)}
-                          >
-                            {TrashIcon ? (
-                              <>
-                                <TrashIcon
-                                  style={{ width: 16, height: 16 }}
-                                  aria-hidden="true"
-                                />
-                                <span className="sr-only">Delete vacancy</span>
-                              </>
-                            ) : (
-                              "Delete"
+                            {resetBundleKnownAt && (
+                              <button
+                                className="btn btn-sm"
+                                onClick={() => resetBundleKnownAt(primary.bundleId!)}
+                              >
+                                Reset timers
+                              </button>
                             )}
-                          </button>
-                        </>
-                      )}
+                            <button
+                              className="btn btn-sm"
+                              title="Delete vacancy"
+                              aria-label="Delete vacancy"
+                              data-testid={`vacancy-delete-${primary.id}`}
+                              tabIndex={0}
+                              onClick={() => confirmDelete(ids)}
+                            >
+                              {TrashIcon ? (
+                                <>
+                                  <TrashIcon
+                                    style={{ width: 16, height: 16 }}
+                                    aria-hidden="true"
+                                  />
+                                  <span className="sr-only">Delete vacancy</span>
+                                </>
+                              ) : (
+                                "Delete"
+                              )}
+                            </button>
+                          </>
+                        )}
+                      </div>
                     </td>
                   </tr>
                   {isOpen && (
@@ -433,28 +452,45 @@ export default function OpenVacancies({
                     : "Varies"}
                 </td>
                 <td style={{ textAlign: "right" }}>
-                  {!readOnly && (
-                    <button
-                      className="btn btn-sm"
-                      title="Delete vacancy"
-                      aria-label="Delete vacancy"
-                      data-testid={`vacancy-delete-${primary.id}`}
-                      tabIndex={0}
-                      onClick={() => confirmDelete(ids)}
-                    >
-                      {TrashIcon ? (
-                        <>
-                          <TrashIcon
-                            style={{ width: 16, height: 16 }}
-                            aria-hidden="true"
-                          />
-                          <span className="sr-only">Delete vacancy</span>
-                        </>
-                      ) : (
-                        "Delete"
-                      )}
-                    </button>
-                  )}
+                  <div
+                    style={{
+                      display: "inline-flex",
+                      gap: 4,
+                      flexWrap: "wrap",
+                      justifyContent: "flex-end",
+                    }}
+                  >
+                    {onOpenDetail && (
+                      <button
+                        className="btn btn-sm"
+                        onClick={() => onOpenDetail(primary.id)}
+                      >
+                        Details
+                      </button>
+                    )}
+                    {!readOnly && (
+                      <button
+                        className="btn btn-sm"
+                        title="Delete vacancy"
+                        aria-label="Delete vacancy"
+                        data-testid={`vacancy-delete-${primary.id}`}
+                        tabIndex={0}
+                        onClick={() => confirmDelete(ids)}
+                      >
+                        {TrashIcon ? (
+                          <>
+                            <TrashIcon
+                              style={{ width: 16, height: 16 }}
+                              aria-hidden="true"
+                            />
+                            <span className="sr-only">Delete vacancy</span>
+                          </>
+                        ) : (
+                          "Delete"
+                        )}
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             );

--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -24,6 +24,7 @@ type Props = {
   onSplitBundle?: (ids: string[]) => void;
   resetKnownAt: (id: string) => void;
   resetBundleKnownAt?: (bundleId: string) => void;
+  onOpenDetail?: (id: string) => void;
   filters?: {
     search?: string;
     wing?: string;
@@ -209,6 +210,7 @@ export default function OpenVacanciesRedesign(props: Props) {
                   onEditCoverage={props.onEditCoverage}
                   onAwardBundle={(eid) => props.awardBundle?.(key, eid)}
                   onResetBundle={props.resetBundleKnownAt}
+                  onOpenDetail={props.onOpenDetail}
                   dueNextId={props.dueNextId}
                   coveredName={coveredName}
                 />
@@ -233,6 +235,11 @@ export default function OpenVacanciesRedesign(props: Props) {
                   isDueNext={props.dueNextId === v.id}
                   coveredName={coveredName}
                   settings={settings}
+                  onOpenDetail={
+                    props.onOpenDetail
+                      ? () => props.onOpenDetail?.(v.id)
+                      : undefined
+                  }
                 />,
               );
             }

--- a/src/components/VacancyRow.tsx
+++ b/src/components/VacancyRow.tsx
@@ -29,6 +29,7 @@ export default function VacancyRow({
   as = "tr",
   style,
   ariaProps,
+  onOpenDetail,
 }: {
   v: Vacancy;
   recommendation?: Recommendation;
@@ -48,6 +49,7 @@ export default function VacancyRow({
   as?: "tr" | "div";
   style?: CSSProperties;
   ariaProps?: Record<string, string | number | undefined>;
+  onOpenDetail?: () => void;
 }) {
   const [choice, setChoice] = useState<string>("");
   const [choiceManual, setChoiceManual] = useState<boolean>(false);
@@ -228,6 +230,11 @@ export default function VacancyRow({
       <CellActions component={cellComponent}>
         {isBundleChild ? (
           <div className="action-grid">
+            {onOpenDetail && (
+              <button className="btn btn-sm" onClick={onOpenDetail}>
+                Details
+              </button>
+            )}
             <button className="btn btn-sm" onClick={resetKnownAt}>
               Reset timer
             </button>
@@ -253,6 +260,11 @@ export default function VacancyRow({
           </div>
         ) : (
           <div className="action-grid">
+            {onOpenDetail && (
+              <button className="btn btn-sm" onClick={onOpenDetail}>
+                Details
+              </button>
+            )}
             <button
               className="btn btn-sm"
               onClick={() =>


### PR DESCRIPTION
## Summary
- add an active vacancy detail modal to the coverage tab and wire it to `VacancyDetail`
- expose "Details" entry points on bundle and vacancy rows in both redesign and legacy tables
- ensure deletions close the detail view while updates flow through `setVacancies`

## Testing
- npm test -- tests/components/recommendationCycle.test.tsx
- npm test -- tests/openVacancies.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dacb2c6ad4832784e21106dff11615