### PR TITLE
Allow bundling papaparse

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,10 +18,5 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
-  },
-  build: {
-    rollupOptions: {
-      external: ["papaparse"]
-    }
   }
 });


### PR DESCRIPTION
## Summary
- remove the build.rollupOptions.external entry so papaparse is bundled with the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dead88906083278371bab0ed535443