### PR TITLE
Add Cloudflare analytics loader

### DIFF
--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+
+type AnalyticsProps = {
+  token?: string | null;
+};
+
+export function Analytics({ token }: AnalyticsProps) {
+  useEffect(() => {
+    if (!token) return;
+
+    const dataAttribute = JSON.stringify({ token });
+    const existingScript = Array.from(
+      document.querySelectorAll<HTMLScriptElement>(
+        'script[src="https://static.cloudflareinsights.com/beacon.min.js"]',
+      ),
+    ).find((script) => script.getAttribute("data-cf-beacon") === dataAttribute);
+
+    if (existingScript) return;
+
+    const script = document.createElement("script");
+    script.defer = true;
+    script.src = "https://static.cloudflareinsights.com/beacon.min.js";
+    script.setAttribute("data-cf-beacon", dataAttribute);
+    document.head.appendChild(script);
+
+    return () => {
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    };
+  }, [token]);
+
+  return null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import App from "./App";
-import Analytics from "./Analytics";
+import AnalyticsPage from "./Analytics";
 import Dashboard from "./Dashboard";
 import AuditLog from "./AuditLog";
 import { ThemeProvider, Theme } from "./theme";
+import { Analytics } from "./components/Analytics";
 import "./styles/theme.css";
 import "./styles/responsive.css";
 import "./styles/ui-sanity.css";
@@ -26,13 +27,19 @@ const initialTheme: Theme = (() => {
   return theme;
 })();
 
+const token = import.meta.env.VITE_CLOUDFLARE_ANALYTICS_TOKEN;
+const isPreview = (import.meta.env.VITE_IS_PREVIEW ?? "").toLowerCase() === "true";
+const isProduction = import.meta.env.MODE === "production";
+const shouldLoadAnalytics = Boolean(isProduction && !isPreview && token);
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider initialTheme={initialTheme}>
+      {shouldLoadAnalytics && <Analytics token={token} />}
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<App />} />
-          <Route path="/analytics" element={<Analytics />} />
+          <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/audit-log" element={<AuditLog />} />
         </Routes>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,8 @@ export {};
 declare global {
   interface ImportMetaEnv {
     readonly VITE_API_TOKEN?: string;
+    readonly VITE_CLOUDFLARE_ANALYTICS_TOKEN?: string;
+    readonly VITE_IS_PREVIEW?: string;
     readonly [key: string]: string | undefined;
   }
 


### PR DESCRIPTION
## Summary
- add a reusable Cloudflare Analytics component that injects the beacon script when a token is provided
- type the new VITE_CLOUDFLARE_ANALYTICS_TOKEN and VITE_IS_PREVIEW environment variables
- load the analytics script from the main entry only for production builds that are not previews

## Testing
- npm run typecheck *(fails: existing errors in src/components/VacancyList.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68deba25defc8327a9ce3c41cb03e18d