### PR TITLE
Refactor App and Dashboard to use centralized storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import { groupVacanciesByDate } from "./lib/vacancy";
 import { matchText } from "./lib/text";
 import { reorder } from "./utils/reorder";
+import { loadState, saveState } from "./utils/storage";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
 import VacancyRangeForm from "./components/VacancyRangeForm";
@@ -186,35 +187,6 @@ const SHIFT_PRESETS = [
 
 const VACANT_EMPLOYEE_ID = "__vacant__";
 
-// ---------- Local Storage ----------
-const LS_KEY = "maplewood-scheduler-v3";
-const loadState = () => {
-  try {
-    const raw = localStorage.getItem(LS_KEY);
-    return raw ? JSON.parse(raw) : null;
-  } catch (err) {
-    console.error("Failed to parse saved state", err);
-    if (typeof window !== "undefined" && typeof window.alert === "function") {
-      window.alert("Stored data was corrupted and has been reset.");
-    }
-    try {
-      localStorage.removeItem(LS_KEY);
-    } catch (removeErr) {
-      console.error("Failed to reset localStorage", removeErr);
-    }
-    return null;
-  }
-};
-const saveState = (state: any): boolean => {
-  try {
-    localStorage.setItem(LS_KEY, JSON.stringify(state));
-    return true;
-  } catch (err) {
-    console.warn("Unable to access localStorage. State not persisted.", err);
-    return false;
-  }
-};
-
 type StagedDeleteSnapshot = {
   previousVacancies: Vacancy[];
   previousBids: Bid[];
@@ -222,6 +194,16 @@ type StagedDeleteSnapshot = {
   previousSelectedIds: string[];
   message: string;
   timeout: ReturnType<typeof setTimeout>;
+};
+
+type PersistedState = {
+  employees?: Employee[];
+  vacations?: Vacation[];
+  vacancies?: Vacancy[];
+  bids?: Bid[];
+  archivedBids?: Record<string, Bid[]>;
+  settings?: Partial<Settings>;
+  notificationPrefs?: NotificationPreferences;
 };
 
 // ---------- Utils ----------
@@ -304,7 +286,7 @@ export const archiveBidsForVacancy = (
 
 // ---------- Main App ----------
 export default function App() {
-  const persisted = loadState();
+  const persisted = loadState<PersistedState>() ?? null;
   const [tab, setTab] = useState<typeof TAB_KEYS[number]>("coverage");
 
   const [employees, setEmployees] = useState<Employee[]>(
@@ -398,7 +380,7 @@ export default function App() {
   (window as any).appShowConfirm = showConfirm;
   (window as any).appShowPrompt = showPrompt;
   (window as any).appShowAlert = showAlert;
-  const persistedSettings = persisted?.settings ?? {};
+  const persistedSettings: Partial<Settings> = persisted?.settings ?? {};
   const storedOrder: string[] = persistedSettings.tabOrder || [];
   const mergedOrder = [
     ...storedOrder,

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -11,33 +11,21 @@ import type { Vacancy, VacancyRange } from "./types";
 import type { Tag } from "./models/tag";
 import useVacancies from "./state/useVacancies";
 import "./styles/branding.css";
-
-const LS_KEY = "maplewood-scheduler-v3";
-const loadState = () => {
-  try {
-    const raw = localStorage.getItem(LS_KEY);
-    return raw ? JSON.parse(raw) : null;
-  } catch (err) {
-    console.error("Failed to parse saved state", err);
-    if (typeof window !== "undefined" && typeof window.alert === "function") {
-      window.alert("Stored data was corrupted and has been reset.");
-    }
-    try {
-      localStorage.removeItem(LS_KEY);
-    } catch (removeErr) {
-      console.error("Failed to reset localStorage", removeErr);
-    }
-    return null;
-  }
-};
+import { loadState } from "./utils/storage";
 
 type State = {
   employees: Employee[];
   vacations: Vacation[];
 };
 
+type PersistedDashboardState = Partial<State>;
+
 export default function Dashboard() {
-  const data: State = loadState() || { employees: [], vacations: [] };
+  const persisted = loadState<PersistedDashboardState>() ?? {};
+  const data: State = {
+    employees: persisted.employees ?? [],
+    vacations: persisted.vacations ?? [],
+  };
   const { employees, vacations } = data;
   const {
     vacancies,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -3,11 +3,11 @@ import migrateCoverageDates from "../../migrations/2025-coverage-dates";
 
 const LS_KEY = "maplewood-scheduler-v3";
 
-export function loadState() {
+export function loadState<T = any>(): T | null {
   try {
     const raw = localStorage.getItem(LS_KEY);
-    const data = raw ? JSON.parse(raw) : null;
-    if (data) migrateCoverageDates(data);
+    const data = (raw ? JSON.parse(raw) : null) as T | null;
+    if (data) migrateCoverageDates(data as any);
     return data;
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- import the shared storage helpers into App and Dashboard and drop duplicated local persistence logic
- type persisted state usage so components maintain proper inference when hydrating saved data
- make the shared loadState helper generic for better type safety when reading from storage

## Testing
- npx vitest run tests/coverageDaysModalRangeUpdate.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ddf56213cc83279b3cc52e1159423b