### PR TITLE
Sort archived vacancies by timestamp

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2121,7 +2121,25 @@ export function ArchivePage({
   vacancies: Vacancy[];
   archivedBids: Record<string, Bid[]>;
 }) {
-  const archived = vacancies.filter((v) => v.archived);
+  const archived = useMemo(() => {
+    const getTimestamp = (v: Vacancy) => {
+      if (v.archivedAt) {
+        return new Date(v.archivedAt).getTime();
+      }
+      if (v.shiftDate && v.shiftStart) {
+        return combineDateTime(v.shiftDate, v.shiftStart).getTime();
+      }
+      if (v.shiftDate) {
+        return new Date(`${v.shiftDate}T00:00:00`).getTime();
+      }
+      return 0;
+    };
+
+    return vacancies
+      .filter((v) => v.archived)
+      .slice()
+      .sort((a, b) => getTimestamp(b) - getTimestamp(a));
+  }, [vacancies]);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   return (
     <div className="grid">


### PR DESCRIPTION
## Summary
- memoize archived vacancies list to avoid unnecessary recalculations
- sort archived vacancies by archivedAt and fallback shift timing
- render archive table using the sorted collection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd550418988327af5fffa4c1073e98