### PR TITLE
Fix bundle grouping toggle handling

### DIFF
--- a/src/components/OpenVacancies.tsx
+++ b/src/components/OpenVacancies.tsx
@@ -147,7 +147,7 @@ export default function OpenVacancies({
           <input
             type="checkbox"
             checked={groupByBundle}
-            onChange={() => setGroupByBundle(true)}
+            onChange={(event) => setGroupByBundle(event.target.checked)}
           />
           Group by bundle
         </label>


### PR DESCRIPTION
## Summary
- update the Group by bundle checkbox to respect the checked state so grouping can be toggled off

## Testing
- Manual verification: confirmed that when `groupByBundle` is false, the `grouped` memo returns single-item arrays

------
https://chatgpt.com/codex/tasks/task_e_68dd6b63a498832796e27393adedbaad