### PR TITLE
Add select-all toggle to daily vacancy sections

### DIFF
--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -228,6 +228,15 @@ export default function OpenVacanciesRedesign(props: Props) {
               );
             })}
           {byDate.map(([date, items]) => {
+            const dayIds = items.map((item) => item.id);
+            const allSelected = dayIds.every((id) =>
+              props.selectedIds.includes(id),
+            );
+            const sectionLabel = fmtDate(date);
+            const toggleLabel = allSelected ? "Clear" : "Select all";
+            const toggleAriaLabel = allSelected
+              ? `Clear selections for ${sectionLabel} vacancies`
+              : `Select all vacancies for ${sectionLabel}`;
             const rendered: React.ReactNode[] = [];
             for (const v of items) {
               const recommendation = recommendations[v.id];
@@ -257,7 +266,19 @@ export default function OpenVacanciesRedesign(props: Props) {
             return (
               <React.Fragment key={`sec-${date}`}>
                 <tr className="section-h">
-                  <td colSpan={4}>{fmtDate(date)}</td>
+                  <td colSpan={4}>
+                    <div className="section-h__content">
+                      <span>{sectionLabel}</span>
+                      <button
+                        type="button"
+                        className="btn btn-sm section-h__toggle"
+                        onClick={() => props.onToggleSelectMany(dayIds)}
+                        aria-label={toggleAriaLabel}
+                      >
+                        {toggleLabel}
+                      </button>
+                    </div>
+                  </td>
                 </tr>
                 {rendered}
               </React.Fragment>

--- a/src/styles/vacancies-redesign.css
+++ b/src/styles/vacancies-redesign.css
@@ -35,3 +35,5 @@ td.cell-actions { width:1%; text-align:right; padding:10px 12px; }
 .badge-class { background: var(--badge-class-bg); color: var(--badge-class-text); }
 
 .section-h { position:sticky; top:36px; z-index:1; background: var(--section-bg); padding:6px 12px; font-weight:600; color: var(--section-text); border-top:1px solid var(--table-row-border); border-bottom:1px solid var(--table-row-border); }
+.section-h__content { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.section-h__toggle { white-space:nowrap; }

--- a/tests/openVacancies/dateSectionSelect.test.tsx
+++ b/tests/openVacancies/dateSectionSelect.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import OpenVacanciesRedesign from "../../src/components/OpenVacanciesRedesign";
+import type { Settings, Vacancy } from "../../src/types";
+
+vi.mock("../../src/hooks/useVacancyFilters", async () => {
+  const actual = await vi.importActual<typeof import("../../src/hooks/useVacancyFilters")>(
+    "../../src/hooks/useVacancyFilters",
+  );
+  return actual;
+});
+
+const settings: Settings = {
+  responseWindows: {
+    lt2h: 0,
+    h2to4: 0,
+    h4to24: 0,
+    h24to72: 0,
+    gt72: 0,
+  },
+};
+
+const dayVacancies: Vacancy[] = [
+  {
+    id: "vac-1",
+    reason: "Day One",
+    classification: "RN",
+    wing: "North",
+    date: "2024-05-01",
+    start: "08:00",
+    end: "16:00",
+    shiftDate: "2024-05-01",
+    shiftStart: "08:00",
+    shiftEnd: "16:00",
+    knownAt: "2024-04-01T00:00:00.000Z",
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+  },
+  {
+    id: "vac-2",
+    reason: "Day Two",
+    classification: "RN",
+    wing: "North",
+    date: "2024-05-01",
+    start: "10:00",
+    end: "18:00",
+    shiftDate: "2024-05-01",
+    shiftStart: "10:00",
+    shiftEnd: "18:00",
+    knownAt: "2024-04-01T00:00:00.000Z",
+    offeringTier: "CASUALS",
+    offeringStep: "Casuals",
+    status: "Open",
+  },
+];
+
+describe("OpenVacanciesRedesign date group selection", () => {
+  it("toggles all vacancies for the day", () => {
+    const onToggleSelectMany = vi.fn();
+
+    const { rerender } = render(
+      <OpenVacanciesRedesign
+        vacancies={dayVacancies}
+        employees={[]}
+        vacations={[]}
+        settings={settings}
+        selectedIds={[]}
+        dueNextId={null}
+        onToggleSelect={() => {}}
+        onToggleSelectMany={onToggleSelectMany}
+        onDelete={() => {}}
+        onDeleteMany={() => {}}
+        awardVacancy={() => {}}
+        resetKnownAt={() => {}}
+        recommendations={{}}
+      />,
+    );
+
+    const selectAllButton = screen.getByRole("button", {
+      name: /select all vacancies for/i,
+    });
+    expect(selectAllButton.textContent).toContain("Select all");
+
+    fireEvent.click(selectAllButton);
+    expect(onToggleSelectMany).toHaveBeenCalledWith(["vac-1", "vac-2"]);
+
+    rerender(
+      <OpenVacanciesRedesign
+        vacancies={dayVacancies}
+        employees={[]}
+        vacations={[]}
+        settings={settings}
+        selectedIds={["vac-1", "vac-2"]}
+        dueNextId={null}
+        onToggleSelect={() => {}}
+        onToggleSelectMany={onToggleSelectMany}
+        onDelete={() => {}}
+        onDeleteMany={() => {}}
+        awardVacancy={() => {}}
+        resetKnownAt={() => {}}
+        recommendations={{}}
+      />,
+    );
+
+    const clearButton = screen.getByRole("button", {
+      name: /clear selections for/i,
+    });
+    expect(clearButton.textContent).toContain("Clear");
+
+    fireEvent.click(clearButton);
+    expect(onToggleSelectMany).toHaveBeenCalledWith(["vac-1", "vac-2"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add select-all / clear controls to each daily vacancy section header and trigger `onToggleSelectMany`
- adjust section header layout styles so the new control aligns with existing toolbar buttons
- add a focused test covering the date group selection toggle behavior

## Testing
- npm test -- dateSectionSelect

------
https://chatgpt.com/codex/tasks/task_e_68debb11a1908327887ee8167ddb0fda