### PR TITLE
Handle invalid deadline dates in API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,25 @@ const sanitizeChannels = (input) =>
     ? input.filter((channel) => VALID_CHANNELS.has(channel))
     : [];
 
+const coerceDate = (value, label) => {
+  if (value instanceof Date) {
+    return new Date(value);
+  }
+  if (value === undefined || value === null) {
+    return new Date();
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    if (label) {
+      console.warn(
+        `Received invalid ${label} value (${String(value)}); falling back to current time`,
+      );
+    }
+    return new Date();
+  }
+  return date;
+};
+
 const normalizeEvent = (raw) => {
   if (!raw || typeof raw !== "object") return null;
   const vacancyId = typeof raw.vacancyId === "string" ? raw.vacancyId : null;
@@ -29,8 +48,8 @@ const normalizeEvent = (raw) => {
     typeof raw.leadTimeId === "string" && raw.leadTimeId
       ? raw.leadTimeId
       : "custom";
-  const deadlineAt = new Date(raw.deadlineAt ?? Date.now());
-  const triggeredAt = new Date(raw.triggeredAt ?? Date.now());
+  const deadlineAt = coerceDate(raw.deadlineAt, "deadlineAt");
+  const triggeredAt = coerceDate(raw.triggeredAt, "triggeredAt");
   return {
     id: typeof raw.id === "string" && raw.id ? raw.id : undefined,
     vacancyId,

--- a/tests/deadlineHub.test.ts
+++ b/tests/deadlineHub.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import request from "supertest";
+import { app, deadlineHub } from "../server/index.js";
+
+describe("POST /api/deadlines", () => {
+  const token = "test-token";
+
+  beforeEach(() => {
+    process.env.ANALYTICS_AUTH_TOKEN = token;
+  });
+
+  afterEach(() => {
+    delete process.env.ANALYTICS_AUTH_TOKEN;
+    vi.restoreAllMocks();
+  });
+
+  it("coerces invalid deadline values and still accepts the batch", async () => {
+    const broadcastSpy = vi
+      .spyOn(deadlineHub, "broadcast")
+      .mockImplementation(async (event) => event);
+
+    const res = await request(app)
+      .post("/api/deadlines")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        events: [
+          {
+            id: "evt-1",
+            vacancyId: "vac-123",
+            message: "Hello",
+            deadlineAt: "not-a-date",
+            channels: ["email"],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ accepted: 1 });
+    expect(broadcastSpy).toHaveBeenCalledTimes(1);
+
+    const [eventArg] = broadcastSpy.mock.calls[0];
+    const parsedDeadline = new Date(eventArg.deadlineAt);
+    const parsedTriggered = new Date(eventArg.triggeredAt);
+
+    expect(Number.isNaN(parsedDeadline.getTime())).toBe(false);
+    expect(eventArg.deadlineAt).toBe(parsedDeadline.toISOString());
+    expect(Number.isNaN(parsedTriggered.getTime())).toBe(false);
+    expect(eventArg.triggeredAt).toBe(parsedTriggered.toISOString());
+  });
+});


### PR DESCRIPTION
## Summary
- add a coerceDate helper to normalize deadline timestamps and log invalid values
- replace direct Date constructions in normalizeEvent with the helper to keep ISO output
- add coverage ensuring /api/deadlines accepts invalid deadlineAt inputs and still emits ISO strings downstream

## Testing
- npm test -- --run tests/deadlineHub.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddf5793be48327b789c60330bc1a66