### PR TITLE
Adjust date field ref typings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,11 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import { Link } from "react-router-dom";
 import { recommend, Recommendation } from "./recommend";
 import type { OfferingTier } from "./offering/offeringMachine";
@@ -552,7 +559,7 @@ export default function App() {
   const vacDateRef = useRef<HTMLInputElement>(null);
   const vacStartRef = useRef<HTMLInputElement>(null);
   const vacEndRef = useRef<HTMLInputElement>(null);
-  const handleDateFieldClick = (ref: React.RefObject<HTMLInputElement>) => {
+  const handleDateFieldClick = (ref: RefObject<HTMLInputElement>) => {
     ref.current?.focus();
     ref.current?.showPicker();
   };


### PR DESCRIPTION
## Summary
- import the RefObject type directly from React for date field refs
- update the date field click handler to use the imported RefObject type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0587123483278379eb4cfc6de861