### PR TITLE
Style dashboard navigation toggle

### DIFF
--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -157,11 +157,16 @@ export default function Dashboard() {
       </header>
 
       <nav className="dashboard-nav">
-        <button onClick={() => setView("list")} disabled={view === "list"}>
+        <button
+          onClick={() => setView("list")}
+          className={view === "list" ? "active" : undefined}
+          disabled={view === "list"}
+        >
           List View
         </button>
         <button
           onClick={() => setView("calendar")}
+          className={view === "calendar" ? "active" : undefined}
           disabled={view === "calendar"}
         >
           Calendar View

--- a/src/styles/branding.css
+++ b/src/styles/branding.css
@@ -17,6 +17,41 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+.dashboard-nav {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.dashboard-nav button {
+  flex: 1 1 0;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--stroke);
+  background: rgba(4, 120, 87, 0.1);
+  color: var(--brand);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-nav button:not(.active):hover {
+  background: rgba(16, 185, 129, 0.15);
+  box-shadow: inset 0 0 0 1px rgba(4, 120, 87, 0.15);
+}
+
+.dashboard-nav button.active {
+  background: linear-gradient(90deg, var(--brand), var(--accent));
+  color: var(--button-text-on-brand);
+  border-color: var(--brand);
+  box-shadow: 0 4px 10px rgba(4, 120, 87, 0.25);
+}
+
+.dashboard-nav button[disabled] {
+  cursor: default;
+  pointer-events: none;
+}
+
 .dashboard-content {
   max-width: 960px;
   margin: 20px auto 0;


### PR DESCRIPTION
## Summary
- style the dashboard view toggle with Maplewood brand colors and segmented control layout
- mark the active dashboard view button so the new styles can highlight the current view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de011074948327855e861e392835ef