### PR TITLE
Bind analytics server to all interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ npm run dev
 | Variable | Default | Description |
 |---------|---------|-------------|
 | `ANALYTICS_AUTH_TOKEN` | – | Bearer token for analytics endpoints |
-| `PORT` | `3000` | Server port |
+| `PORT` | `3001` | Analytics server port (binds to all network interfaces) |
 
 Example `.env.local`:
 
 ```bash
 ANALYTICS_AUTH_TOKEN=mys3cret
-PORT=3000
+PORT=3001
 ```
 
 ## Usage

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -5,13 +5,13 @@ Maplewood Scheduler uses environment variables for runtime settings.
 | Variable | Required | Description |
 |---------|----------|-------------|
 | `ANALYTICS_AUTH_TOKEN` | ✅ | Bearer token protecting analytics endpoints |
-| `PORT` | ❌ (`3000`) | Port the server listens on |
+| `PORT` | ❌ (`3001`) | Port the analytics server listens on (binds to all network interfaces) |
 
 ## Example `.env.local`
 
 ```bash
 ANALYTICS_AUTH_TOKEN=mys3cret
-PORT=3000
+PORT=3001
 ```
 
 Store secrets outside of version control. Use `.env.local` for development

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,7 +12,7 @@ npm run preview
 
 ```bash
 docker build -t maplewood-scheduler .
-docker run -p 3000:3000 maplewood-scheduler
+docker run -p 3001:3001 maplewood-scheduler
 ```
 
 ## Netlify

--- a/server/index.js
+++ b/server/index.js
@@ -104,7 +104,7 @@ app.get("/api/analytics/export", requireAuth, (req, res) => {
 
 if (process.env.NODE_ENV !== "test") {
   const port = process.env.PORT || 3001;
-  app.listen(port, "localhost", () => {
+  app.listen(port, () => {
     console.log(`Analytics server running on port ${port}`);
   });
 }


### PR DESCRIPTION
## Summary
- allow the analytics express server to listen on all interfaces by removing the localhost binding
- document the default 3001 port and interface binding in the README and configuration docs
- update deployment instructions to use the correct container port mapping

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf258c0b083279e8717b3ad4bd6f3