### PR TITLE
Fix overflow wing detection type check

### DIFF
--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -71,7 +71,7 @@ export default function SearchFilterBar({
 
   const quickWings = WINGS.slice(0, 4);
   const overflowWings = WINGS.slice(4);
-  const overflowWingValue = overflowWings.includes(wing) ? wing : "";
+  const overflowWingValue = overflowWings.some((w) => w === wing) ? wing : "";
 
   const toggleShiftPreset = (value: string) => {
     if (!onShiftPresetChange) return;


### PR DESCRIPTION
## Summary
- update the overflow wing lookup to avoid forcing the wing value into the literal tuple type

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68de07d95bdc8327b53f9042d0fbc36d