### PR TITLE
Restore search filters in Open Vacancies redesign

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -23,3 +23,9 @@ sequenceDiagram
   API-->>UI: JSON
   UI-->>U: Render schedule
 ```
+
+## Open Vacancies filters
+
+The redesigned Open Vacancies list restores the full set of toolbar filters. Admins can now
+combine keyword search, wing, classification, shift preset, countdown status, bundle mode,
+and date range chips to quickly zero in on the vacancies they need to manage.

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -8,6 +8,7 @@ placeholders below with your own captures.
 | ![Home](./media/screenshot-1.png) | Home screen |
 | ![Analytics](./media/screenshot-2.png) | Analytics dashboard |
 | ![Mobile](./media/screenshot-3.gif) | Mobile demo |
+| ![Search filters restored](./media/search-filters.png) | Wing, shift, and countdown filters on the Open Vacancies toolbar |
 
 Tips:
 - Use consistent window sizes.

--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -1,11 +1,13 @@
 import React, { useMemo } from "react";
 import type { Vacancy, Employee, Settings, Vacation } from "../types";
+import { SHIFT_PRESETS } from "../types";
 import type { Recommendation } from "../recommend";
 import BundleRow from "./BundleRow";
 import VacancyRow from "./VacancyRow";
-import { combineDateTime } from "../lib/dates";
+import { combineDateTime, minutesBetween } from "../lib/dates";
 import SearchFilterBar from "./SearchFilterBar";
 import { useVacancyFilters } from "../hooks/useVacancyFilters";
+import { deadlineFor, pickWindowMinutes } from "../lib/vacancy";
 
 type Props = {
   vacancies: Vacancy[];
@@ -46,6 +48,12 @@ export default function OpenVacanciesRedesign(props: Props) {
     setEnd,
     filterClass,
     setFilterClass,
+    filterWing,
+    setFilterWing,
+    filterShift,
+    setFilterShift,
+    filterCountdown,
+    setFilterCountdown,
     bundleMode,
     setBundleMode,
   } = useVacancyFilters();
@@ -79,7 +87,28 @@ export default function OpenVacanciesRedesign(props: Props) {
         );
       });
     }
+    if (filterWing) list = list.filter((v) => (v.wing || "") === filterWing);
     if (filterClass) list = list.filter((v) => v.classification === filterClass);
+    if (filterShift) {
+      const preset = SHIFT_PRESETS.find((p) => p.label === filterShift);
+      if (preset)
+        list = list.filter(
+          (v) => v.shiftStart === preset.start && v.shiftEnd === preset.end,
+        );
+    }
+    if (filterCountdown) {
+      list = list.filter((v) => {
+        const msLeft = deadlineFor(v, settings).getTime() - Date.now();
+        const winMin = pickWindowMinutes(v, settings);
+        const sinceKnownMin = minutesBetween(new Date(), new Date(v.knownAt));
+        const ratio = winMin > 0 ? (winMin - sinceKnownMin) / winMin : 0;
+        const pct = Math.max(0, Math.min(1, ratio));
+        let cdClass: "green" | "yellow" | "red" = "green";
+        if (msLeft <= 0) cdClass = "red";
+        else if (pct < 0.25) cdClass = "yellow";
+        return cdClass === filterCountdown;
+      });
+    }
     if (start) list = list.filter((v) => v.shiftDate >= start);
     if (end) list = list.filter((v) => v.shiftDate <= end);
     if (filters?.wing) list = list.filter((v) => (v.wing || "") === filters!.wing);
@@ -90,7 +119,20 @@ export default function OpenVacanciesRedesign(props: Props) {
     if (filters?.bundlesOnly) list = list.filter((v) => v.bundleId);
     if (filters?.singlesOnly) list = list.filter((v) => !v.bundleId);
     return list;
-  }, [vacancies, search, filterClass, start, end, filters, vacNameById, bundleMode]);
+  }, [
+    vacancies,
+    search,
+    filterClass,
+    filterWing,
+    filterShift,
+    filterCountdown,
+    start,
+    end,
+    filters,
+    vacNameById,
+    bundleMode,
+    settings,
+  ]);
 
   // Cross-day bundle groups so multi-day vacancies render as ONE row
   const bundleGroups = useMemo(() => {
@@ -150,10 +192,16 @@ export default function OpenVacanciesRedesign(props: Props) {
         startDate={start}
         endDate={end}
         category={filterClass}
+        wing={filterWing}
+        shiftPreset={filterShift}
+        countdown={filterCountdown}
         onQueryChange={setSearch}
         onStartDateChange={setStart}
         onEndDateChange={setEnd}
         onCategoryChange={(value) => setFilterClass(value)}
+        onWingChange={setFilterWing}
+        onShiftPresetChange={setFilterShift}
+        onCountdownChange={setFilterCountdown}
         bundleMode={bundleMode}
         onBundleModeChange={(mode) => setBundleMode(mode)}
         onClear={() => {
@@ -161,6 +209,9 @@ export default function OpenVacanciesRedesign(props: Props) {
           setStart("");
           setEnd("");
           setFilterClass("");
+          setFilterWing("");
+          setFilterShift("");
+          setFilterCountdown("");
           setBundleMode("all");
         }}
       />

--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent } from "react";
-import { CLASSIFICATIONS } from "../types";
+import { CLASSIFICATIONS, WINGS, SHIFT_PRESETS } from "../types";
 import type { Classification } from "../types";
 
 type BundleMode = "all" | "bundles" | "singles";
@@ -10,11 +10,17 @@ interface Props {
   endDate: string;
   category: Classification | "";
   bundleMode: BundleMode;
+  wing?: string;
+  shiftPreset?: string;
+  countdown?: string;
   onQueryChange: (value: string) => void;
   onStartDateChange: (value: string) => void;
   onEndDateChange: (value: string) => void;
   onCategoryChange: (value: Classification | "") => void;
   onBundleModeChange: (value: BundleMode) => void;
+  onWingChange?: (value: string) => void;
+  onShiftPresetChange?: (value: string) => void;
+  onCountdownChange?: (value: string) => void;
   onClear?: () => void;
 }
 
@@ -24,11 +30,17 @@ export default function SearchFilterBar({
   endDate,
   category,
   bundleMode,
+  wing = "",
+  shiftPreset = "",
+  countdown = "",
   onQueryChange,
   onStartDateChange,
   onEndDateChange,
   onCategoryChange,
   onBundleModeChange,
+  onWingChange,
+  onShiftPresetChange,
+  onCountdownChange,
   onClear,
 }: Props) {
   const clear = () => {
@@ -37,6 +49,9 @@ export default function SearchFilterBar({
     onEndDateChange("");
     onCategoryChange("");
     onBundleModeChange("all");
+    onWingChange?.("");
+    onShiftPresetChange?.("");
+    onCountdownChange?.("");
     onClear?.();
   };
 
@@ -46,6 +61,24 @@ export default function SearchFilterBar({
     } else {
       onCategoryChange(value);
     }
+  };
+
+  const toggleWing = (value: string) => {
+    if (!onWingChange) return;
+    if (wing === value) onWingChange("");
+    else onWingChange(value);
+  };
+
+  const toggleShiftPreset = (value: string) => {
+    if (!onShiftPresetChange) return;
+    if (shiftPreset === value) onShiftPresetChange("");
+    else onShiftPresetChange(value);
+  };
+
+  const toggleCountdown = (value: string) => {
+    if (!onCountdownChange) return;
+    if (countdown === value) onCountdownChange("");
+    else onCountdownChange(value);
   };
 
   const toggleBundleMode = (value: BundleMode) => {
@@ -66,6 +99,24 @@ export default function SearchFilterBar({
   }
   if (category) {
     activeFilters.push({ key: "category", label: `Class: ${category}`, onRemove: () => onCategoryChange("") });
+  }
+  if (wing && onWingChange) {
+    activeFilters.push({ key: "wing", label: `Wing: ${wing}`, onRemove: () => onWingChange("") });
+  }
+  if (shiftPreset && onShiftPresetChange) {
+    activeFilters.push({
+      key: "shift",
+      label: `Shift: ${shiftPreset}`,
+      onRemove: () => onShiftPresetChange(""),
+    });
+  }
+  if (countdown && onCountdownChange) {
+    const label = countdown.charAt(0).toUpperCase() + countdown.slice(1);
+    activeFilters.push({
+      key: "countdown",
+      label: `Countdown: ${label}`,
+      onRemove: () => onCountdownChange(""),
+    });
   }
   if (startDate || endDate) {
     const startLabel = startDate || "Any";
@@ -136,6 +187,47 @@ export default function SearchFilterBar({
           </option>
         ))}
       </select>
+      {onWingChange && (
+        <div className="chip-group" aria-label="Wing filters">
+          {WINGS.map((w) => (
+            <button
+              key={w}
+              type="button"
+              className="pill pill-toggle"
+              data-active={wing === w}
+              aria-pressed={wing === w}
+              onClick={() => toggleWing(w)}
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+      )}
+      {onWingChange && (
+        <select
+          aria-label="Wing filter"
+          value={wing}
+          onChange={(event: ChangeEvent<HTMLSelectElement>) => onWingChange(event.target.value)}
+          style={{
+            position: "absolute",
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: "hidden",
+            clip: "rect(0 0 0 0)",
+            whiteSpace: "nowrap",
+            border: 0,
+          }}
+        >
+          <option value="">All Wings</option>
+          {WINGS.map((w) => (
+            <option key={w} value={w}>
+              {w}
+            </option>
+          ))}
+        </select>
+      )}
       <div className="date-range" aria-label="Date range filters">
         <input
           type="date"
@@ -148,6 +240,90 @@ export default function SearchFilterBar({
           onChange={(e: ChangeEvent<HTMLInputElement>) => onEndDateChange(e.target.value)}
         />
       </div>
+      {onShiftPresetChange && (
+        <div className="chip-group" aria-label="Shift filters">
+          {SHIFT_PRESETS.map((preset) => (
+            <button
+              key={preset.label}
+              type="button"
+              className="pill pill-toggle"
+              data-active={shiftPreset === preset.label}
+              aria-pressed={shiftPreset === preset.label}
+              onClick={() => toggleShiftPreset(preset.label)}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+      )}
+      {onShiftPresetChange && (
+        <select
+          aria-label="Shift preset filter"
+          value={shiftPreset}
+          onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+            onShiftPresetChange(event.target.value)
+          }
+          style={{
+            position: "absolute",
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: "hidden",
+            clip: "rect(0 0 0 0)",
+            whiteSpace: "nowrap",
+            border: 0,
+          }}
+        >
+          <option value="">All Shifts</option>
+          {SHIFT_PRESETS.map((preset) => (
+            <option key={preset.label} value={preset.label}>
+              {preset.label}
+            </option>
+          ))}
+        </select>
+      )}
+      {onCountdownChange && (
+        <div className="chip-group" aria-label="Countdown filters">
+          {["green", "yellow", "red"].map((value) => (
+            <button
+              key={value}
+              type="button"
+              className="pill pill-toggle"
+              data-active={countdown === value}
+              aria-pressed={countdown === value}
+              onClick={() => toggleCountdown(value)}
+            >
+              {value.charAt(0).toUpperCase() + value.slice(1)}
+            </button>
+          ))}
+        </div>
+      )}
+      {onCountdownChange && (
+        <select
+          aria-label="Countdown filter"
+          value={countdown}
+          onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+            onCountdownChange(event.target.value)
+          }
+          style={{
+            position: "absolute",
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: "hidden",
+            clip: "rect(0 0 0 0)",
+            whiteSpace: "nowrap",
+            border: 0,
+          }}
+        >
+          <option value="">All Countdowns</option>
+          <option value="green">Green</option>
+          <option value="yellow">Yellow</option>
+          <option value="red">Red</option>
+        </select>
+      )}
       <div className="chip-group" aria-label="Bundle filters">
         <button
           type="button"

--- a/tests/searchFiltering.test.tsx
+++ b/tests/searchFiltering.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OpenVacanciesRedesign from "../src/components/OpenVacanciesRedesign.tsx";
 import type { Vacancy } from "../src/types";
 
@@ -11,11 +11,11 @@ vi.mock("../src/hooks/useVacancyFilters", async () => {
 
 const settings = {
   responseWindows: {
-    lt2h: 0,
-    h2to4: 0,
-    h4to24: 0,
-    h24to72: 0,
-    gt72: 0,
+    lt2h: 60,
+    h2to4: 120,
+    h4to24: 240,
+    h24to72: 720,
+    gt72: 1440,
   },
 };
 
@@ -24,13 +24,13 @@ const vacancies: Vacancy[] = [
     id: "v1",
     reason: "Shift A",
     classification: "RN",
-    wing: "Alpha",
+    wing: "Shamrock",
     date: "2024-01-01",
-    start: "08:00",
-    end: "16:00",
+    start: "06:30",
+    end: "14:30",
     shiftDate: "2024-01-01",
-    shiftStart: "08:00",
-    shiftEnd: "16:00",
+    shiftStart: "06:30",
+    shiftEnd: "14:30",
     knownAt: "2024-01-01T00:00:00.000Z",
     offeringTier: "CASUALS",
     offeringStep: "Casuals",
@@ -40,14 +40,30 @@ const vacancies: Vacancy[] = [
     id: "v2",
     reason: "Shift B",
     classification: "LPN",
-    wing: "Beta",
-    date: "2024-02-01",
-    start: "08:00",
-    end: "16:00",
-    shiftDate: "2024-02-01",
-    shiftStart: "08:00",
-    shiftEnd: "16:00",
-    knownAt: "2024-01-01T00:00:00.000Z",
+    wing: "Rosewood",
+    date: "2024-01-01",
+    start: "14:30",
+    end: "22:30",
+    shiftDate: "2024-01-01",
+    shiftStart: "14:30",
+    shiftEnd: "22:30",
+    knownAt: "2024-01-01T08:30:00.000Z",
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+  },
+  {
+    id: "v3",
+    reason: "Shift C",
+    classification: "RN",
+    wing: "Bluebell",
+    date: "2024-01-02",
+    start: "22:30",
+    end: "06:30",
+    shiftDate: "2024-01-02",
+    shiftStart: "22:30",
+    shiftEnd: "06:30",
+    knownAt: "2024-01-01T10:30:00.000Z",
     offeringTier: "CASUALS",
     offeringStep: "Casuals",
     status: "Open",
@@ -74,35 +90,86 @@ function renderComponent() {
   );
 }
 
-afterEach(cleanup);
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2024-01-01T12:00:00.000Z"));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe("OpenVacanciesRedesign filters", () => {
   it("filters by keyword", () => {
     renderComponent();
     const input = screen.getByPlaceholderText("Search...");
-    fireEvent.change(input, { target: { value: "Alpha" } });
-    expect(screen.getByText("Alpha")).toBeTruthy();
-    expect(screen.queryByText("Beta")).toBeNull();
+    fireEvent.change(input, { target: { value: "Shamrock" } });
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Shamrock")).toBeTruthy();
+    expect(within(table).queryByText("Rosewood")).toBeNull();
   });
 
   it("filters by category", () => {
     renderComponent();
-    const select = screen.getByRole("combobox");
+    const select = screen.getByRole("combobox", { name: "Classification filter" });
     fireEvent.change(select, { target: { value: "RN" } });
-    expect(screen.getByText("Alpha")).toBeTruthy();
-    expect(screen.queryByText("Beta")).toBeNull();
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Shamrock")).toBeTruthy();
+    expect(within(table).getByText("Bluebell")).toBeTruthy();
+    expect(within(table).queryByText("Rosewood")).toBeNull();
   });
 
   it("filters by date range", () => {
-  const { container } = renderComponent();
-  const [start, end] = Array.from(
-    container.querySelectorAll<HTMLInputElement>('input[type="date"]'),
-  ) as [HTMLInputElement, HTMLInputElement];
-    fireEvent.change(start, { target: { value: "2024-01-15" } });
-    expect(screen.queryByText("Alpha")).toBeNull();
-    expect(screen.getByText("Beta")).toBeTruthy();
-    fireEvent.change(end, { target: { value: "2024-01-31" } });
-    expect(screen.queryByText("Beta")).toBeNull();
+    const { container } = renderComponent();
+    const [start, end] = Array.from(
+      container.querySelectorAll<HTMLInputElement>('input[type="date"]'),
+    ) as [HTMLInputElement, HTMLInputElement];
+    fireEvent.change(start, { target: { value: "2024-01-02" } });
+    const table = screen.getByRole("table");
+    expect(within(table).queryByText("Shamrock")).toBeNull();
+    expect(within(table).getByText("Bluebell")).toBeTruthy();
+    fireEvent.change(end, { target: { value: "2024-01-01" } });
+    expect(within(table).queryByText("Bluebell")).toBeNull();
+  });
+
+  it("filters by wing", () => {
+    renderComponent();
+    fireEvent.click(screen.getByRole("button", { name: "Rosewood" }));
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Rosewood")).toBeTruthy();
+    expect(within(table).queryByText("Shamrock")).toBeNull();
+    expect(within(table).queryByText("Bluebell")).toBeNull();
+  });
+
+  it("filters by shift preset", () => {
+    renderComponent();
+    fireEvent.click(screen.getByRole("button", { name: "Night" }));
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Bluebell")).toBeTruthy();
+    expect(within(table).queryByText("Shamrock")).toBeNull();
+    expect(within(table).queryByText("Rosewood")).toBeNull();
+  });
+
+  it("filters by countdown status", () => {
+    renderComponent();
+    fireEvent.click(screen.getByRole("button", { name: "Red" }));
+    let table = screen.getByRole("table");
+    expect(within(table).getByText("Shamrock")).toBeTruthy();
+    expect(within(table).queryByText("Rosewood")).toBeNull();
+    expect(within(table).queryByText("Bluebell")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Yellow" }));
+    table = screen.getByRole("table");
+    expect(within(table).getByText("Rosewood")).toBeTruthy();
+    expect(within(table).queryByText("Shamrock")).toBeNull();
+    expect(within(table).queryByText("Bluebell")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Green" }));
+    table = screen.getByRole("table");
+    expect(within(table).getByText("Bluebell")).toBeTruthy();
+    expect(within(table).queryByText("Shamrock")).toBeNull();
+    expect(within(table).queryByText("Rosewood")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- extend the shared SearchFilterBar with wing, shift preset, and countdown controls so the redesign matches the legacy toolbar
- hook OpenVacanciesRedesign into the expanded vacancy filters and apply the extra criteria when building the filtered list
- refresh the search filtering test coverage plus docs/screenshots to document the restored toolbar options

## Testing
- npm run test -- searchFiltering

------
https://chatgpt.com/codex/tasks/task_e_68ddf6c693d88327a768e57a09afc632