### PR TITLE
Persist open vacancy filters in local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2914,15 +2914,8 @@ export function BidsPage({
     setSelectedWings: setVacancySelectedWings,
     bundleMode: vacancyBundleMode,
     setBundleMode: setVacancyBundleMode,
+    resetFilters: resetVacancyFilters,
   } = useVacancyFilters();
-  const resetVacancyFilters = () => {
-    setVacancySearch("");
-    setVacancyStart("");
-    setVacancyEnd("");
-    setVacancySelectedPositions([]);
-    setVacancySelectedWings([]);
-    setVacancyBundleMode("all");
-  };
 
   const vacWithCoveredName = (v: Vacancy) => {
     const vac = vacations.find((x) => x.id === v.vacationId);

--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -53,6 +53,7 @@ export default function OpenVacanciesRedesign(props: Props) {
     setFilterShift,
     bundleMode,
     setBundleMode,
+    resetFilters,
   } = useVacancyFilters();
   const employeesById = useMemo(() => {
     const map: Record<string, Employee> = {};
@@ -186,15 +187,7 @@ export default function OpenVacanciesRedesign(props: Props) {
         onShiftPresetChange={setFilterShift}
         bundleMode={bundleMode}
         onBundleModeChange={(mode) => setBundleMode(mode)}
-        onClear={() => {
-          setSearch("");
-          setStart("");
-          setEnd("");
-          setSelectedPositions([]);
-          setSelectedWings([]);
-          setFilterShift("");
-          setBundleMode("all");
-        }}
+        onClear={resetFilters}
       />
       <table className="vacancies">
         <thead>

--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -106,6 +106,11 @@ export default function SearchFilterBar({
   onClear,
 }: Props) {
   const clear = () => {
+    if (onClear) {
+      onClear();
+      onShiftPresetChange?.("");
+      return;
+    }
     onQueryChange("");
     onStartDateChange("");
     onEndDateChange("");
@@ -113,7 +118,6 @@ export default function SearchFilterBar({
     onBundleModeChange("all");
     onWingsChange([]);
     onShiftPresetChange?.("");
-    onClear?.();
   };
 
   const toggleShiftPreset = (value: string) => {

--- a/src/hooks/useVacancyFilters.test.ts
+++ b/src/hooks/useVacancyFilters.test.ts
@@ -1,0 +1,128 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useVacancyFilters } from "./useVacancyFilters";
+import {
+  OPEN_VACANCY_FILTERS_KEY,
+  type VacancyFilterSnapshot,
+} from "../utils/storage";
+
+describe("useVacancyFilters localStorage integration", () => {
+  const originalLocalStorage = window.localStorage;
+  let store: Record<string, string>;
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    store = {};
+    mockStorage = {
+      getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: vi.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: vi.fn((key: string) => {
+        delete store[key];
+      }),
+      clear: vi.fn(() => {
+        store = {};
+      }),
+      key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+      get length() {
+        return Object.keys(store).length;
+      },
+    } as Storage;
+
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: mockStorage,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: originalLocalStorage,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("hydrates state from storage", () => {
+    const snapshot: VacancyFilterSnapshot = {
+      selectedWings: ["North"],
+      selectedPositions: ["RN"],
+      filterShift: "Day",
+      start: "2024-01-01",
+      end: "2024-01-02",
+      search: "nurse",
+      bundleMode: "bundles",
+    };
+    store[OPEN_VACANCY_FILTERS_KEY] = JSON.stringify(snapshot);
+
+    const { result } = renderHook(() => useVacancyFilters());
+
+    expect(result.current.selectedWings).toEqual(snapshot.selectedWings);
+    expect(result.current.selectedPositions).toEqual(snapshot.selectedPositions);
+    expect(result.current.filterShift).toBe(snapshot.filterShift);
+    expect(result.current.start).toBe(snapshot.start);
+    expect(result.current.end).toBe(snapshot.end);
+    expect(result.current.search).toBe(snapshot.search);
+    expect(result.current.bundleMode).toBe(snapshot.bundleMode);
+  });
+
+  it("persists changes when filters update", async () => {
+    const { result } = renderHook(() => useVacancyFilters());
+
+    act(() => {
+      result.current.setSearch("evening");
+      result.current.setStart("2024-02-01");
+      result.current.setEnd("2024-02-14");
+      result.current.setSelectedPositions(["LPN"]);
+      result.current.setSelectedWings(["Bluebell"]);
+      result.current.setFilterShift("Evening");
+      result.current.setBundleMode("singles");
+    });
+
+    await waitFor(() => {
+      expect(mockStorage.setItem).toHaveBeenLastCalledWith(
+        OPEN_VACANCY_FILTERS_KEY,
+        JSON.stringify({
+          selectedWings: ["Bluebell"],
+          selectedPositions: ["LPN"],
+          filterShift: "Evening",
+          start: "2024-02-01",
+          end: "2024-02-14",
+          search: "evening",
+          bundleMode: "singles",
+        }),
+      );
+    });
+  });
+
+  it("clears storage and resets when resetFilters is called", async () => {
+    const { result } = renderHook(() => useVacancyFilters());
+
+    act(() => {
+      result.current.setSearch("night");
+      result.current.setSelectedWings(["Rosewood"]);
+    });
+
+    await waitFor(() => {
+      expect(mockStorage.setItem).toHaveBeenCalled();
+    });
+
+    const setItemMock = mockStorage.setItem as ReturnType<typeof vi.fn>;
+    const callsBeforeReset = setItemMock.mock.calls.length;
+
+    act(() => {
+      result.current.resetFilters();
+    });
+
+    expect(mockStorage.removeItem).toHaveBeenCalledWith(OPEN_VACANCY_FILTERS_KEY);
+
+    await waitFor(() => {
+      expect(result.current.search).toBe("");
+      expect(result.current.selectedWings).toEqual([]);
+      expect(result.current.bundleMode).toBe("all");
+    });
+
+    expect(setItemMock.mock.calls.length).toBe(callsBeforeReset);
+  });
+});

--- a/src/hooks/useVacancyFilters.ts
+++ b/src/hooks/useVacancyFilters.ts
@@ -1,15 +1,83 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Classification } from "../types";
+import {
+  clearVacancyFilters,
+  loadVacancyFilters,
+  saveVacancyFilters,
+  type VacancyFilterSnapshot,
+} from "../utils/storage";
+
+const DEFAULT_FILTERS: VacancyFilterSnapshot = {
+  selectedWings: [],
+  selectedPositions: [],
+  filterShift: "",
+  start: "",
+  end: "",
+  search: "",
+  bundleMode: "all",
+};
 
 export function useVacancyFilters() {
-  const [selectedWings, setSelectedWings] = useState<string[]>([]);
-  const [selectedPositions, setSelectedPositions] = useState<Classification[]>([]);
-  const [filterShift, setFilterShift] = useState<string>("");
-  const [start, setStart] = useState<string>("");
-  const [end, setEnd] = useState<string>("");
-  const [search, setSearch] = useState<string>("");
-  const [bundleMode, setBundleMode] = useState<"all" | "bundles" | "singles">("all");
+  const persistedFilters = useMemo(() => loadVacancyFilters(), []);
+  const [selectedWings, setSelectedWings] = useState<string[]>(
+    () => persistedFilters?.selectedWings ?? DEFAULT_FILTERS.selectedWings,
+  );
+  const [selectedPositions, setSelectedPositions] = useState<Classification[]>(
+    () => persistedFilters?.selectedPositions ?? DEFAULT_FILTERS.selectedPositions,
+  );
+  const [filterShift, setFilterShift] = useState<string>(
+    () => persistedFilters?.filterShift ?? DEFAULT_FILTERS.filterShift,
+  );
+  const [start, setStart] = useState<string>(
+    () => persistedFilters?.start ?? DEFAULT_FILTERS.start,
+  );
+  const [end, setEnd] = useState<string>(() => persistedFilters?.end ?? DEFAULT_FILTERS.end);
+  const [search, setSearch] = useState<string>(
+    () => persistedFilters?.search ?? DEFAULT_FILTERS.search,
+  );
+  const [bundleMode, setBundleMode] = useState<"all" | "bundles" | "singles">(
+    () => persistedFilters?.bundleMode ?? DEFAULT_FILTERS.bundleMode,
+  );
   const [filtersOpen, setFiltersOpen] = useState(false);
+  const skipNextPersistRef = useRef(false);
+
+  useEffect(() => {
+    if (skipNextPersistRef.current) {
+      skipNextPersistRef.current = false;
+      return;
+    }
+    const snapshot: VacancyFilterSnapshot = {
+      selectedWings,
+      selectedPositions,
+      filterShift,
+      start,
+      end,
+      search,
+      bundleMode,
+    };
+    saveVacancyFilters(snapshot);
+  }, [
+    selectedWings,
+    selectedPositions,
+    filterShift,
+    start,
+    end,
+    search,
+    bundleMode,
+  ]);
+
+  const resetFilters = () => {
+    skipNextPersistRef.current = true;
+    setSelectedWings(DEFAULT_FILTERS.selectedWings);
+    setSelectedPositions(DEFAULT_FILTERS.selectedPositions);
+    setFilterShift(DEFAULT_FILTERS.filterShift);
+    setStart(DEFAULT_FILTERS.start);
+    setEnd(DEFAULT_FILTERS.end);
+    setSearch(DEFAULT_FILTERS.search);
+    setBundleMode(DEFAULT_FILTERS.bundleMode);
+    clearVacancyFilters();
+  };
+
   return {
     selectedWings,
     setSelectedWings,
@@ -27,5 +95,6 @@ export function useVacancyFilters() {
     setBundleMode,
     filtersOpen,
     setFiltersOpen,
+    resetFilters,
   };
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,7 +1,61 @@
 import { appConfig } from "../config";
 import migrateCoverageDates from "../../migrations/2025-coverage-dates";
+import type { Classification } from "../types";
 
 export const LS_KEY = "maplewood-scheduler-v3";
+export const OPEN_VACANCY_FILTERS_KEY = "openVacancyFilters";
+
+const getLocalStorage = (): Storage | null => {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    return localStorage;
+  } catch {
+    return null;
+  }
+};
+
+export type VacancyFilterSnapshot = {
+  selectedWings: string[];
+  selectedPositions: Classification[];
+  filterShift: string;
+  start: string;
+  end: string;
+  search: string;
+  bundleMode: "all" | "bundles" | "singles";
+};
+
+export type StoredVacancyFilters = Partial<VacancyFilterSnapshot> | null;
+
+export function loadVacancyFilters(): StoredVacancyFilters {
+  const storage = getLocalStorage();
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(OPEN_VACANCY_FILTERS_KEY);
+    return raw ? (JSON.parse(raw) as Partial<VacancyFilterSnapshot>) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveVacancyFilters(snapshot: VacancyFilterSnapshot): boolean {
+  const storage = getLocalStorage();
+  if (!storage) return false;
+  try {
+    storage.setItem(OPEN_VACANCY_FILTERS_KEY, JSON.stringify(snapshot));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearVacancyFilters(): void {
+  const storage = getLocalStorage();
+  try {
+    storage?.removeItem(OPEN_VACANCY_FILTERS_KEY);
+  } catch {
+    // noop – storage unavailable
+  }
+}
 
 export function loadState<T = any>(): T | null {
   try {


### PR DESCRIPTION
## Summary
- add a dedicated localStorage helper for saving and loading open vacancy filters
- hydrate `useVacancyFilters` from persisted values, sync updates, and expose a reset helper
- wire consumers to the reset helper and add unit coverage for the storage behaviour

## Testing
- npm test *(fails: searchFiltering.test.tsx, validation.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68deb67e15b88327b7e1d1c0c9119987