### PR TITLE
Configure dev proxy for analytics API

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ npm install
 npm run dev
 ```
 
+> **Note:** The UI fetches analytics data from the Express backend during local development. In another terminal, run `node server/index.js` (or your preferred proxy to the analytics API) so `/api` requests resolve to a server such as `http://localhost:3001` while the Vite dev server is running.
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,13 @@ export default defineConfig({
   },
   server: {
     host: "0.0.0.0",
-    port: 5000
+    port: 5000,
+    proxy: {
+      "/api": {
+        target: "http://localhost:3001",
+        changeOrigin: true,
+      },
+    },
   },
   build: {
     rollupOptions: {


### PR DESCRIPTION
## Summary
- add a Vite dev server proxy so /api calls go to the local Express backend during development
- document running or proxying the analytics backend in the quick-start instructions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf2561d848327bc9a3ed599ea2b2e