### PR TITLE
Update useFocusTrap hook types

### DIFF
--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,6 +1,6 @@
-import { useEffect } from "react";
+import { useEffect, type RefObject } from "react";
 
-export function useFocusTrap(ref: React.RefObject<HTMLElement>, onEscape?: () => void) {
+export function useFocusTrap(ref: RefObject<HTMLElement>, onEscape?: () => void) {
   useEffect(() => {
     const node = ref.current;
     if (!node) return;


### PR DESCRIPTION
## Summary
- import the RefObject type directly from React
- update the useFocusTrap hook signature to use the imported RefObject type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de050f25e883278cfdb6d670864447