### PR TITLE
Ensure countdown badge uses tabular numbers

### DIFF
--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -170,6 +170,10 @@
   border-radius: 999px;
   border: 1px solid var(--stroke);
   font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+  min-width: 3ch;
+  text-align: right;
 }
 
 .cd-green {


### PR DESCRIPTION
## Summary
- enable tabular numbers in the countdown badge so digits occupy consistent widths
- add a small minimum width and right alignment to keep the badge stable in standard and responsive tables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda24c71ac8327a3f0b0f527c0ae8e