### PR TITLE
fix: make bundle recommendation pill accessible

### DIFF
--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -141,14 +141,17 @@ export default function BundleRow({
           rightTag={
             <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
               {recId ? (
-                <span
+                <button
+                  type="button"
                   className="pill"
-                  style={{ cursor: "pointer" }}
                   title={recName}
-                  onClick={() => activeCandidate?.id && onAwardBundle?.(activeCandidate.id)}
+                  aria-label={`Award bundle to ${recName}`}
+                  onClick={() =>
+                    activeCandidate?.id && onAwardBundle?.(activeCandidate.id)
+                  }
                 >
                   {recName}
-                </span>
+                </button>
               ) : (
                 <span className="subtitle">—</span>
               )}


### PR DESCRIPTION
## Summary
- convert the bundle recommendation pill in the bundle row to a button for better accessibility
- add descriptive labelling while preserving the existing pill styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddf93c272083279a25994e033a5e35