### PR TITLE
Add npm start script for Express backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "start": "node server/index.js",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "build:ci": "tsc -p tsconfig.ci.json && vite build",


### PR DESCRIPTION
## Summary
- add an npm start script to launch the Express server with `node server/index.js`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9f555ef083278fb1468de0c9aa58