### PR TITLE
Add analytics forecasting, scenario API, and UI enhancements

### DIFF
--- a/server/analyticsFormats/csv.d.ts
+++ b/server/analyticsFormats/csv.d.ts
@@ -1,3 +1,11 @@
-import type { AggregatedVacancyMetrics } from "../metrics.js";
+export interface AnalyticsExportRow {
+  period: string;
+  posted: number;
+  awarded: number;
+  cancelled: number;
+  cancellationRate: number;
+  overtime: number;
+  averageHours: number;
+}
 
-export function createCsv(data: AggregatedVacancyMetrics[]): string;
+export function createCsv(data: AnalyticsExportRow[]): string;

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,10 @@
 import express from "express";
 import cors from "cors";
-import { aggregateByMonth, sampleVacancies } from "./metrics.js";
+import {
+  aggregateByMonth,
+  projectScenario,
+  sampleVacancies,
+} from "./metrics.js";
 import { requireAuth } from "./auth.js";
 import { createCsv } from "./analyticsFormats/csv.js";
 import { createPdf } from "./analyticsFormats/pdf.js";
@@ -8,6 +12,7 @@ import { parseNumberParam } from "./parseNumberParam.js";
 
 export const app = express();
 app.use(cors());
+app.use(express.json());
 
 app.get("/api/search", (req, res) => {
   const { q, category } = req.query;
@@ -67,9 +72,33 @@ app.get("/api/analytics", requireAuth, (req, res) => {
     return res.status(400).json({ error: err.message });
   }
 
-  const data = aggregateByMonth(sampleVacancies, { overtimeThreshold });
+  const classificationsParam = req.query.classifications;
+  let classifications;
+  if (typeof classificationsParam === "string" && classificationsParam.trim()) {
+    classifications = classificationsParam
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  const data = aggregateByMonth(sampleVacancies, {
+    overtimeThreshold,
+    classifications,
+  });
   res.json(data);
 });
+
+function toExportRows(analytics) {
+  return analytics.periods.map((period) => ({
+    period: period.period,
+    posted: period.totals.posted,
+    awarded: period.totals.awarded,
+    cancelled: period.totals.cancelled,
+    cancellationRate: period.totals.cancellationRate,
+    overtime: period.totals.overtime,
+    averageHours: period.totals.averageHours,
+  }));
+}
 
 app.get("/api/analytics/export", requireAuth, (req, res) => {
   const format = req.query.format;
@@ -84,22 +113,77 @@ app.get("/api/analytics/export", requireAuth, (req, res) => {
   }
 
   const data = aggregateByMonth(sampleVacancies, { overtimeThreshold });
+  const rows = toExportRows(data);
   switch (format) {
     case "csv": {
       res.setHeader("Content-Type", "text/csv");
-      res.send(createCsv(data));
+      res.send(createCsv(rows));
       break;
     }
     case "pdf": {
       res.setHeader("Content-Type", "application/pdf");
-      const doc = createPdf(data);
+      const doc = createPdf(rows);
       doc.pipe(res);
       doc.end();
       break;
     }
     default:
-      res.status(400).json({ error: "format query parameter required (csv|pdf)" });
+      res
+        .status(400)
+        .json({ error: "format query parameter required (csv|pdf)" });
   }
+});
+
+app.post("/api/analytics/scenario", requireAuth, (req, res) => {
+  const { classifications, overtimeThreshold, extraShiftPercent } = req.body ?? {};
+
+  if (!Array.isArray(classifications) || classifications.length === 0) {
+    return res
+      .status(400)
+      .json({ error: "classifications must be a non-empty array" });
+  }
+  if (
+    classifications.some(
+      (value) => typeof value !== "string" || value.trim().length === 0,
+    )
+  ) {
+    return res
+      .status(400)
+      .json({ error: "classifications must only contain strings" });
+  }
+
+  if (overtimeThreshold === undefined) {
+    return res
+      .status(400)
+      .json({ error: "overtimeThreshold is required for scenario" });
+  }
+
+  const parsedOvertime = Number(overtimeThreshold);
+  if (!Number.isFinite(parsedOvertime) || parsedOvertime <= 0) {
+    return res.status(400).json({
+      error: "overtimeThreshold must be a positive number",
+    });
+  }
+
+  const parsedExtra = extraShiftPercent === undefined ? 0 : Number(extraShiftPercent);
+  if (!Number.isFinite(parsedExtra)) {
+    return res
+      .status(400)
+      .json({ error: "extraShiftPercent must be a number" });
+  }
+  if (parsedExtra < -50 || parsedExtra > 200) {
+    return res.status(400).json({
+      error: "extraShiftPercent must be between -50 and 200",
+    });
+  }
+
+  const result = projectScenario(sampleVacancies, {
+    classifications: classifications.map((value) => value.trim()),
+    overtimeThreshold: parsedOvertime,
+    extraShiftPercent: parsedExtra,
+  });
+
+  res.json(result);
 });
 
 if (process.env.NODE_ENV !== "test") {

--- a/server/metrics.js
+++ b/server/metrics.js
@@ -1,60 +1,331 @@
 const ALLOWED_STATUSES = new Set(["awarded", "cancelled", "posted"]);
 
-export function aggregateByMonth(vacancies, options = {}) {
-  const { overtimeThreshold = 8 } = options;
-  const groups = {};
-  for (const v of vacancies) {
-    if (!ALLOWED_STATUSES.has(v.status)) {
-      console.warn(`Unknown status: ${v.status}`);
+const DEFAULT_MOVING_AVERAGE_WINDOW = 3;
+const DEFAULT_FORECAST_PERIODS = 3;
+
+function finalizeMetrics(acc) {
+  const posted = acc.posted ?? 0;
+  const cancelled = acc.cancelled ?? 0;
+  const totalHours = acc.totalHours ?? 0;
+  const averageHours = posted ? totalHours / posted : 0;
+  const cancellationRate = posted ? cancelled / posted : 0;
+
+  return {
+    posted,
+    awarded: acc.awarded ?? 0,
+    cancelled,
+    overtime: acc.overtime ?? 0,
+    totalHours,
+    cancellationRate,
+    averageHours,
+  };
+}
+
+function computeMovingAverage(values, window = DEFAULT_MOVING_AVERAGE_WINDOW) {
+  const result = [];
+  for (let i = 0; i < values.length; i++) {
+    if (i + 1 < window) {
+      result.push(null);
       continue;
     }
-    const month = v.date.slice(0, 7);
-    groups[month] = groups[month] || [];
-    groups[month].push(v);
+    const slice = values.slice(i + 1 - window, i + 1);
+    const sum = slice.reduce((acc, val) => acc + val, 0);
+    result.push(sum / window);
   }
-  return Object.entries(groups)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([period, items]) => {
-      const stats = items.reduce(
-        (acc, item) => {
-          acc.posted++;
-          acc.totalHours += item.hours;
-          if (item.status === "awarded") {
-            acc.awarded++;
-            acc.overtime += Math.max(0, item.hours - overtimeThreshold);
-          } else if (item.status === "cancelled") {
-            acc.cancelled++;
-          }
-          return acc;
-        },
-        { posted: 0, awarded: 0, cancelled: 0, overtime: 0, totalHours: 0 },
-      );
+  return result;
+}
 
-      const cancellationRate = stats.posted
-        ? stats.cancelled / stats.posted
-        : 0;
-      const averageHours = stats.posted
-        ? stats.totalHours / stats.posted
-        : 0;
+function addMonths(period, offset) {
+  const [year, month] = period.split("-").map((n) => Number.parseInt(n, 10));
+  const base = new Date(year, month - 1 + offset, 1);
+  const nextYear = base.getFullYear();
+  const nextMonth = String(base.getMonth() + 1).padStart(2, "0");
+  return `${nextYear}-${nextMonth}`;
+}
 
-      return {
-        period,
-        posted: stats.posted,
-        awarded: stats.awarded,
-        cancelled: stats.cancelled,
-        cancellationRate,
-        overtime: stats.overtime,
-        averageHours,
-      };
+export function holtWintersForecast(
+  series,
+  {
+    alpha = 0.3,
+    beta = 0.1,
+    periodsAhead = DEFAULT_FORECAST_PERIODS,
+    lastPeriod,
+  } = {},
+) {
+  if (!Array.isArray(series) || series.length < 2) {
+    return [];
+  }
+
+  let level = series[0];
+  let trend = series[1] - series[0];
+  const fitted = [];
+
+  for (const point of series) {
+    const prevLevel = level;
+    level = alpha * point + (1 - alpha) * (level + trend);
+    trend = beta * (level - prevLevel) + (1 - beta) * trend;
+    fitted.push(level + trend);
+  }
+
+  const residuals = series.slice(1).map((value, index) => {
+    const prediction = fitted[index];
+    return value - prediction;
+  });
+  const variance =
+    residuals.reduce((acc, value) => acc + value * value, 0) /
+      Math.max(1, residuals.length) || 0;
+  const stdDev = Math.sqrt(variance);
+  const basePeriod = lastPeriod ?? addMonths("1970-01", series.length - 1);
+
+  const forecast = [];
+  for (let i = 1; i <= periodsAhead; i++) {
+    const forecastValue = level + trend * i;
+    const period = addMonths(basePeriod, i);
+    const margin = 1.96 * stdDev;
+    forecast.push({
+      period,
+      value: forecastValue,
+      lower: Math.max(0, forecastValue - margin),
+      upper: forecastValue + margin,
     });
+  }
+  return forecast;
+}
+
+function toFlatObject(map) {
+  const obj = {};
+  for (const [key, value] of map.entries()) {
+    obj[key] = finalizeMetrics(value);
+  }
+  return obj;
+}
+
+export function aggregateByMonth(vacancies, options = {}) {
+  const {
+    overtimeThreshold = 8,
+    classifications,
+    movingAverageWindow = DEFAULT_MOVING_AVERAGE_WINDOW,
+    forecastPeriods = DEFAULT_FORECAST_PERIODS,
+  } = options;
+
+  const filtered = Array.isArray(classifications) && classifications.length
+    ? vacancies.filter((vacancy) =>
+        classifications.includes(vacancy.classification ?? "Unspecified"),
+      )
+    : vacancies;
+
+  const groups = new Map();
+  const availableClassifications = new Set();
+
+  for (const vacancy of filtered) {
+    if (!vacancy || typeof vacancy.date !== "string") continue;
+    if (!ALLOWED_STATUSES.has(vacancy.status)) {
+      console.warn(`Unknown status: ${vacancy.status}`);
+      continue;
+    }
+    const classification = vacancy.classification ?? "Unspecified";
+    availableClassifications.add(classification);
+
+    const period = vacancy.date.slice(0, 7);
+    if (!groups.has(period)) {
+      groups.set(period, {
+        totals: {
+          posted: 0,
+          awarded: 0,
+          cancelled: 0,
+          overtime: 0,
+          totalHours: 0,
+        },
+        classifications: new Map(),
+      });
+    }
+
+    const periodEntry = groups.get(period);
+    periodEntry.totals.posted += 1;
+    periodEntry.totals.totalHours += vacancy.hours ?? 0;
+
+    if (!periodEntry.classifications.has(classification)) {
+      periodEntry.classifications.set(classification, {
+        posted: 0,
+        awarded: 0,
+        cancelled: 0,
+        overtime: 0,
+        totalHours: 0,
+      });
+    }
+
+    const classificationEntry = periodEntry.classifications.get(classification);
+    classificationEntry.posted += 1;
+    classificationEntry.totalHours += vacancy.hours ?? 0;
+
+    if (vacancy.status === "awarded") {
+      periodEntry.totals.awarded += 1;
+      classificationEntry.awarded += 1;
+      const overtime = Math.max(0, (vacancy.hours ?? 0) - overtimeThreshold);
+      periodEntry.totals.overtime += overtime;
+      classificationEntry.overtime += overtime;
+    } else if (vacancy.status === "cancelled") {
+      periodEntry.totals.cancelled += 1;
+      classificationEntry.cancelled += 1;
+    }
+  }
+
+  const sortedPeriods = Array.from(groups.entries()).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+
+  const periods = sortedPeriods.map(([period, { totals, classifications: map }]) => ({
+    period,
+    totals: finalizeMetrics(totals),
+    classifications: toFlatObject(map),
+    movingAverage: { posted: null, awarded: null, overtime: null },
+  }));
+
+  const postedSeries = periods.map((period) => period.totals.posted);
+  const awardedSeries = periods.map((period) => period.totals.awarded);
+  const overtimeSeries = periods.map((period) => period.totals.overtime);
+
+  const movingPosted = computeMovingAverage(postedSeries, movingAverageWindow);
+  const movingAwarded = computeMovingAverage(awardedSeries, movingAverageWindow);
+  const movingOvertime = computeMovingAverage(overtimeSeries, movingAverageWindow);
+
+  periods.forEach((period, index) => {
+    period.movingAverage = {
+      posted: movingPosted[index],
+      awarded: movingAwarded[index],
+      overtime: movingOvertime[index],
+    };
+  });
+
+  const forecast = holtWintersForecast(postedSeries, {
+    periodsAhead: forecastPeriods,
+    lastPeriod: periods.at(-1)?.period,
+  });
+
+  return {
+    periods,
+    forecast,
+    availableClassifications: Array.from(availableClassifications).sort(),
+    metadata: {
+      overtimeThreshold,
+      movingAverageWindow,
+      forecastPeriods,
+    },
+  };
+}
+
+function scaleMetrics(metrics, factor) {
+  const baseTotalHours = metrics.totalHours ?? metrics.posted * metrics.averageHours;
+  const posted = Math.round(metrics.posted * factor);
+  const awarded = Math.round(metrics.awarded * factor);
+  const cancelled = Math.round(metrics.cancelled * factor);
+  const overtime = metrics.overtime * factor;
+  const totalHours = baseTotalHours * factor;
+  const cancellationRate = posted ? cancelled / posted : 0;
+  const averageHours = posted ? totalHours / posted : 0;
+
+  return {
+    posted,
+    awarded,
+    cancelled,
+    overtime,
+    totalHours,
+    cancellationRate,
+    averageHours,
+  };
+}
+
+export function projectScenario(vacancies, options = {}) {
+  const {
+    classifications,
+    overtimeThreshold = 8,
+    extraShiftPercent = 0,
+    forecastPeriods = DEFAULT_FORECAST_PERIODS,
+    movingAverageWindow = DEFAULT_MOVING_AVERAGE_WINDOW,
+  } = options;
+
+  const base = aggregateByMonth(vacancies, {
+    classifications,
+    overtimeThreshold,
+    forecastPeriods,
+    movingAverageWindow,
+  });
+
+  const factor = 1 + extraShiftPercent / 100;
+  const scenarioPeriods = base.periods.map((period) => {
+    const scaledTotals = scaleMetrics(period.totals, factor);
+    const scaledClassifications = Object.fromEntries(
+      Object.entries(period.classifications).map(([cls, metrics]) => [
+        cls,
+        scaleMetrics(metrics, factor),
+      ]),
+    );
+    return {
+      period: period.period,
+      totals: scaledTotals,
+      classifications: scaledClassifications,
+      movingAverage: { ...period.movingAverage },
+    };
+  });
+
+  const scenarioPosted = scenarioPeriods.map((period) => period.totals.posted);
+  const scenarioAwarded = scenarioPeriods.map((period) => period.totals.awarded);
+  const scenarioOvertime = scenarioPeriods.map((period) => period.totals.overtime);
+
+  const movingPosted = computeMovingAverage(
+    scenarioPosted,
+    movingAverageWindow,
+  );
+  const movingAwarded = computeMovingAverage(
+    scenarioAwarded,
+    movingAverageWindow,
+  );
+  const movingOvertime = computeMovingAverage(
+    scenarioOvertime,
+    movingAverageWindow,
+  );
+
+  scenarioPeriods.forEach((period, index) => {
+    period.movingAverage = {
+      posted: movingPosted[index],
+      awarded: movingAwarded[index],
+      overtime: movingOvertime[index],
+    };
+  });
+
+  const scenarioForecast = holtWintersForecast(scenarioPosted, {
+    periodsAhead: forecastPeriods,
+    lastPeriod: scenarioPeriods.at(-1)?.period,
+  });
+
+  return {
+    base,
+    scenario: {
+      ...base,
+      periods: scenarioPeriods,
+      forecast: scenarioForecast,
+      metadata: {
+        ...base.metadata,
+        overtimeThreshold,
+        extraShiftPercent,
+      },
+    },
+  };
 }
 
 export const sampleVacancies = [
-  { date: "2024-01-01", status: "awarded", hours: 10 },
-  { date: "2024-01-05", status: "cancelled", hours: 8 },
-  { date: "2024-01-07", status: "posted", hours: 8 },
-  { date: "2024-02-02", status: "awarded", hours: 9 },
-  { date: "2024-02-04", status: "awarded", hours: 8 },
-  { date: "2024-02-08", status: "cancelled", hours: 8 },
-  { date: "2024-03-03", status: "posted", hours: 8 },
+  { date: "2024-01-04", status: "awarded", hours: 10, classification: "RN" },
+  { date: "2024-01-08", status: "cancelled", hours: 8, classification: "RN" },
+  { date: "2024-01-12", status: "posted", hours: 7, classification: "LPN" },
+  { date: "2024-02-02", status: "awarded", hours: 9, classification: "RN" },
+  { date: "2024-02-11", status: "awarded", hours: 8, classification: "LPN" },
+  { date: "2024-02-15", status: "cancelled", hours: 6, classification: "RCA" },
+  { date: "2024-03-03", status: "posted", hours: 8, classification: "RN" },
+  { date: "2024-03-10", status: "awarded", hours: 11, classification: "RCA" },
+  { date: "2024-04-05", status: "awarded", hours: 12, classification: "RN" },
+  { date: "2024-04-18", status: "cancelled", hours: 8, classification: "LPN" },
+  { date: "2024-05-02", status: "posted", hours: 7, classification: "RCA" },
+  { date: "2024-05-07", status: "awarded", hours: 9, classification: "RN" },
+  { date: "2024-06-01", status: "awarded", hours: 10, classification: "LPN" },
+  { date: "2024-06-09", status: "cancelled", hours: 6, classification: "RCA" },
 ];

--- a/src/Analytics.tsx
+++ b/src/Analytics.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useState, useRef, useCallback } from "react";
+import {
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
 import { Bar, Line } from "react-chartjs-2";
 import { authFetch, setToken } from "./utils/api";
 import {
@@ -10,6 +16,7 @@ import {
   LineElement,
   Tooltip,
   Legend,
+  Filler,
 } from "chart.js";
 
 Chart.register(
@@ -20,23 +27,101 @@ Chart.register(
   LineElement,
   Tooltip,
   Legend,
+  Filler,
 );
 
-export type AnalyticsRow = {
-  period: string;
+type ClassificationMetrics = {
   posted: number;
   awarded: number;
   cancelled: number;
-  cancellationRate: number;
   overtime: number;
+  totalHours: number;
+  cancellationRate: number;
+  averageHours: number;
 };
 
+type MovingAverageMetrics = {
+  posted: number | null;
+  awarded: number | null;
+  overtime: number | null;
+};
+
+type PeriodAnalytics = {
+  period: string;
+  totals: ClassificationMetrics;
+  classifications: Record<string, ClassificationMetrics>;
+  movingAverage: MovingAverageMetrics;
+};
+
+type ForecastPoint = {
+  period: string;
+  value: number;
+  lower: number;
+  upper: number;
+};
+
+type AnalyticsPayload = {
+  periods: PeriodAnalytics[];
+  forecast: ForecastPoint[];
+  availableClassifications: string[];
+  metadata: {
+    overtimeThreshold?: number;
+    movingAverageWindow?: number;
+    forecastPeriods?: number;
+    extraShiftPercent?: number;
+  };
+};
+
+type ScenarioResponse = {
+  base: AnalyticsPayload;
+  scenario: AnalyticsPayload;
+};
+
+const EXTRA_SHIFT_MIN = -50;
+const EXTRA_SHIFT_MAX = 200;
+
+const BASE_COLORS = [
+  "rgba(54,162,235,0.6)",
+  "rgba(75,192,192,0.6)",
+  "rgba(153,102,255,0.6)",
+  "rgba(255,159,64,0.6)",
+  "rgba(201,203,207,0.6)",
+];
+
+const SCENARIO_COLORS = [
+  "rgba(255,99,132,0.45)",
+  "rgba(255,205,86,0.45)",
+  "rgba(255,159,64,0.45)",
+  "rgba(201,203,207,0.45)",
+  "rgba(153,102,255,0.45)",
+];
+
+function padArray<T>(input: T[], targetLength: number, fill: T) {
+  if (input.length >= targetLength) return input;
+  return [...input, ...Array(targetLength - input.length).fill(fill)];
+}
+
+function buildSeriesMap(values: ForecastPoint[]) {
+  return values.reduce<Record<string, ForecastPoint>>((map, point) => {
+    map[point.period] = point;
+    return map;
+  }, {});
+}
+
 export default function Analytics() {
-  const [rows, setRows] = useState<AnalyticsRow[]>([]);
+  const [analytics, setAnalytics] = useState<AnalyticsPayload | null>(null);
+  const [scenario, setScenario] = useState<AnalyticsPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [scenarioError, setScenarioError] = useState<string | null>(null);
+  const [scenarioLoading, setScenarioLoading] = useState(false);
+  const [selectedClasses, setSelectedClasses] = useState<string[]>([]);
+  const [overtimeThreshold, setOvertimeThreshold] = useState(8);
+  const [extraShiftPercent, setExtraShiftPercent] = useState(0);
 
   const controllerRef = useRef<AbortController | null>(null);
+  const thresholdInitialized = useRef(false);
+  const classesInitialized = useRef(false);
 
   const promptForToken = useCallback(() => {
     const token = window.prompt("Enter API token");
@@ -57,8 +142,23 @@ export default function Analytics() {
         const response = await authFetch("/api/analytics", {
           signal: controller.signal,
         });
-        const data = await response.json();
-        setRows(data);
+        const data: AnalyticsPayload = await response.json();
+        setAnalytics(data);
+        setScenario(null);
+        if (
+          !thresholdInitialized.current &&
+          data.metadata?.overtimeThreshold !== undefined
+        ) {
+          setOvertimeThreshold(data.metadata.overtimeThreshold);
+          thresholdInitialized.current = true;
+        }
+        if (
+          !classesInitialized.current &&
+          data.availableClassifications.length > 0
+        ) {
+          setSelectedClasses(data.availableClassifications);
+          classesInitialized.current = true;
+        }
         setLoading(false);
         return;
       } catch (err: any) {
@@ -85,9 +185,15 @@ export default function Analytics() {
   }, [promptForToken]);
 
   const handleExport = async (format: string) => {
+    if (!analytics) return;
+    const params = new URLSearchParams({ format });
+    const threshold = analytics.metadata?.overtimeThreshold;
+    if (threshold !== undefined) {
+      params.set("overtimeThreshold", String(threshold));
+    }
     try {
       const response = await authFetch(
-        `/api/analytics/export?format=${format}`,
+        `/api/analytics/export?${params.toString()}`,
       );
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
@@ -110,10 +216,259 @@ export default function Analytics() {
     }
   };
 
+  const runScenario = useCallback(async () => {
+    if (!analytics) return;
+    if (selectedClasses.length === 0) {
+      setScenarioError("Select at least one classification to project.");
+      return;
+    }
+
+    setScenarioLoading(true);
+    setScenarioError(null);
+    try {
+      const response = await authFetch("/api/analytics/scenario", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          classifications: selectedClasses,
+          overtimeThreshold,
+          extraShiftPercent,
+        }),
+      });
+      const payload: ScenarioResponse = await response.json();
+      setScenario(payload.scenario);
+    } catch (err: any) {
+      if (err.status === 401) {
+        if (promptForToken()) {
+          setScenarioLoading(false);
+          return runScenario();
+        }
+        setScenarioError("Unauthorized");
+      } else {
+        setScenarioError(err.message);
+      }
+    } finally {
+      setScenarioLoading(false);
+    }
+  }, [
+    analytics,
+    selectedClasses,
+    overtimeThreshold,
+    extraShiftPercent,
+    promptForToken,
+  ]);
+
   useEffect(() => {
     loadData();
     return () => controllerRef.current?.abort();
   }, [loadData]);
+
+  const toggleClassification = (cls: string) => {
+    setSelectedClasses((prev) =>
+      prev.includes(cls) ? prev.filter((item) => item !== cls) : [...prev, cls],
+    );
+  };
+
+  const classificationOptions = analytics?.availableClassifications ?? [];
+
+  const barChartData = useMemo(() => {
+    if (!analytics) return null;
+    const labels = analytics.periods.map((period) => period.period);
+    const classificationSet = new Set<string>(
+      analytics.availableClassifications,
+    );
+    scenario?.availableClassifications.forEach((cls) =>
+      classificationSet.add(cls),
+    );
+    const classificationList = Array.from(classificationSet).sort();
+
+    const baseDatasets = classificationList.map((cls, index) => ({
+      label: `Base ${cls}`,
+      data: analytics.periods.map(
+        (period) => period.classifications[cls]?.posted ?? 0,
+      ),
+      backgroundColor: BASE_COLORS[index % BASE_COLORS.length],
+      stack: "base",
+    }));
+
+    const scenarioDatasets = scenario
+      ? classificationList.map((cls, index) => ({
+          label: `Scenario ${cls}`,
+          data: scenario.periods.map(
+            (period) => period.classifications[cls]?.posted ?? 0,
+          ),
+          backgroundColor:
+            SCENARIO_COLORS[index % SCENARIO_COLORS.length],
+          stack: "scenario",
+        }))
+      : [];
+
+    return {
+      labels,
+      datasets: [...baseDatasets, ...scenarioDatasets],
+    };
+  }, [analytics, scenario]);
+
+  const lineChartData = useMemo(() => {
+    if (!analytics) return null;
+
+    const labels = [...analytics.periods.map((period) => period.period)];
+    const appendLabel = (value: string) => {
+      if (!labels.includes(value)) labels.push(value);
+    };
+    analytics.forecast.forEach((point) => appendLabel(point.period));
+    scenario?.forecast.forEach((point) => appendLabel(point.period));
+    const labelCount = labels.length;
+
+    const baseActual = padArray<number | null>(
+      analytics.periods.map((period) => period.totals.posted),
+      labelCount,
+      null,
+    );
+    const baseMovingAverage = padArray(
+      analytics.periods.map((period) => period.movingAverage.posted ?? null),
+      labelCount,
+      null,
+    );
+
+    const forecastMap = buildSeriesMap(analytics.forecast);
+    const baseForecastMean = labels.map((period) =>
+      forecastMap[period]?.value ?? null,
+    );
+    const baseForecastUpper = labels.map((period) =>
+      forecastMap[period]?.upper ?? null,
+    );
+    const baseForecastLower = labels.map((period) =>
+      forecastMap[period]?.lower ?? null,
+    );
+
+    const scenarioActual = scenario
+      ? padArray<number | null>(
+          scenario.periods.map((period) => period.totals.posted),
+          labelCount,
+          null,
+        )
+      : [];
+
+    const scenarioForecastMap = scenario
+      ? buildSeriesMap(scenario.forecast)
+      : {};
+    const scenarioForecastMean = scenario
+      ? labels.map((period) => scenarioForecastMap[period]?.value ?? null)
+      : [];
+    const scenarioForecastUpper = scenario
+      ? labels.map((period) => scenarioForecastMap[period]?.upper ?? null)
+      : [];
+    const scenarioForecastLower = scenario
+      ? labels.map((period) => scenarioForecastMap[period]?.lower ?? null)
+      : [];
+
+    const datasets: any[] = [
+      {
+        label: "Base Posted",
+        data: baseActual,
+        borderColor: "rgba(54,162,235,1)",
+        backgroundColor: "rgba(54,162,235,0.1)",
+        pointRadius: 3,
+        tension: 0.3,
+        spanGaps: true,
+      },
+      {
+        label: "Base Moving Average",
+        data: baseMovingAverage,
+        borderColor: "rgba(255,159,64,1)",
+        backgroundColor: "rgba(255,159,64,0.1)",
+        pointRadius: 0,
+        borderDash: [6, 3],
+        tension: 0.3,
+        spanGaps: true,
+      },
+    ];
+
+    if (scenario) {
+      datasets.splice(1, 0, {
+        label: "Scenario Posted",
+        data: scenarioActual,
+        borderColor: "rgba(255,99,132,1)",
+        backgroundColor: "rgba(255,99,132,0.1)",
+        pointRadius: 3,
+        tension: 0.3,
+        spanGaps: true,
+      });
+    }
+
+    if (baseForecastMean.some((value) => value !== null)) {
+      datasets.push(
+        {
+          label: "Forecast Lower",
+          data: baseForecastLower,
+          borderColor: "rgba(99,132,255,0)",
+          backgroundColor: "rgba(99,132,255,0)",
+          pointRadius: 0,
+          spanGaps: true,
+          fill: false,
+          tension: 0.3,
+        },
+        {
+          label: "Forecast Range",
+          data: baseForecastUpper,
+          borderColor: "rgba(99,132,255,0)",
+          backgroundColor: "rgba(99,132,255,0.2)",
+          pointRadius: 0,
+          spanGaps: true,
+          fill: "-1",
+          tension: 0.3,
+        },
+        {
+          label: "Forecast Mean",
+          data: baseForecastMean,
+          borderColor: "rgba(99,132,255,1)",
+          backgroundColor: "rgba(99,132,255,0.1)",
+          pointRadius: 3,
+          borderDash: [4, 4],
+          tension: 0.3,
+          spanGaps: true,
+        },
+      );
+    }
+
+    if (scenario && scenarioForecastMean.some((value) => value !== null)) {
+      datasets.push(
+        {
+          label: "Scenario Forecast Lower",
+          data: scenarioForecastLower,
+          borderColor: "rgba(255,99,132,0)",
+          backgroundColor: "rgba(255,99,132,0)",
+          pointRadius: 0,
+          spanGaps: true,
+          fill: false,
+          tension: 0.3,
+        },
+        {
+          label: "Scenario Forecast Range",
+          data: scenarioForecastUpper,
+          borderColor: "rgba(255,99,132,0)",
+          backgroundColor: "rgba(255,99,132,0.2)",
+          pointRadius: 0,
+          spanGaps: true,
+          fill: "-1",
+          tension: 0.3,
+        },
+        {
+          label: "Scenario Forecast Mean",
+          data: scenarioForecastMean,
+          borderColor: "rgba(255,99,132,1)",
+          backgroundColor: "rgba(255,99,132,0.1)",
+          pointRadius: 3,
+          borderDash: [4, 4],
+          tension: 0.3,
+          spanGaps: true,
+        },
+      );
+    }
+
+    return { labels, datasets };
+  }, [analytics, scenario]);
 
   if (loading) {
     return (
@@ -150,11 +505,15 @@ export default function Analytics() {
     );
   }
 
-  const labels = rows.map((r) => r.period);
-  const posted = rows.map((r) => r.posted);
-  const filled = rows.map((r) => r.awarded);
-  const cancellationRate = rows.map((r) => r.cancellationRate * 100);
-  const overtime = rows.map((r) => r.overtime);
+  if (!analytics) {
+    return (
+      <div style={{ padding: 20 }}>
+        <h1>Analytics</h1>
+        <p>No analytics data available.</p>
+      </div>
+    );
+  }
+
   return (
     <div style={{ padding: 20 }}>
       <h1>Analytics</h1>
@@ -165,43 +524,104 @@ export default function Analytics() {
       >
         Set API Token
       </button>
-      <div style={{ width: 600 }}>
-        <Bar
-          data={{
-            labels,
-            datasets: [
-              {
-                label: "Posted",
-                data: posted,
-                backgroundColor: "rgba(54,162,235,0.5)",
-              },
-              {
-                label: "Filled",
-                data: filled,
-                backgroundColor: "rgba(75,192,192,0.5)",
-              },
-            ],
-          }}
-        />
+      <div style={{ marginBottom: 20 }}>
+        <h2 style={{ marginBottom: 10 }}>Scenario Planning</h2>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+          {classificationOptions.map((cls) => (
+            <label key={cls} style={{ display: "flex", alignItems: "center" }}>
+              <input
+                type="checkbox"
+                checked={selectedClasses.includes(cls)}
+                onChange={() => toggleClassification(cls)}
+                style={{ marginRight: 6 }}
+              />
+              {cls}
+            </label>
+          ))}
+        </div>
+        <div style={{ marginTop: 16 }}>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Overtime threshold: {overtimeThreshold.toFixed(1)} hours
+          </label>
+          <input
+            type="range"
+            min={4}
+            max={16}
+            step={0.5}
+            value={overtimeThreshold}
+            onChange={(event) =>
+              setOvertimeThreshold(Number.parseFloat(event.target.value))
+            }
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div style={{ marginTop: 16 }}>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Extra shifts: {extraShiftPercent}%
+          </label>
+          <input
+            type="range"
+            min={EXTRA_SHIFT_MIN}
+            max={EXTRA_SHIFT_MAX}
+            step={5}
+            value={extraShiftPercent}
+            onChange={(event) =>
+              setExtraShiftPercent(Number.parseFloat(event.target.value))
+            }
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div style={{ marginTop: 16 }}>
+          <button
+            onClick={runScenario}
+            className="btn"
+            disabled={scenarioLoading}
+          >
+            {scenarioLoading ? "Running scenario..." : "Run Scenario"}
+          </button>
+        </div>
+        {scenarioError && (
+          <p style={{ color: "#d33", marginTop: 8 }}>{scenarioError}</p>
+        )}
       </div>
-      <div style={{ width: 600, marginTop: 40 }}>
-        <Line
-          data={{
-            labels,
-            datasets: [
-              {
-                label: "Cancellation %",
-                data: cancellationRate,
-                borderColor: "red",
+      <div style={{ width: "min(900px, 100%)" }}>
+        <h2>Posted Shifts by Classification</h2>
+        {barChartData && (
+          <Bar
+            data={barChartData}
+            options={{
+              responsive: true,
+              interaction: { mode: "index", intersect: false },
+              scales: {
+                x: { stacked: true },
+                y: { stacked: true, beginAtZero: true },
               },
-              {
-                label: "Overtime Hours",
-                data: overtime,
-                borderColor: "orange",
+            }}
+          />
+        )}
+      </div>
+      <div style={{ width: "min(900px, 100%)", marginTop: 40 }}>
+        <h2>Volume Trends & Forecast</h2>
+        {lineChartData && (
+          <Line
+            data={lineChartData}
+            options={{
+              responsive: true,
+              interaction: { mode: "index", intersect: false },
+              scales: {
+                y: { beginAtZero: true },
               },
-            ],
-          }}
-        />
+              plugins: {
+                legend: {
+                  labels: {
+                    filter: (item) =>
+                      !(item.text && item.text.toLowerCase().includes("lower")),
+                  },
+                },
+              },
+            }}
+          />
+        )}
       </div>
       <div style={{ marginTop: 20 }}>
         <button onClick={() => handleExport("csv")} className="btn">

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -2,30 +2,34 @@ import { describe, it, expect } from "vitest";
 import { aggregateByMonth, sampleVacancies } from "../server/metrics.js";
 
 describe("aggregateByMonth", () => {
-  it("calculates metrics correctly", () => {
-    const result = aggregateByMonth(sampleVacancies);
-    const jan = result.find((r) => r.period === "2024-01");
-    const feb = result.find((r) => r.period === "2024-02");
-    expect(jan?.posted).toBe(3);
-    expect(jan?.awarded).toBe(1);
-    expect(jan?.cancelled).toBe(1);
-    expect(jan?.cancellationRate).toBeCloseTo(1 / 3);
-    expect(jan?.overtime).toBe(2);
-    expect(jan?.averageHours).toBeCloseTo(26 / 3);
-    expect(feb?.posted).toBe(3);
-    expect(feb?.awarded).toBe(2);
-    expect(feb?.cancelled).toBe(1);
-    expect(feb?.cancellationRate).toBeCloseTo(1 / 3);
-    expect(feb?.overtime).toBe(1);
-    expect(feb?.averageHours).toBeCloseTo(25 / 3);
+  it("calculates totals, breakdowns, and moving averages", () => {
+    const analytics = aggregateByMonth(sampleVacancies);
+    expect(analytics.availableClassifications).toEqual(["LPN", "RCA", "RN"]);
+    expect(analytics.forecast).toHaveLength(3);
+
+    const jan = analytics.periods.find((period) => period.period === "2024-01");
+    const apr = analytics.periods.find((period) => period.period === "2024-04");
+
+    expect(jan?.totals.posted).toBe(3);
+    expect(jan?.totals.awarded).toBe(1);
+    expect(jan?.totals.cancellationRate).toBeCloseTo(1 / 3);
+    expect(jan?.totals.overtime).toBe(2);
+    expect(jan?.classifications.RN.awarded).toBe(1);
+    expect(jan?.classifications.LPN.posted).toBe(1);
+    expect(jan?.movingAverage.posted).toBeNull();
+
+    expect(apr?.movingAverage.posted).toBeCloseTo(7 / 3);
+    expect(apr?.movingAverage.overtime).toBeCloseTo(8 / 3);
   });
 
   it("supports custom overtime threshold", () => {
-    const result = aggregateByMonth(sampleVacancies, { overtimeThreshold: 10 });
-    const jan = result.find((r) => r.period === "2024-01");
-    const feb = result.find((r) => r.period === "2024-02");
-    expect(jan?.overtime).toBe(0);
-    expect(feb?.overtime).toBe(0);
+    const analytics = aggregateByMonth(sampleVacancies, {
+      overtimeThreshold: 10,
+    });
+    const jan = analytics.periods.find((period) => period.period === "2024-01");
+    const feb = analytics.periods.find((period) => period.period === "2024-02");
+    expect(jan?.totals.overtime).toBe(0);
+    expect(feb?.totals.overtime).toBe(0);
   });
 
   it("ignores vacancies with unknown status", () => {
@@ -34,10 +38,10 @@ describe("aggregateByMonth", () => {
       status: "pending",
       hours: 5,
     };
-    const result = aggregateByMonth([...sampleVacancies, extra]);
-    const jan = result.find((r) => r.period === "2024-01");
-    expect(jan?.posted).toBe(3);
-    expect(jan?.awarded).toBe(1);
-    expect(jan?.cancelled).toBe(1);
+    const analytics = aggregateByMonth([...sampleVacancies, extra]);
+    const jan = analytics.periods.find((period) => period.period === "2024-01");
+    expect(jan?.totals.posted).toBe(3);
+    expect(jan?.totals.awarded).toBe(1);
+    expect(jan?.totals.cancelled).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- extend server-side analytics to compute per-classification aggregates, moving averages, and Holt-Winters forecasts while sharing scenario projections
- expose richer analytics payloads via updated endpoints, including a new scenario planning API and export support
- add advanced analytics UI with scenario controls, stacked bars, and forecast visualizations while updating accompanying tests

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68dda803bb588327895e928f834eb8b7