### PR TITLE
Fix summary card grid responsiveness

### DIFF
--- a/src/styles/polish.css
+++ b/src/styles/polish.css
@@ -85,15 +85,19 @@
   gap: 12px;
   margin: 16px 0 20px;
 }
+.summary-grid .card {
+  grid-column: span 3;
+}
 @media (max-width: 1100px) {
   .summary-grid { grid-template-columns: repeat(6, 1fr); }
+  .summary-grid .card { grid-column: span 6; }
 }
 @media (max-width: 720px) {
   .summary-grid { grid-template-columns: repeat(2, 1fr); }
+  .summary-grid .card { grid-column: span 2; }
 }
 
 .card {
-  grid-column: span 3;
   background: var(--card);
   border: 1px solid var(--stroke);
   border-radius: 14px;


### PR DESCRIPTION
## Summary
- adjust the summary grid card spans to match the column count at each breakpoint so cards wrap cleanly on smaller viewports

## Testing
- Manual QA

------
https://chatgpt.com/codex/tasks/task_e_68dd7d324ed483278baf3ad6f956956f