### PR TITLE
Add notification preferences, deadline monitoring, and SSE support

### DIFF
--- a/server/deadlineHub.d.ts
+++ b/server/deadlineHub.d.ts
@@ -1,0 +1,30 @@
+import type { ServerResponse } from "http";
+
+export type DeadlineChannel = "inApp" | "email" | "sms";
+export type DeadlineSeverity = "info" | "warning" | "critical";
+
+export interface DeadlineEventPayload {
+  id?: string;
+  vacancyId: string;
+  leadTimeId: string;
+  message: string;
+  deadlineAt: string;
+  triggeredAt: string;
+  severity?: DeadlineSeverity;
+  channels?: DeadlineChannel[];
+  suppressedChannels?: DeadlineChannel[];
+  origin?: string;
+  broadcastedAt?: string;
+}
+
+export declare class DeadlineHub {
+  constructor(options?: { dispatcher?: any });
+  addClient(res: ServerResponse): string;
+  removeClient(id: string): void;
+  broadcast(event: DeadlineEventPayload): Promise<DeadlineEventPayload>;
+  dispatch(event: DeadlineEventPayload): Promise<void>;
+  setDispatcher(dispatcher: any): void;
+}
+
+export declare const deadlineHub: DeadlineHub;
+export default deadlineHub;

--- a/server/deadlineHub.js
+++ b/server/deadlineHub.js
@@ -1,0 +1,81 @@
+import { randomUUID } from "crypto";
+import { createWebhookDispatcher } from "./notificationDispatcher.js";
+
+export class DeadlineHub {
+  constructor({ dispatcher } = {}) {
+    this.clients = new Map();
+    this.dispatcher = dispatcher ?? createWebhookDispatcher();
+    this.keepAliveMs = 25_000;
+  }
+
+  setDispatcher(dispatcher) {
+    this.dispatcher = dispatcher ?? createWebhookDispatcher();
+  }
+
+  addClient(res) {
+    const id = randomUUID();
+    const keepAlive = setInterval(() => {
+      try {
+        res.write(":keep-alive\n\n");
+      } catch (err) {
+        clearInterval(keepAlive);
+        this.removeClient(id);
+      }
+    }, this.keepAliveMs);
+    this.clients.set(id, { res, keepAlive });
+    return id;
+  }
+
+  removeClient(id) {
+    const client = this.clients.get(id);
+    if (!client) return;
+    clearInterval(client.keepAlive);
+    try {
+      client.res.end();
+    } catch {
+      // ignore
+    }
+    this.clients.delete(id);
+  }
+
+  async broadcast(event) {
+    const payload = {
+      id: event.id ?? randomUUID(),
+      ...event,
+      origin: event.origin ?? "server",
+      broadcastedAt: event.broadcastedAt ?? new Date().toISOString(),
+    };
+    const serialized = `event: deadline\ndata: ${JSON.stringify(payload)}\n\n`;
+    for (const { res } of this.clients.values()) {
+      try {
+        res.write(serialized);
+      } catch (err) {
+        console.warn("Failed to push deadline event to client", err);
+      }
+    }
+    await this.dispatch(payload);
+    return payload;
+  }
+
+  async dispatch(event) {
+    if (!this.dispatcher) return;
+    if (typeof this.dispatcher.dispatch === "function") {
+      await this.dispatcher.dispatch(event);
+      return;
+    }
+    const tasks = [];
+    if (event.channels?.includes("email") && typeof this.dispatcher.sendEmail === "function") {
+      tasks.push(this.dispatcher.sendEmail(event));
+    }
+    if (event.channels?.includes("sms") && typeof this.dispatcher.sendSms === "function") {
+      tasks.push(this.dispatcher.sendSms(event));
+    }
+    if (tasks.length) {
+      await Promise.allSettled(tasks);
+    }
+  }
+}
+
+export const deadlineHub = new DeadlineHub();
+
+export default deadlineHub;

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -1,4 +1,6 @@
 import type { Express } from "express";
+import type { DeadlineHub } from "./deadlineHub.js";
 
 export const app: Express;
+export const deadlineHub: DeadlineHub;
 export default app;

--- a/server/index.js
+++ b/server/index.js
@@ -5,9 +5,45 @@ import { requireAuth } from "./auth.js";
 import { createCsv } from "./analyticsFormats/csv.js";
 import { createPdf } from "./analyticsFormats/pdf.js";
 import { parseNumberParam } from "./parseNumberParam.js";
+import { deadlineHub } from "./deadlineHub.js";
 
 export const app = express();
 app.use(cors());
+app.use(express.json());
+
+const VALID_CHANNELS = new Set(["inApp", "email", "sms"]);
+const VALID_SEVERITIES = new Set(["info", "warning", "critical"]);
+
+const sanitizeChannels = (input) =>
+  Array.isArray(input)
+    ? input.filter((channel) => VALID_CHANNELS.has(channel))
+    : [];
+
+const normalizeEvent = (raw) => {
+  if (!raw || typeof raw !== "object") return null;
+  const vacancyId = typeof raw.vacancyId === "string" ? raw.vacancyId : null;
+  if (!vacancyId) return null;
+  const message = typeof raw.message === "string" ? raw.message : null;
+  if (!message) return null;
+  const leadTimeId =
+    typeof raw.leadTimeId === "string" && raw.leadTimeId
+      ? raw.leadTimeId
+      : "custom";
+  const deadlineAt = new Date(raw.deadlineAt ?? Date.now());
+  const triggeredAt = new Date(raw.triggeredAt ?? Date.now());
+  return {
+    id: typeof raw.id === "string" && raw.id ? raw.id : undefined,
+    vacancyId,
+    leadTimeId,
+    message,
+    deadlineAt: deadlineAt.toISOString(),
+    triggeredAt: triggeredAt.toISOString(),
+    severity: VALID_SEVERITIES.has(raw.severity) ? raw.severity : "info",
+    channels: sanitizeChannels(raw.channels),
+    suppressedChannels: sanitizeChannels(raw.suppressedChannels),
+    origin: typeof raw.origin === "string" ? raw.origin : "remote",
+  };
+};
 
 app.get("/api/search", (req, res) => {
   const { q, category } = req.query;
@@ -102,6 +138,39 @@ app.get("/api/analytics/export", requireAuth, (req, res) => {
   }
 });
 
+app.get("/api/deadlines/stream", requireAuth, (req, res) => {
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  if (typeof res.flushHeaders === "function") {
+    res.flushHeaders();
+  }
+  res.write("event: ready\ndata: {}\n\n");
+  const clientId = deadlineHub.addClient(res);
+  req.on("close", () => {
+    deadlineHub.removeClient(clientId);
+  });
+});
+
+app.post("/api/deadlines", requireAuth, async (req, res) => {
+  const events = Array.isArray(req.body?.events) ? req.body.events : [];
+  const sanitized = events
+    .map((event) => normalizeEvent(event))
+    .filter((event) => event !== null);
+  if (!sanitized.length) {
+    return res.status(400).json({ error: "events array required" });
+  }
+  try {
+    const broadcasts = await Promise.all(
+      sanitized.map((event) => deadlineHub.broadcast(event)),
+    );
+    res.status(202).json({ accepted: broadcasts.length });
+  } catch (err) {
+    console.error("Failed to broadcast deadline events", err);
+    res.status(500).json({ error: "Failed to broadcast events" });
+  }
+});
+
 if (process.env.NODE_ENV !== "test") {
   const port = process.env.PORT || 3001;
   app.listen(port, () => {
@@ -109,4 +178,5 @@ if (process.env.NODE_ENV !== "test") {
   });
 }
 
+export { deadlineHub };
 export default app;

--- a/server/notificationDispatcher.js
+++ b/server/notificationDispatcher.js
@@ -1,0 +1,43 @@
+export function createWebhookDispatcher(options = {}) {
+  const {
+    emailUrl = process.env.DEADLINE_EMAIL_WEBHOOK,
+    smsUrl = process.env.DEADLINE_SMS_WEBHOOK,
+    fetchImpl = globalThis.fetch?.bind(globalThis),
+  } = options;
+
+  const send = async (url, event, channel) => {
+    if (!url || typeof fetchImpl !== "function") return;
+    try {
+      await fetchImpl(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...event, channel }),
+      });
+    } catch (err) {
+      console.warn(`Failed to dispatch ${channel} webhook`, err);
+    }
+  };
+
+  return {
+    async dispatch(event) {
+      const tasks = [];
+      if (event.channels?.includes("email")) {
+        tasks.push(send(emailUrl, event, "email"));
+      }
+      if (event.channels?.includes("sms")) {
+        tasks.push(send(smsUrl, event, "sms"));
+      }
+      if (tasks.length) {
+        await Promise.allSettled(tasks);
+      }
+    },
+    async sendEmail(event) {
+      await send(emailUrl, event, "email");
+    },
+    async sendSms(event) {
+      await send(smsUrl, event, "sms");
+    },
+  };
+}
+
+export default createWebhookDispatcher;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,14 @@ import Toast from "./components/ui/Toast";
 import Button from "./components/ui/Button";
 import FilterBar from "./components/ui/FilterBar";
 import Modal from "./components/ui/Modal";
+import useDeadlineMonitor from "./hooks/useDeadlineMonitor";
+import useNotificationPrefs, {
+  NotificationPreferences,
+  NotificationChannel,
+  NotificationLeadTimePreference,
+  QuietHoursPreference,
+} from "./state/useNotificationPrefs";
+import type { DeadlineNotification } from "./types/notifications";
 
 /**
  * Maplewood Scheduler — Coverage-first (v2.3.0)
@@ -402,6 +410,14 @@ export default function App() {
     tabOrder: mergedOrder,
   });
 
+  const {
+    notificationPrefs,
+    toggleChannel: toggleNotificationChannel,
+    updateChannel: updateNotificationChannel,
+    updateLeadTime: updateNotificationLeadTime,
+    setQuietHours: setNotificationQuietHours,
+  } = useNotificationPrefs(persisted?.notificationPrefs);
+
   const [filterWing, setFilterWing] = useState<string>("");
   const [filterClass, setFilterClass] = useState<Classification | "">("");
   const [filterShift, setFilterShift] = useState<string>("");
@@ -418,6 +434,26 @@ export default function App() {
     return () => clearInterval(t);
   }, []);
 
+  const {
+    notifications,
+    latestNotification,
+    unreadCount,
+    acknowledgeNotification,
+    acknowledgeAll,
+  } = useDeadlineMonitor({
+    vacancies,
+    settings,
+    notificationPrefs,
+    now,
+    formatVacancy: displayVacancyLabel,
+  });
+
+  useEffect(() => {
+    if (tab === "alerts") {
+      acknowledgeAll();
+    }
+  }, [tab, acknowledgeAll]);
+
   useEffect(() => {
     if (
       !saveState({
@@ -427,11 +463,20 @@ export default function App() {
         bids,
         archivedBids,
         settings,
+        notificationPrefs,
       })
     ) {
       // localStorage unavailable; state persistence disabled
     }
-  }, [employees, vacations, vacancies, bids, archivedBids, settings]);
+  }, [
+    employees,
+    vacations,
+    vacancies,
+    bids,
+    archivedBids,
+    settings,
+    notificationPrefs,
+  ]);
 
   const employeesById = useMemo(
     () => Object.fromEntries(employees.map((e) => [e.id, e])),
@@ -1217,7 +1262,15 @@ export default function App() {
                 const blob = new Blob(
                   [
                     JSON.stringify(
-                      { employees, vacations, vacancies, bids, settings },
+                      {
+                        employees,
+                        vacations,
+                        vacancies,
+                        bids,
+                        archivedBids,
+                        settings,
+                        notificationPrefs,
+                      },
                       null,
                       2,
                     ),
@@ -1255,6 +1308,18 @@ export default function App() {
               onClick={() => setTab(k as any)}
             >
               {k[0].toUpperCase() + k.slice(1)}
+              {k === "alerts" && unreadCount > 0 && (
+                <span
+                  className="pill"
+                  style={{
+                    marginLeft: 6,
+                    background: "var(--bad)",
+                    color: "#fff",
+                  }}
+                >
+                  {unreadCount}
+                </span>
+              )}
             </button>
           ))}
         </div>
@@ -1824,11 +1889,80 @@ export default function App() {
                 </div>
               </div>
             </div>
+            <div className="card">
+              <div className="card-h" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                Deadline Notifications
+                {unreadCount > 0 && (
+                  <span
+                    className="pill"
+                    style={{ background: "var(--bad)", color: "#fff" }}
+                  >
+                    {unreadCount} unread
+                  </span>
+                )}
+              </div>
+              <div className="card-c">
+                {notifications.length === 0 ? (
+                  <div className="subtitle">No deadline alerts right now.</div>
+                ) : (
+                  <>
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: 12,
+                        gap: 12,
+                      }}
+                    >
+                      <div className="subtitle">
+                        Showing {notifications.length} notification
+                        {notifications.length === 1 ? "" : "s"}
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={acknowledgeAll}
+                        disabled={!notifications.some((n) => !n.read)}
+                      >
+                        Mark all read
+                      </Button>
+                    </div>
+                    <ul
+                      style={{
+                        listStyle: "none",
+                        margin: 0,
+                        padding: 0,
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 12,
+                      }}
+                    >
+                      {notifications.map((notification) => (
+                        <DeadlineNotificationRow
+                          key={notification.id}
+                          notification={notification}
+                          onAcknowledge={acknowledgeNotification}
+                        />
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </div>
+            </div>
           </div>
         )}
 
         {tab === "settings" && (
-          <SettingsPage settings={settings} setSettings={setSettings} />
+          <SettingsPage
+            settings={settings}
+            setSettings={setSettings}
+            notificationPrefs={notificationPrefs}
+            toggleChannel={toggleNotificationChannel}
+            updateChannel={updateNotificationChannel}
+            updateLeadTime={updateNotificationLeadTime}
+            setQuietHours={setNotificationQuietHours}
+          />
         )}
         {coverageOpen && (
           <CoverageDaysModal
@@ -1935,6 +2069,61 @@ export default function App() {
             setBulkAwardOpen(false);
           }}
         />
+        {latestNotification && (
+          <div
+            role="status"
+            style={{
+              position: "fixed",
+              top: 96,
+              right: 24,
+              zIndex: 30,
+              background: "var(--card)",
+              color: "var(--text)",
+              border: "1px solid var(--stroke)",
+              borderRadius: 12,
+              padding: "14px 16px",
+              maxWidth: 360,
+              boxShadow: "0 16px 40px rgba(0, 0, 0, 0.2)",
+            }}
+          >
+            <div style={{ fontWeight: 700, marginBottom: 4 }}>
+              {latestNotification.severity === "critical"
+                ? "Deadline passed"
+                : latestNotification.severity === "warning"
+                ? "Deadline approaching"
+                : "Upcoming deadline"}
+            </div>
+            <div style={{ fontSize: 14, lineHeight: 1.4 }}>
+              {latestNotification.message}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                gap: 8,
+                marginTop: 12,
+              }}
+            >
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => acknowledgeNotification(latestNotification.id)}
+              >
+                Dismiss
+              </Button>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={() => {
+                  acknowledgeNotification(latestNotification.id);
+                  setTab("alerts");
+                }}
+              >
+                View alerts
+              </Button>
+            </div>
+          </div>
+        )}
         <Toast
           open={!!stagedDelete}
           message={stagedDelete?.message || ""}
@@ -2263,12 +2452,131 @@ export function ArchivePage({
   );
 }
 
+function DeadlineNotificationRow({
+  notification,
+  onAcknowledge,
+}: {
+  notification: DeadlineNotification;
+  onAcknowledge: (id: string) => void;
+}) {
+  const severityStyles = {
+    info: { background: "var(--brand)", color: "#fff" },
+    warning: { background: "#f5a623", color: "#1c1c1c" },
+    critical: { background: "var(--bad)", color: "#fff" },
+  } as const;
+  const severityLabels = {
+    info: "Info",
+    warning: "Warning",
+    critical: "Critical",
+  } as const;
+  const deadlineDate = new Date(notification.deadlineAt);
+  const triggeredDate = new Date(notification.triggeredAt);
+  const suppressed = notification.suppressedChannels.filter(
+    (channel) => !notification.channels.includes(channel),
+  );
+  return (
+    <li
+      style={{
+        border: "1px solid var(--stroke)",
+        borderRadius: 12,
+        padding: "12px 16px",
+        background: "var(--cardAlt)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <span
+            style={{
+              ...severityStyles[notification.severity],
+              borderRadius: 999,
+              padding: "2px 10px",
+              fontSize: 12,
+              fontWeight: 700,
+              textTransform: "uppercase",
+            }}
+          >
+            {severityLabels[notification.severity]}
+          </span>
+          {notification.resolved && (
+            <span
+              className="pill"
+              style={{ background: "#1a7f37", color: "#fff" }}
+            >
+              Resolved
+            </span>
+          )}
+          {!notification.read && (
+            <span
+              className="pill"
+              style={{ background: "var(--brand)", color: "#fff" }}
+            >
+              Unread
+            </span>
+          )}
+        </div>
+        {!notification.read && (
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => onAcknowledge(notification.id)}
+          >
+            Mark read
+          </Button>
+        )}
+      </div>
+      <div style={{ fontWeight: 600, marginTop: 8 }}>{notification.message}</div>
+      <div className="subtitle" style={{ marginTop: 4 }}>
+        Deadline: {deadlineDate.toLocaleString()} • Triggered: {" "}
+        {triggeredDate.toLocaleString()}
+      </div>
+      <div className="subtitle" style={{ marginTop: 4 }}>
+        Channels: {notification.channels.length ? notification.channels.join(", ") : "None"}
+        {suppressed.length > 0 && (
+          <span>
+            {" "}• Quiet hours suppressed: {suppressed.join(", ")}
+          </span>
+        )}
+      </div>
+      {notification.resolved && notification.resolvedAt && (
+        <div className="subtitle" style={{ marginTop: 4 }}>
+          Resolved at {new Date(notification.resolvedAt).toLocaleString()}
+        </div>
+      )}
+    </li>
+  );
+}
+
 function SettingsPage({
   settings,
   setSettings,
+  notificationPrefs,
+  toggleChannel,
+  updateChannel,
+  updateLeadTime,
+  setQuietHours,
 }: {
   settings: Settings;
   setSettings: (u: any) => void;
+  notificationPrefs: NotificationPreferences;
+  toggleChannel: ReturnType<typeof useNotificationPrefs>["toggleChannel"];
+  updateChannel: ReturnType<typeof useNotificationPrefs>["updateChannel"];
+  updateLeadTime: ReturnType<typeof useNotificationPrefs>["updateLeadTime"];
+  setQuietHours: ReturnType<typeof useNotificationPrefs>["setQuietHours"];
 }) {
   return (
     <div className="grid">
@@ -2308,6 +2616,191 @@ function SettingsPage({
                   </option>
                 ))}
               </select>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-h">Notifications</div>
+        <div className="card-c" style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+          <div>
+            <div className="subtitle" style={{ marginBottom: 8 }}>
+              Channels
+            </div>
+            <div className="row cols3" style={{ gap: 16 }}>
+              {(
+                [
+                  {
+                    key: "inApp" as NotificationChannel,
+                    label: "In-app",
+                    description: "Show alerts inside Maplewood Scheduler.",
+                  },
+                  {
+                    key: "email" as NotificationChannel,
+                    label: "Email",
+                    description: "Send notification emails when deadlines approach.",
+                    placeholder: "alerts@example.com",
+                    inputType: "email",
+                  },
+                  {
+                    key: "sms" as NotificationChannel,
+                    label: "SMS",
+                    description: "Send a text message for urgent deadlines.",
+                    placeholder: "555-123-4567",
+                    inputType: "tel",
+                  },
+                ]
+              ).map((channel) => {
+                const channelConfig = notificationPrefs.channels[channel.key];
+                const isEmail = channel.key === "email";
+                const isSms = channel.key === "sms";
+                return (
+                  <div
+                    key={channel.key}
+                    style={{
+                      border: "1px solid var(--stroke)",
+                      borderRadius: 12,
+                      padding: "12px 14px",
+                      background: "var(--cardAlt)",
+                    }}
+                  >
+                    <label style={{ display: "flex", alignItems: "center", gap: 8, fontWeight: 600 }}>
+                      <input
+                        type="checkbox"
+                        checked={channelConfig.enabled}
+                        onChange={(e) => toggleChannel(channel.key, e.target.checked)}
+                      />
+                      {channel.label}
+                    </label>
+                    <div className="subtitle" style={{ marginTop: 4 }}>
+                      {channel.description}
+                    </div>
+                    {isEmail && (
+                      <input
+                        type={channel.inputType}
+                        value={notificationPrefs.channels.email.address}
+                        placeholder={channel.placeholder}
+                        onChange={(e) => updateChannel("email", { address: e.target.value })}
+                        style={{ marginTop: 8, width: "100%" }}
+                      />
+                    )}
+                    {isSms && (
+                      <input
+                        type={channel.inputType}
+                        value={notificationPrefs.channels.sms.number}
+                        placeholder={channel.placeholder}
+                        onChange={(e) => updateChannel("sms", { number: e.target.value })}
+                        style={{ marginTop: 8, width: "100%" }}
+                      />
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div>
+            <div className="subtitle" style={{ marginBottom: 8 }}>
+              Lead times
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+              {notificationPrefs.leadTimes.map((lt) => (
+                <div
+                  key={lt.id}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 12,
+                    padding: "8px 12px",
+                    border: "1px solid var(--stroke)",
+                    borderRadius: 12,
+                    background: "var(--cardAlt)",
+                  }}
+                >
+                  <label style={{ display: "flex", alignItems: "center", gap: 8, flex: 1 }}>
+                    <input
+                      type="checkbox"
+                      checked={lt.enabled}
+                      onChange={(e) => updateLeadTime(lt.id, { enabled: e.target.checked })}
+                    />
+                    <span>{lt.label}</span>
+                  </label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={lt.minutes}
+                    onChange={(e) => updateLeadTime(lt.id, { minutes: Number(e.target.value) })}
+                    style={{ width: 90 }}
+                  />
+                  <span className="subtitle">minutes</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <div className="subtitle" style={{ marginBottom: 8 }}>
+              Quiet hours
+            </div>
+            <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <input
+                type="checkbox"
+                checked={notificationPrefs.quietHours.enabled}
+                onChange={(e) => setQuietHours({ enabled: e.target.checked })}
+              />
+              Enable quiet hours
+            </label>
+            <div className="row cols3" style={{ marginTop: 12 }}>
+              <div>
+                <label>Start</label>
+                <input
+                  type="time"
+                  value={notificationPrefs.quietHours.start}
+                  onChange={(e) => setQuietHours({ start: e.target.value })}
+                />
+              </div>
+              <div>
+                <label>End</label>
+                <input
+                  type="time"
+                  value={notificationPrefs.quietHours.end}
+                  onChange={(e) => setQuietHours({ end: e.target.value })}
+                />
+              </div>
+              <div>
+                <label>Timezone</label>
+                <input
+                  type="text"
+                  value={notificationPrefs.quietHours.timezone}
+                  placeholder="America/Chicago"
+                  onChange={(e) => setQuietHours({ timezone: e.target.value })}
+                />
+              </div>
+            </div>
+            <div className="subtitle" style={{ marginTop: 12 }}>
+              Suppress during quiet hours
+            </div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 8 }}>
+              {(["email", "sms", "inApp"] as NotificationChannel[]).map((channel) => {
+                const checked = notificationPrefs.quietHours.suppress.includes(channel);
+                return (
+                  <label key={channel} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        const current = notificationPrefs.quietHours.suppress;
+                        const next = e.target.checked
+                          ? Array.from(new Set([...current, channel]))
+                          : current.filter((c) => c !== channel);
+                        setQuietHours({ suppress: next });
+                      }}
+                    />
+                    {channel === "inApp" ? "In-app" : channel.toUpperCase()}
+                  </label>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/hooks/useDeadlineMonitor.ts
+++ b/src/hooks/useDeadlineMonitor.ts
@@ -1,0 +1,440 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { Settings, Vacancy } from "../App";
+import { combineDateTime } from "../lib/dates";
+import type {
+  NotificationPreferences,
+  NotificationChannel,
+} from "../state/useNotificationPrefs";
+import type {
+  DeadlineEvent,
+  DeadlineNotification,
+} from "../types/notifications";
+import { authFetch, getToken, getApiBaseUrl } from "../utils/api";
+
+const isBrowser = typeof window !== "undefined";
+
+function createEventId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `deadline_${Math.random().toString(36).slice(2)}_${Date.now()}`;
+}
+
+function formatDuration(minutes: number): string {
+  if (!Number.isFinite(minutes)) return "unknown";
+  const absMinutes = Math.abs(minutes);
+  if (absMinutes < 1) return "less than a minute";
+  if (absMinutes < 60) {
+    const rounded = Math.round(absMinutes);
+    return `${rounded} minute${rounded === 1 ? "" : "s"}`;
+  }
+  const hours = absMinutes / 60;
+  if (hours < 24) {
+    const rounded = Math.round(hours);
+    return `${rounded} hour${rounded === 1 ? "" : "s"}`;
+  }
+  const days = hours / 24;
+  const rounded = Math.round(days);
+  return `${rounded} day${rounded === 1 ? "" : "s"}`;
+}
+
+function pickWindowMinutes(vacancy: Vacancy, settings: Settings) {
+  const known = new Date(vacancy.knownAt);
+  const shiftStart = combineDateTime(vacancy.shiftDate, vacancy.shiftStart);
+  if (Number.isNaN(known.getTime()) || Number.isNaN(shiftStart.getTime())) {
+    return settings.responseWindows.h4to24;
+  }
+  const hrsUntilShift = (shiftStart.getTime() - known.getTime()) / 3_600_000;
+  if (hrsUntilShift < 2) return settings.responseWindows.lt2h;
+  if (hrsUntilShift < 4) return settings.responseWindows.h2to4;
+  if (hrsUntilShift < 24) return settings.responseWindows.h4to24;
+  if (hrsUntilShift < 72) return settings.responseWindows.h24to72;
+  return settings.responseWindows.gt72;
+}
+
+function deadlineFor(vacancy: Vacancy, settings: Settings) {
+  const known = new Date(vacancy.knownAt);
+  if (Number.isNaN(known.getTime())) return null;
+  const minutes = pickWindowMinutes(vacancy, settings);
+  return new Date(known.getTime() + minutes * 60_000);
+}
+
+function isWithinQuietHours(now: Date, quiet: NotificationPreferences["quietHours"]) {
+  if (!quiet.enabled) return false;
+  const parseTime = (value: string) => {
+    const match = /^(\d{2}):(\d{2})$/.exec(value);
+    if (!match) return 0;
+    const [, hh, mm] = match;
+    return Number(hh) * 60 + Number(mm);
+  };
+  const start = parseTime(quiet.start);
+  const end = parseTime(quiet.end);
+  const current = now.getHours() * 60 + now.getMinutes();
+  if (start === end) return true; // quiet all day
+  if (start < end) {
+    return current >= start && current < end;
+  }
+  return current >= start || current < end;
+}
+
+function parseSseChunk(chunk: string) {
+  const lines = chunk.split("\n");
+  let eventName: string | undefined;
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    if (!line || line.startsWith(":")) continue;
+    if (line.startsWith("event:")) {
+      eventName = line.slice(6).trim();
+    } else if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  }
+  if (!dataLines.length) return null;
+  return { event: eventName, data: dataLines.join("\n") };
+}
+
+type DeadlineMonitorOptions = {
+  vacancies: Vacancy[];
+  settings: Settings;
+  notificationPrefs: NotificationPreferences;
+  now: number;
+  formatVacancy: (vacancy: Vacancy) => string;
+};
+
+export function useDeadlineMonitor({
+  vacancies,
+  settings,
+  notificationPrefs,
+  now,
+  formatVacancy,
+}: DeadlineMonitorOptions) {
+  const [notifications, setNotifications] = useState<DeadlineNotification[]>([]);
+  const notificationsRef = useRef(new Map<string, DeadlineNotification>());
+  const triggeredRef = useRef(new Map<string, string>());
+  const pendingRef = useRef<DeadlineEvent[]>([]);
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const apiBase = useMemo(() => {
+    const base = getApiBaseUrl();
+    if (!base) return "";
+    return base.replace(/\/$/, "");
+  }, []);
+
+  const syncNotifications = useCallback(() => {
+    setNotifications(
+      Array.from(notificationsRef.current.values()).sort((a, b) =>
+        a.triggeredAt > b.triggeredAt ? -1 : a.triggeredAt < b.triggeredAt ? 1 : 0,
+      ),
+    );
+  }, []);
+
+  const upsertNotification = useCallback(
+    (event: DeadlineEvent, overrides: Partial<DeadlineNotification> = {}) => {
+      const existing = notificationsRef.current.get(event.id);
+      const base: DeadlineNotification = existing
+        ? { ...existing, ...event }
+        : { ...event, read: false };
+      const next: DeadlineNotification = {
+        ...base,
+        read:
+          typeof overrides.read === "boolean" ? overrides.read : base.read ?? false,
+        resolved:
+          typeof overrides.resolved === "boolean"
+            ? overrides.resolved
+            : base.resolved,
+        resolvedAt:
+          typeof overrides.resolvedAt === "string"
+            ? overrides.resolvedAt
+            : base.resolvedAt,
+      };
+      notificationsRef.current.set(event.id, next);
+      syncNotifications();
+    },
+    [syncNotifications],
+  );
+
+  const markNotificationResolved = useCallback(
+    (id: string) => {
+      const existing = notificationsRef.current.get(id);
+      if (!existing || existing.resolved) return;
+      notificationsRef.current.set(id, {
+        ...existing,
+        resolved: true,
+        resolvedAt: new Date().toISOString(),
+      });
+      syncNotifications();
+    },
+    [syncNotifications],
+  );
+
+  const flushPending = useCallback(async () => {
+    if (!pendingRef.current.length) return;
+    if (!isBrowser) {
+      pendingRef.current = [];
+      return;
+    }
+    const events = pendingRef.current.splice(0, pendingRef.current.length);
+    if (!events.length) return;
+    const endpoint = `${apiBase}/api/deadlines`;
+    try {
+      await authFetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ events }),
+      });
+    } catch (error) {
+      console.warn("Failed to sync deadline events", error);
+      pendingRef.current.unshift(...events);
+      throw error;
+    }
+  }, [apiBase]);
+
+  const scheduleFlush = useCallback(
+    (delayMs: number) => {
+      if (!isBrowser) return;
+      if (flushTimerRef.current) return;
+      flushTimerRef.current = setTimeout(async () => {
+        flushTimerRef.current = null;
+        try {
+          await flushPending();
+        } catch {
+          scheduleFlush(5_000);
+        }
+      }, delayMs);
+    },
+    [flushPending],
+  );
+
+  const enqueueServerSync = useCallback(
+    (event: DeadlineEvent) => {
+      if (!isBrowser) return;
+      pendingRef.current.push(event);
+      scheduleFlush(500);
+    },
+    [scheduleFlush],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (flushTimerRef.current) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  const acknowledgeNotification = useCallback(
+    (id: string) => {
+      const existing = notificationsRef.current.get(id);
+      if (!existing) return;
+      notificationsRef.current.set(id, { ...existing, read: true });
+      syncNotifications();
+    },
+    [syncNotifications],
+  );
+
+  const acknowledgeAll = useCallback(() => {
+    if (!notificationsRef.current.size) return;
+    let changed = false;
+    notificationsRef.current.forEach((value, key) => {
+      if (value.read) return;
+      changed = true;
+      notificationsRef.current.set(key, { ...value, read: true });
+    });
+    if (changed) syncNotifications();
+  }, [syncNotifications]);
+
+  const enabledLeadTimes = useMemo(
+    () => notificationPrefs.leadTimes.filter((lt) => lt.enabled).sort((a, b) => a.minutes - b.minutes),
+    [notificationPrefs.leadTimes],
+  );
+
+  useEffect(() => {
+    const nowDate = new Date(now);
+    const quietActive = isWithinQuietHours(nowDate, notificationPrefs.quietHours);
+    const suppressedChannels = quietActive
+      ? notificationPrefs.quietHours.suppress
+      : [];
+    const enabledChannels = (Object.entries(notificationPrefs.channels) as [
+      NotificationChannel,
+      { enabled: boolean },
+    ][])
+      .filter(([, cfg]) => cfg.enabled)
+      .map(([key]) => key);
+
+    const vacancyById = new Map(vacancies.map((vacancy) => [vacancy.id, vacancy]));
+    const activeKeys = new Set<string>();
+    let mutated = false;
+
+    for (const vacancy of vacancies) {
+      if (vacancy.status === "Filled" || vacancy.status === "Awarded") {
+        continue;
+      }
+      const deadline = deadlineFor(vacancy, settings);
+      if (!deadline) continue;
+      const minutesUntil = (deadline.getTime() - nowDate.getTime()) / 60_000;
+      for (const leadTime of enabledLeadTimes) {
+        const key = `${vacancy.id}:${leadTime.id}`;
+        if (minutesUntil > leadTime.minutes) continue;
+        activeKeys.add(key);
+        if (triggeredRef.current.has(key)) continue;
+        const channelsForEvent = enabledChannels.filter(
+          (channel) => !suppressedChannels.includes(channel),
+        );
+        if (!channelsForEvent.length && suppressedChannels.length === 0) continue;
+        const eventId = createEventId();
+        const severity = minutesUntil <= 0 ? "critical" : leadTime.minutes <= 30 ? "warning" : "info";
+        const message =
+          minutesUntil <= 0
+            ? `${formatVacancy(vacancy)} deadline passed ${formatDuration(minutesUntil)} ago`
+            : `${formatVacancy(vacancy)} deadline in ${formatDuration(minutesUntil)}`;
+        const event: DeadlineEvent = {
+          id: eventId,
+          vacancyId: vacancy.id,
+          leadTimeId: leadTime.id,
+          message,
+          deadlineAt: deadline.toISOString(),
+          triggeredAt: new Date().toISOString(),
+          severity,
+          channels: channelsForEvent,
+          suppressedChannels,
+          origin: "local",
+        };
+        triggeredRef.current.set(key, eventId);
+        upsertNotification(event, {
+          read: !channelsForEvent.includes("inApp"),
+        });
+        enqueueServerSync(event);
+        mutated = true;
+      }
+    }
+
+    // resolve notifications for vacancies that are now closed or keys no longer active
+    for (const [key, id] of triggeredRef.current.entries()) {
+      if (activeKeys.has(key)) continue;
+      const vacancyId = key.split(":", 1)[0];
+      const vacancy = vacancyById.get(vacancyId);
+      if (vacancy && vacancy.status !== "Filled" && vacancy.status !== "Awarded") {
+        continue;
+      }
+      triggeredRef.current.delete(key);
+      markNotificationResolved(id);
+      mutated = true;
+    }
+
+    if (mutated) syncNotifications();
+  }, [
+    vacancies,
+    settings,
+    notificationPrefs,
+    enabledLeadTimes,
+    now,
+    upsertNotification,
+    enqueueServerSync,
+    markNotificationResolved,
+    syncNotifications,
+    formatVacancy,
+  ]);
+
+  useEffect(() => {
+    if (!isBrowser) return;
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let controller: AbortController | null = null;
+
+    const scheduleReconnect = () => {
+      if (cancelled) return;
+      if (retryTimer) return;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        if (!cancelled) connect();
+      }, 5_000);
+    };
+
+    const handleEvent = (event: DeadlineEvent) => {
+      const compositeKey = `${event.vacancyId}:${event.leadTimeId}`;
+      triggeredRef.current.set(compositeKey, event.id);
+      upsertNotification(event);
+    };
+
+    const connect = async () => {
+      controller = new AbortController();
+      try {
+        const token = getToken();
+        const response = await fetch(`${apiBase}/api/deadlines/stream`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Stream failed with status ${response.status}`);
+        }
+        if (!response.body) {
+          throw new Error("Stream response missing body");
+        }
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        while (!cancelled) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let boundary = buffer.indexOf("\n\n");
+          while (boundary !== -1) {
+            const chunk = buffer.slice(0, boundary);
+            buffer = buffer.slice(boundary + 2);
+            const parsed = parseSseChunk(chunk);
+            if (parsed?.data) {
+              try {
+                const payload = JSON.parse(parsed.data) as DeadlineEvent;
+                handleEvent(payload);
+              } catch (err) {
+                console.warn("Failed to parse deadline event", err);
+              }
+            }
+            boundary = buffer.indexOf("\n\n");
+          }
+        }
+      } catch (err) {
+        if (!cancelled && !(controller?.signal.aborted)) {
+          console.warn("Deadline stream disconnected", err);
+          scheduleReconnect();
+        }
+      }
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      controller?.abort();
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+    };
+  }, [apiBase, upsertNotification]);
+
+  const latestNotification = useMemo(() => {
+    return notifications.find((n) => !n.read) ?? null;
+  }, [notifications]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((n) => !n.read).length,
+    [notifications],
+  );
+
+  return {
+    notifications,
+    latestNotification,
+    unreadCount,
+    acknowledgeNotification,
+    acknowledgeAll,
+  } as const;
+}
+
+export default useDeadlineMonitor;

--- a/src/state/useNotificationPrefs.ts
+++ b/src/state/useNotificationPrefs.ts
@@ -1,0 +1,308 @@
+import { useCallback, useState } from "react";
+
+export type NotificationChannel = "inApp" | "email" | "sms";
+
+export type ChannelPreferences = {
+  inApp: { enabled: boolean };
+  email: { enabled: boolean; address: string };
+  sms: { enabled: boolean; number: string };
+};
+
+export type NotificationLeadTimePreference = {
+  id: string;
+  label: string;
+  minutes: number;
+  enabled: boolean;
+};
+
+export type QuietHoursPreference = {
+  enabled: boolean;
+  start: string; // HH:mm
+  end: string; // HH:mm
+  timezone: string;
+  suppress: NotificationChannel[];
+};
+
+export type NotificationPreferences = {
+  channels: ChannelPreferences;
+  leadTimes: NotificationLeadTimePreference[];
+  quietHours: QuietHoursPreference;
+  updatedAt: string;
+};
+
+const DEFAULT_TIMEZONE = (() => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+})();
+
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPreferences = {
+  channels: {
+    inApp: { enabled: true },
+    email: { enabled: false, address: "" },
+    sms: { enabled: false, number: "" },
+  },
+  leadTimes: [
+    {
+      id: "lt15",
+      label: "15 minutes before deadline",
+      minutes: 15,
+      enabled: true,
+    },
+    {
+      id: "lt30",
+      label: "30 minutes before deadline",
+      minutes: 30,
+      enabled: false,
+    },
+    {
+      id: "lt60",
+      label: "1 hour before deadline",
+      minutes: 60,
+      enabled: false,
+    },
+    {
+      id: "lt120",
+      label: "2 hours before deadline",
+      minutes: 120,
+      enabled: false,
+    },
+  ],
+  quietHours: {
+    enabled: false,
+    start: "22:00",
+    end: "06:00",
+    timezone: DEFAULT_TIMEZONE,
+    suppress: ["email", "sms"],
+  },
+  updatedAt: new Date().toISOString(),
+};
+
+type NormalizeOptions = {
+  stamp?: boolean;
+};
+
+function normalizeChannels(value: any): ChannelPreferences {
+  const channels = value && typeof value === "object" ? value : {};
+  return {
+    inApp: {
+      enabled:
+        typeof channels?.inApp?.enabled === "boolean"
+          ? channels.inApp.enabled
+          : DEFAULT_NOTIFICATION_PREFS.channels.inApp.enabled,
+    },
+    email: {
+      enabled:
+        typeof channels?.email?.enabled === "boolean"
+          ? channels.email.enabled
+          : DEFAULT_NOTIFICATION_PREFS.channels.email.enabled,
+      address:
+        typeof channels?.email?.address === "string"
+          ? channels.email.address
+          : DEFAULT_NOTIFICATION_PREFS.channels.email.address,
+    },
+    sms: {
+      enabled:
+        typeof channels?.sms?.enabled === "boolean"
+          ? channels.sms.enabled
+          : DEFAULT_NOTIFICATION_PREFS.channels.sms.enabled,
+      number:
+        typeof channels?.sms?.number === "string"
+          ? channels.sms.number
+          : DEFAULT_NOTIFICATION_PREFS.channels.sms.number,
+    },
+  };
+}
+
+function normalizeLeadTimes(value: any): NotificationLeadTimePreference[] {
+  const defaults = DEFAULT_NOTIFICATION_PREFS.leadTimes;
+  const list = Array.isArray(value) ? value : [];
+  const byId = new Map<string, any>();
+  for (const item of list) {
+    if (item && typeof item.id === "string") {
+      byId.set(item.id, item);
+    }
+  }
+  const normalized: NotificationLeadTimePreference[] = defaults.map((def) => {
+    const raw = byId.get(def.id) ?? {};
+    const minutes = Number(raw.minutes);
+    return {
+      id: def.id,
+      label:
+        typeof raw.label === "string" && raw.label.trim().length > 0
+          ? raw.label
+          : def.label,
+      minutes: Number.isFinite(minutes) && minutes > 0 ? minutes : def.minutes,
+      enabled:
+        typeof raw.enabled === "boolean" ? raw.enabled : def.enabled,
+    };
+  });
+  for (const [id, raw] of byId.entries()) {
+    if (normalized.some((item) => item.id === id)) continue;
+    const minutes = Number(raw.minutes);
+    normalized.push({
+      id,
+      label:
+        typeof raw.label === "string" && raw.label.trim().length > 0
+          ? raw.label
+          : `${raw.minutes ?? "?"} minutes before`,
+      minutes: Number.isFinite(minutes) && minutes > 0 ? minutes : 30,
+      enabled: typeof raw.enabled === "boolean" ? raw.enabled : true,
+    });
+  }
+  return normalized.sort((a, b) => a.minutes - b.minutes);
+}
+
+function normalizeQuietHours(value: any): QuietHoursPreference {
+  const quiet = value && typeof value === "object" ? value : {};
+  const suppressRaw = Array.isArray(quiet.suppress)
+    ? quiet.suppress
+    : DEFAULT_NOTIFICATION_PREFS.quietHours.suppress;
+  const suppress = suppressRaw.filter((item: unknown): item is NotificationChannel =>
+    item === "email" || item === "sms" || item === "inApp",
+  );
+  return {
+    enabled:
+      typeof quiet.enabled === "boolean"
+        ? quiet.enabled
+        : DEFAULT_NOTIFICATION_PREFS.quietHours.enabled,
+    start:
+      typeof quiet.start === "string" && /^\d{2}:\d{2}$/.test(quiet.start)
+        ? quiet.start
+        : DEFAULT_NOTIFICATION_PREFS.quietHours.start,
+    end:
+      typeof quiet.end === "string" && /^\d{2}:\d{2}$/.test(quiet.end)
+        ? quiet.end
+        : DEFAULT_NOTIFICATION_PREFS.quietHours.end,
+    timezone:
+      typeof quiet.timezone === "string" && quiet.timezone.trim().length > 0
+        ? quiet.timezone
+        : DEFAULT_NOTIFICATION_PREFS.quietHours.timezone,
+    suppress: suppress.length ? suppress : DEFAULT_NOTIFICATION_PREFS.quietHours.suppress,
+  };
+}
+
+export function normalizeNotificationPrefs(
+  value?: Partial<NotificationPreferences>,
+  options: NormalizeOptions = {},
+): NotificationPreferences {
+  const updatedAt =
+    typeof value?.updatedAt === "string" && value.updatedAt
+      ? value.updatedAt
+      : DEFAULT_NOTIFICATION_PREFS.updatedAt;
+  const normalized: NotificationPreferences = {
+    channels: normalizeChannels(value?.channels),
+    leadTimes: normalizeLeadTimes(value?.leadTimes),
+    quietHours: normalizeQuietHours(value?.quietHours),
+    updatedAt,
+  };
+  if (options.stamp) {
+    normalized.updatedAt = new Date().toISOString();
+  }
+  return normalized;
+}
+
+type SetStateArg =
+  | NotificationPreferences
+  | ((prev: NotificationPreferences) => NotificationPreferences);
+
+export function useNotificationPrefs(
+  initial?: Partial<NotificationPreferences>,
+) {
+  const [prefs, setPrefsState] = useState<NotificationPreferences>(() =>
+    normalizeNotificationPrefs(initial),
+  );
+
+  const setPrefs = useCallback((value: SetStateArg) => {
+    setPrefsState((prev) =>
+      normalizeNotificationPrefs(
+        typeof value === "function" ? (value as any)(prev) : value,
+        { stamp: true },
+      ),
+    );
+  }, []);
+
+  const toggleChannel = useCallback(
+    (channel: NotificationChannel, enabled?: boolean) => {
+      setPrefs((prev) => ({
+        ...prev,
+        channels: {
+          ...prev.channels,
+          [channel]: {
+            ...prev.channels[channel],
+            enabled:
+              typeof enabled === "boolean"
+                ? enabled
+                : !prev.channels[channel].enabled,
+          },
+        },
+      }));
+    },
+    [setPrefs],
+  );
+
+  type MutableChannelMap = {
+    email: Partial<ChannelPreferences["email"]>;
+    sms: Partial<ChannelPreferences["sms"]>;
+  };
+
+  const updateChannel = useCallback(
+    <T extends keyof MutableChannelMap>(channel: T, patch: MutableChannelMap[T]) => {
+      setPrefs((prev) => ({
+        ...prev,
+        channels: {
+          ...prev.channels,
+          [channel]: {
+            ...prev.channels[channel],
+            ...patch,
+          },
+        },
+      }));
+    },
+    [setPrefs],
+  );
+
+  const updateLeadTime = useCallback(
+    (id: string, patch: Partial<NotificationLeadTimePreference>) => {
+      setPrefs((prev) => ({
+        ...prev,
+        leadTimes: prev.leadTimes.map((lt) =>
+          lt.id === id
+            ? {
+                ...lt,
+                ...patch,
+                minutes:
+                  typeof patch.minutes === "number" && patch.minutes > 0
+                    ? patch.minutes
+                    : lt.minutes,
+              }
+            : lt,
+        ),
+      }));
+    },
+    [setPrefs],
+  );
+
+  const setQuietHours = useCallback(
+    (patch: Partial<QuietHoursPreference>) => {
+      setPrefs((prev) => ({
+        ...prev,
+        quietHours: normalizeQuietHours({ ...prev.quietHours, ...patch }),
+      }));
+    },
+    [setPrefs],
+  );
+
+  return {
+    notificationPrefs: prefs,
+    setNotificationPrefs: setPrefs,
+    toggleChannel,
+    updateChannel,
+    updateLeadTime,
+    setQuietHours,
+  } as const;
+}
+
+export default useNotificationPrefs;

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,30 @@
+import type {
+  NotificationChannel,
+  NotificationLeadTimePreference,
+} from "../state/useNotificationPrefs";
+
+export type DeadlineSeverity = "info" | "warning" | "critical";
+
+export type DeadlineEvent = {
+  id: string;
+  vacancyId: string;
+  leadTimeId: NotificationLeadTimePreference["id"];
+  message: string;
+  deadlineAt: string;
+  triggeredAt: string;
+  severity: DeadlineSeverity;
+  channels: NotificationChannel[];
+  suppressedChannels: NotificationChannel[];
+  origin?: "local" | "remote" | "server";
+  broadcastedAt?: string;
+};
+
+export type DeadlineNotification = DeadlineEvent & {
+  read: boolean;
+  resolved?: boolean;
+  resolvedAt?: string;
+};
+
+export type DeadlineBatchPayload = {
+  events: DeadlineEvent[];
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -20,6 +20,15 @@ export function setToken(token: string) {
   }
 }
 
+export function getApiBaseUrl(): string {
+  const metaEnv = (import.meta as unknown as {
+    env?: Record<string, string | undefined>;
+  }).env;
+  const raw = (metaEnv?.VITE_API_BASE_URL ?? "").trim();
+  if (!raw) return "";
+  return raw.replace(/\/$/, "");
+}
+
 export async function authFetch(input: RequestInfo, init: RequestInit = {}) {
   const token = getToken();
   const headers = new Headers(init.headers);


### PR DESCRIPTION
## Summary
- add a notification preference store with quiet hours and surface the configuration in the settings tab
- implement a deadline monitoring hook that triggers in-app notifications, badges, and toast helpers while syncing events to the server
- extend the server with an authenticated SSE feed plus webhook dispatch helpers so deadline events broadcast to all clients

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dda3f94d908327956e1201e8637fd9