### PR TITLE
Expand classification options to include receptionist roles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import VacancyDetail from "./components/VacancyDetail";
 import OpenVacanciesRedesign from "./components/OpenVacanciesRedesign";
 import SearchFilterBar from "./components/SearchFilterBar";
 import { appConfig } from "./config";
+import { CLASSIFICATIONS } from "./types";
 import type { VacancyRange, VacancyStatus, BundleMode } from "./types";
 export { OVERRIDE_REASONS } from "./types";
 import { createVacanciesFromRange, bundleContiguousVacanciesByRef } from "./lib/bundles";
@@ -42,12 +43,12 @@ import Modal from "./components/ui/Modal";
  * ✔ Sticky table header for Open Vacancies + scrollable panel; highlight the row that’s “due next”
  * ✔ Theme toggle (Dark/Light) + text size slider (great for wall displays)
  * ✔ Reason codes required when you override the recommendation (audit‑friendly trail)
- * ✔ Eligibility gate: block awards outside vacancy class (RCA/LPN/RN) unless “Allow class override” is checked
+ * ✔ Eligibility gate: block awards outside vacancy class (RCA/LPN/RN/Rec/Receptionist) unless “Allow class override” is checked
  * ✔ Open Vacancies layout reformatted to take most of the page and avoid cut‑off
  */
 
 // ---------- Types ----------
-export type Classification = "RCA" | "LPN" | "RN";
+export type Classification = (typeof CLASSIFICATIONS)[number];
 export type Status = "FT" | "PT" | "Casual";
 
 export type Employee = {
@@ -1288,7 +1289,7 @@ export default function App() {
                               : "",
                           classification: (e?.classification ??
                             v.classification ??
-                            "RCA") as Classification,
+                            CLASSIFICATIONS[0]) as Classification,
                         }));
                       }}
                     />
@@ -1297,7 +1298,7 @@ export default function App() {
                     <div>
                       <label>Classification</label>
                       <select
-                        value={newVacay.classification ?? "RCA"}
+                        value={newVacay.classification ?? CLASSIFICATIONS[0]}
                         onChange={(e) =>
                           setNewVacay((v) => ({
                             ...v,
@@ -1305,9 +1306,11 @@ export default function App() {
                           }))
                         }
                       >
-                        <option value="RCA">RCA</option>
-                        <option value="LPN">LPN</option>
-                        <option value="RN">RN</option>
+                        {CLASSIFICATIONS.map((option) => (
+                          <option key={option} value={option}>
+                            {option}
+                          </option>
+                        ))}
                       </select>
                     </div>
                   )}
@@ -1633,9 +1636,10 @@ export default function App() {
                         key: "class",
                         options: [
                           { value: "", label: "All Classes" },
-                          { value: "RCA", label: "RCA" },
-                          { value: "LPN", label: "LPN" },
-                          { value: "RN", label: "RN" },
+                          ...CLASSIFICATIONS.map((c) => ({
+                            value: c,
+                            label: c,
+                          })),
                         ],
                       },
                       {
@@ -1976,33 +1980,38 @@ function EmployeesPage({
                 await (window as any).appShowAlert?.("Failed to parse CSV");
                 return;
               }
-              const out: Employee[] = rows.map((r: any, i: number) => ({
-                id: String(r.id ?? r.EmployeeID ?? `emp_${i}`),
-                firstName: String(r.firstName ?? r.name ?? ""),
-                lastName: String(r.lastName ?? ""),
-                classification: (["RCA", "LPN", "RN"].includes(
-                  String(r.classification),
-                )
-                  ? r.classification
-                  : "RCA") as Classification,
-                status: (["FT", "PT", "Casual"].includes(String(r.status))
-                  ? r.status
-                  : "FT") as Status,
-                homeWing: String(r.homeWing ?? ""),
-                startDate: String(r.startDate ?? ""),
-                seniorityHours: Number(r.seniorityHours ?? 0),
-                seniorityRank: Number(r.seniorityRank ?? i + 1),
-                active: String(r.active ?? "Yes")
-                  .toLowerCase()
-                  .startsWith("y"),
-              }));
+              const out: Employee[] = rows.map((r: any, i: number) => {
+                const rawClass = String(r.classification ?? "").trim();
+                const normalizedClass =
+                  CLASSIFICATIONS.find(
+                    (option) =>
+                      option.toLowerCase() === rawClass.toLowerCase(),
+                  ) ?? CLASSIFICATIONS[0];
+
+                return {
+                  id: String(r.id ?? r.EmployeeID ?? `emp_${i}`),
+                  firstName: String(r.firstName ?? r.name ?? ""),
+                  lastName: String(r.lastName ?? ""),
+                  classification: normalizedClass as Classification,
+                  status: (["FT", "PT", "Casual"].includes(String(r.status))
+                    ? r.status
+                    : "FT") as Status,
+                  homeWing: String(r.homeWing ?? ""),
+                  startDate: String(r.startDate ?? ""),
+                  seniorityHours: Number(r.seniorityHours ?? 0),
+                  seniorityRank: Number(r.seniorityRank ?? i + 1),
+                  active: String(r.active ?? "Yes")
+                    .toLowerCase()
+                    .startsWith("y"),
+                };
+              });
               setEmployees(out.filter((e) => !!e.id));
             }}
           />
           <div className="subtitle">
-            Columns: id, firstName, lastName, classification (RCA/LPN/RN),
-            status (FT/PT/Casual), homeWing, startDate, seniorityHours,
-            seniorityRank, active (Yes/No)
+            Columns: id, firstName, lastName, classification (RCA/LPN/RN/Rec/
+            Receptionist), status (FT/PT/Casual), homeWing, startDate,
+            seniorityHours, seniorityRank, active (Yes/No)
           </div>
         </div>
       </div>
@@ -2051,9 +2060,11 @@ function EmployeesPage({
               <div>
                 <label>Class</label>
                 <select name="classification">
-                  <option value="RCA">RCA</option>
-                  <option value="LPN">LPN</option>
-                  <option value="RN">RN</option>
+                  {CLASSIFICATIONS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
                 </select>
               </div>
               <div>
@@ -2747,7 +2758,7 @@ export function BidsPage({
                       bidderName: newBid.bidderName ?? "",
                       bidderStatus: (newBid.bidderStatus ?? "Casual") as Status,
                       bidderClassification: (newBid.bidderClassification ??
-                        "RCA") as Classification,
+                        CLASSIFICATIONS[0]) as Classification,
                       bidTimestamp: ts,
                       notes: newBid.notes ?? "",
                     })),
@@ -2792,9 +2803,7 @@ export function BidsPage({
                   key: "class",
                   options: [
                     { value: "", label: "All Classes" },
-                    { value: "RCA", label: "RCA" },
-                    { value: "LPN", label: "LPN" },
-                    { value: "RN", label: "RN" },
+                    ...CLASSIFICATIONS.map((c) => ({ value: c, label: c })),
                   ],
                 },
                 {

--- a/src/components/OpenVacancies.tsx
+++ b/src/components/OpenVacancies.tsx
@@ -5,7 +5,7 @@ import Toast from "./ui/Toast";
 import { TrashIcon } from "./ui/Icon";
 import CoverageChip from "./ui/CoverageChip";
 import FilterBar from "./ui/FilterBar";
-import { WINGS, SHIFT_PRESETS } from "../types";
+import { WINGS, SHIFT_PRESETS, CLASSIFICATIONS } from "../types";
 import { deadlineFor, pickWindowMinutes } from "../lib/vacancy";
 import { minutesBetween } from "../lib/dates";
 
@@ -168,9 +168,7 @@ export default function OpenVacancies({
             key: "class",
             options: [
               { value: "", label: "All Classes" },
-              { value: "RCA", label: "RCA" },
-              { value: "LPN", label: "LPN" },
-              { value: "RN", label: "RN" },
+              ...CLASSIFICATIONS.map((c) => ({ value: c, label: c })),
             ],
           },
           {

--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent } from "react";
+import { CLASSIFICATIONS } from "../types";
 import type { Classification } from "../types";
 
 type BundleMode = "all" | "bundles" | "singles";
@@ -16,8 +17,6 @@ interface Props {
   onBundleModeChange: (value: BundleMode) => void;
   onClear?: () => void;
 }
-
-const CLASSIFICATIONS: Classification[] = ["RCA", "LPN", "RN"];
 
 export default function SearchFilterBar({
   query,

--- a/src/components/VacancyList.tsx
+++ b/src/components/VacancyList.tsx
@@ -3,7 +3,7 @@ import type { Vacancy, Employee, Settings } from "../types";
 import type { Recommendation } from "../recommend";
 import VacancyRow from "./VacancyRow";
 import { useVacancyFilters } from "../hooks/useVacancyFilters";
-import { WINGS, SHIFT_PRESETS } from "../types";
+import { WINGS, SHIFT_PRESETS, CLASSIFICATIONS } from "../types";
 import { deadlineFor, pickWindowMinutes } from "../lib/vacancy";
 import { minutesBetween } from "../lib/dates";
 import { List, type RowComponentProps } from "react-window";
@@ -171,7 +171,7 @@ export default function VacancyList({
             </select>
             <select value={filterClass} onChange={(e) => setFilterClass(e.target.value as any)}>
               <option value="">All Classes</option>
-              {["RCA", "LPN", "RN"].map((c) => (
+              {CLASSIFICATIONS.map((c) => (
                 <option key={c} value={c}>
                   {c}
                 </option>

--- a/src/components/VacancyRangeForm.tsx
+++ b/src/components/VacancyRangeForm.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import { CLASSIFICATIONS } from "../types";
 import type { VacancyRange, Classification, Vacancy } from "../types";
 import CoverageDaysModal from "./CoverageDaysModal";
 import { getDatesInRange, formatCoverageSummary } from "../utils/date";
@@ -26,7 +27,7 @@ export default function VacancyRangeForm({
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [classification, setClassification] = useState<Classification>(
-    defaultClassification ?? "RCA",
+    defaultClassification ?? CLASSIFICATIONS[0],
   );
   const [wing, setWing] = useState<string>(defaultWing ?? "");
   const [shiftStart, setShiftStart] = useState("06:30");
@@ -136,7 +137,11 @@ export default function VacancyRangeForm({
               className="border rounded-md px-2 py-1"
               disabled={!!defaultClassification}
             >
-              <option>RCA</option><option>LPN</option><option>RN</option>
+              {CLASSIFICATIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
             </select>
           </label>
           <label className="flex flex-col gap-1">

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,12 @@
-export type Classification = "RCA" | "LPN" | "RN";
+export const CLASSIFICATIONS = [
+  "RCA",
+  "LPN",
+  "RN",
+  "Rec",
+  "Receptionist",
+] as const;
+
+export type Classification = (typeof CLASSIFICATIONS)[number];
 export type Status = "FT" | "PT" | "Casual";
 
 export type Employee = {

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -96,12 +96,16 @@ describe("validateClassification", () => {
     expect(validateClassification("RCA").isValid).toBe(true);
     expect(validateClassification("LPN").isValid).toBe(true);
     expect(validateClassification("RN").isValid).toBe(true);
+    expect(validateClassification("Rec").isValid).toBe(true);
+    expect(validateClassification("Receptionist").isValid).toBe(true);
   });
 
   it("should reject invalid classifications", () => {
     const result = validateClassification("INVALID");
     expect(result.isValid).toBe(false);
-    expect(result.error).toBe("Classification must be RCA, LPN, or RN");
+    expect(result.error).toBe(
+      "Classification must be one of: RCA, LPN, RN, Rec, Receptionist",
+    );
   });
 
   it("should reject empty classification", () => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,3 +1,5 @@
+import { CLASSIFICATIONS } from "../types";
+
 /**
  * Validation utilities for form inputs
  */
@@ -90,14 +92,19 @@ export function validateTimeRange(startTime: string, endTime: string): Validatio
  * Validate classification
  */
 export function validateClassification(classification: string): ValidationResult {
-  const validClassifications = ["RCA", "LPN", "RN"];
-  
   if (!classification) {
     return { isValid: false, error: "Classification is required" };
   }
 
-  if (!validClassifications.includes(classification)) {
-    return { isValid: false, error: "Classification must be RCA, LPN, or RN" };
+  const isKnownClass = CLASSIFICATIONS.some(
+    (option) => option === classification,
+  );
+
+  if (!isKnownClass) {
+    return {
+      isValid: false,
+      error: `Classification must be one of: ${CLASSIFICATIONS.join(", ")}`,
+    };
   }
 
   return { isValid: true };


### PR DESCRIPTION
## Summary
- add a shared CLASSIFICATIONS constant with Rec and Receptionist and adopt it across classification selectors
- normalize CSV imports and instructional copy to accept the expanded classification list
- update validation helpers and tests to cover the new classification options

## Testing
- npm test -- src/utils/validation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd5b62c3548327aae2813e7805cba5