### PR TITLE
Update classification validation tests

### DIFF
--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -5,8 +5,9 @@ import {
   validateTime,
   validateTimeRange,
   validateClassification,
-  validateSelection
+  validateSelection,
 } from "./validation";
+import { CLASSIFICATIONS } from "../types";
 
 describe("validateDateRange", () => {
   it("should validate valid date range", () => {
@@ -93,18 +94,24 @@ describe("validateTimeRange", () => {
 
 describe("validateClassification", () => {
   it("should validate valid classifications", () => {
-    expect(validateClassification("RCA").isValid).toBe(true);
-    expect(validateClassification("LPN").isValid).toBe(true);
-    expect(validateClassification("RN").isValid).toBe(true);
-    expect(validateClassification("Rec").isValid).toBe(true);
-    expect(validateClassification("Receptionist").isValid).toBe(true);
+    for (const classification of CLASSIFICATIONS) {
+      expect(validateClassification(classification).isValid).toBe(true);
+    }
   });
 
   it("should reject invalid classifications", () => {
     const result = validateClassification("INVALID");
     expect(result.isValid).toBe(false);
     expect(result.error).toBe(
-      "Classification must be one of: RCA, LPN, RN, Rec, Receptionist",
+      `Classification must be one of: ${CLASSIFICATIONS.join(", ")}`,
+    );
+  });
+
+  it("should reject legacy classifications", () => {
+    const result = validateClassification("Rec");
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe(
+      `Classification must be one of: ${CLASSIFICATIONS.join(", ")}`,
     );
   });
 


### PR DESCRIPTION
## Summary
- iterate over the shared CLASSIFICATIONS list to validate all recognized values
- update the invalid classification message expectation to match the runtime string
- add a regression test ensuring legacy classification tokens such as "Rec" are rejected

## Testing
- npm test -- --run src/utils/validation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68debf905fec8327805f1c2116b5a6db