### PR TITLE
Reset coverage modal state when range props change

### DIFF
--- a/src/components/CoverageDaysModal.tsx
+++ b/src/components/CoverageDaysModal.tsx
@@ -54,11 +54,41 @@ function BodyScrollLock() {
   return null;
 }
 
+function shallowEqualBooleanMap(a: Record<string, boolean>, b: Record<string, boolean>) {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
+function shallowEqualTimesMap(a: Record<string, Times>, b: Record<string, Times>) {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    const aVal = a[key];
+    const bVal = b[key];
+    if (!bVal || aVal.start !== bVal.start || aVal.end !== bVal.end) return false;
+  }
+  return true;
+}
+
+function shallowEqualStringMap(a: Record<string, string>, b: Record<string, string>) {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
 export default function CoverageDaysModal({
   open, startDate, endDate, defaultStart, defaultEnd, classification, initial, onSave, onClose
 }: Props) {
-  if (!open) return null;
-
   // Build a week-grid (calendar) that fully covers the range
   const grid = useMemo(() => {
     const start = startOfWeekISO(startDate);
@@ -78,31 +108,55 @@ export default function CoverageDaysModal({
     return set;
   }, [startDate, endDate]);
 
+  const inRangeDates = useMemo(() => Array.from(inRangeSet), [inRangeSet]);
+
   // Selection + overrides
   const [selected, setSelected] = useState<Record<string, boolean>>(() => {
-    // default: all in range selected
     const seed: Record<string, boolean> = {};
-    grid.flat().forEach(d => { seed[d] = inRangeSet.has(d) ? true : false; });
+    inRangeDates.forEach(d => { seed[d] = true; });
     if (initial?.selectedDates?.length) {
       const chosen = new Set(initial.selectedDates);
-      grid.flat().forEach(d => { seed[d] = chosen.has(d); });
+      inRangeDates.forEach(d => { seed[d] = chosen.has(d); });
     }
     return seed;
   });
 
   const [perDayTimes, setPerDayTimes] = useState<Record<string, Times>>(() => {
     const t: Record<string, Times> = {};
-    grid.flat().forEach(d => {
-      t[d] = initial?.perDayTimes?.[d] ?? { start: defaultStart, end: defaultEnd };
+    inRangeDates.forEach(d => {
+      const override = initial?.perDayTimes?.[d];
+      t[d] = override ? { ...override } : { start: defaultStart, end: defaultEnd };
     });
     return t;
   });
 
   const [perDayWing, setPerDayWing] = useState<Record<string, string>>(() => {
     const w: Record<string, string> = {};
-    grid.flat().forEach(d => { w[d] = initial?.perDayWing?.[d] ?? ""; });
+    inRangeDates.forEach(d => { w[d] = initial?.perDayWing?.[d] ?? ""; });
     return w;
   });
+
+  useEffect(() => {
+    const nextSelected: Record<string, boolean> = {};
+    inRangeDates.forEach(d => { nextSelected[d] = true; });
+    if (initial?.selectedDates?.length) {
+      const chosen = new Set(initial.selectedDates);
+      inRangeDates.forEach(d => { nextSelected[d] = chosen.has(d); });
+    }
+
+    const nextTimes: Record<string, Times> = {};
+    inRangeDates.forEach(d => {
+      const override = initial?.perDayTimes?.[d];
+      nextTimes[d] = override ? { ...override } : { start: defaultStart, end: defaultEnd };
+    });
+
+    const nextWings: Record<string, string> = {};
+    inRangeDates.forEach(d => { nextWings[d] = initial?.perDayWing?.[d] ?? ""; });
+
+    setSelected(prev => shallowEqualBooleanMap(prev, nextSelected) ? prev : nextSelected);
+    setPerDayTimes(prev => shallowEqualTimesMap(prev, nextTimes) ? prev : nextTimes);
+    setPerDayWing(prev => shallowEqualStringMap(prev, nextWings) ? prev : nextWings);
+  }, [open, startDate, endDate, defaultStart, defaultEnd, initial, inRangeDates]);
 
   const toggle = (d: string) => {
     if (!inRangeSet.has(d)) return;
@@ -146,6 +200,8 @@ export default function CoverageDaysModal({
       perDayWing:  Object.fromEntries(chosen.map(d => [d, perDayWing[d] ?? ""])),
     });
   };
+
+  if (!open) return null;
 
   return (
     <div className="modal-overlay" role="dialog" aria-modal="true">

--- a/tests/coverageDaysModalRangeUpdate.test.tsx
+++ b/tests/coverageDaysModalRangeUpdate.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CoverageDaysModal from "../src/components/CoverageDaysModal";
+
+describe("CoverageDaysModal", () => {
+  it("rebuilds selections when the coverage range changes", () => {
+    const onSave = vi.fn();
+
+    const { rerender } = render(
+      <CoverageDaysModal
+        open
+        startDate="2024-01-10"
+        endDate="2024-01-10"
+        defaultStart="08:00"
+        defaultEnd="16:00"
+        classification="RN"
+        initial={{
+          selectedDates: ["2024-01-10"],
+          perDayTimes: {
+            "2024-01-10": { start: "09:00", end: "17:00" },
+          },
+          perDayWing: {
+            "2024-01-10": "West",
+          },
+        }}
+        onSave={onSave}
+        onClose={() => {}}
+      />,
+    );
+
+    onSave.mockReset();
+
+    rerender(
+      <CoverageDaysModal
+        open
+        startDate="2024-01-11"
+        endDate="2024-01-12"
+        defaultStart="08:00"
+        defaultEnd="16:00"
+        classification="RN"
+        initial={{
+          perDayTimes: {
+            "2024-01-11": { start: "09:00", end: "17:00" },
+          },
+          perDayWing: {
+            "2024-01-11": "West",
+          },
+        }}
+        onSave={onSave}
+        onClose={() => {}}
+      />,
+    );
+
+    const modal = screen.getByRole("dialog");
+    const wingInputs = within(modal).getAllByPlaceholderText("Wing (optional)");
+    expect(wingInputs).toHaveLength(2);
+
+    fireEvent.click(within(modal).getByText("Save"));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const payload = onSave.mock.calls[0][0];
+    expect(payload.selectedDates).toEqual(["2024-01-11", "2024-01-12"]);
+    expect(payload.perDayTimes).toEqual({
+      "2024-01-11": { start: "09:00", end: "17:00" },
+      "2024-01-12": { start: "08:00", end: "16:00" },
+    });
+    expect(payload.perDayWing).toEqual({
+      "2024-01-11": "West",
+      "2024-01-12": "",
+    });
+    expect(payload.perDayTimes).not.toHaveProperty("2024-01-10");
+    expect(payload.perDayWing).not.toHaveProperty("2024-01-10");
+  });
+});
+


### PR DESCRIPTION
## Summary
- rebuild coverage modal selection, time, and wing maps when the modal props change
- default new in-range days to selected while honoring overrides passed through `initial`
- add a regression test to ensure extending the range preselects new days and saves without reselection

## Testing
- npm test -- coverageDaysModalRangeUpdate

------
https://chatgpt.com/codex/tasks/task_e_68dd713fb63c8327a7dd8ead43583e49