### PR TITLE
Export storage key for app reset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import {
 import { groupVacanciesByDate } from "./lib/vacancy";
 import { matchText } from "./lib/text";
 import { reorder } from "./utils/reorder";
-import { loadState, saveState } from "./utils/storage";
+import { loadState, saveState, LS_KEY } from "./utils/storage";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
 import VacancyRangeForm from "./components/VacancyRangeForm";

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,7 +1,7 @@
 import { appConfig } from "../config";
 import migrateCoverageDates from "../../migrations/2025-coverage-dates";
 
-const LS_KEY = "maplewood-scheduler-v3";
+export const LS_KEY = "maplewood-scheduler-v3";
 
 export function loadState<T = any>(): T | null {
   try {


### PR DESCRIPTION
## Summary
- export the localStorage key from the storage utilities so it can be reused
- import the shared storage key in the app reset handler to avoid hardcoding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddfd88787c8327be500a06aadd0fc4