### PR TITLE
fix: add accessible labels to vacancy filter inputs

### DIFF
--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -141,7 +141,11 @@ export default function SearchFilterBar({
   return (
     <div className="toolbar smart-filter-bar search-filter-bar">
       <div style={{ minWidth: 180, flexShrink: 0 }}>
+        <label className="sr-only" htmlFor="vacancy-search-input">
+          Search vacancies
+        </label>
         <input
+          id="vacancy-search-input"
           type="text"
           placeholder="Search..."
           value={query}
@@ -230,11 +234,13 @@ export default function SearchFilterBar({
       )}
       <div className="date-range" aria-label="Date range filters">
         <input
+          aria-label="Filter from date"
           type="date"
           value={startDate}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onStartDateChange(e.target.value)}
         />
         <input
+          aria-label="Filter to date"
           type="date"
           value={endDate}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onEndDateChange(e.target.value)}


### PR DESCRIPTION
## Summary
- add a screen-reader-only label for the vacancy search input
- add aria labels to the start and end date filters for better accessibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf95cb1188327a2755edf91c28793