### PR TITLE
Improve employee import header handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,13 @@ import {
 import { groupVacanciesByDate } from "./lib/vacancy";
 import { matchText } from "./lib/text";
 import { reorder } from "./utils/reorder";
+import {
+  getFirst,
+  normalizeActive,
+  normalizeClassification,
+  normalizeStatus,
+  splitName,
+} from "./utils/headers";
 import { loadState, saveState, LS_KEY } from "./utils/storage";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
@@ -223,6 +230,183 @@ const displayVacancyLabel = (v: Vacancy) => {
   );
 };
 
+const EMPLOYEE_ID_HEADERS = [
+  "EmployeeID",
+  "Employee ID",
+  "Payroll ID",
+  "PayrollID",
+  "ID",
+  "Employee Number",
+  "Employee #",
+  "EmpID",
+  "Emp ID",
+  "EmployeeCode",
+  "Employee Code",
+];
+
+const FIRST_NAME_HEADERS = [
+  "First Name",
+  "FirstName",
+  "Given Name",
+  "Preferred Name",
+  "Preferred First Name",
+  "Legal First Name",
+];
+
+const LAST_NAME_HEADERS = [
+  "Last Name",
+  "LastName",
+  "Surname",
+  "Family Name",
+  "Legal Last Name",
+];
+
+const FULL_NAME_HEADERS = [
+  "Name",
+  "Employee Name",
+  "Full Name",
+  "Employee",
+];
+
+const CLASSIFICATION_HEADERS = [
+  "Classification",
+  "Class",
+  "Job Class",
+  "Job Title",
+  "Position",
+  "Role",
+];
+
+const STATUS_HEADERS = [
+  "Status",
+  "Employment Status",
+  "Employee Status",
+  "FT/PT",
+  "Employment Type",
+  "Type",
+];
+
+const ACTIVE_HEADERS = [
+  "Active",
+  "Is Active",
+  "Currently Active",
+  "Employment State",
+  "On Leave",
+];
+
+const HOME_WING_HEADERS = [
+  "Home Wing",
+  "Wing",
+  "Home Department",
+  "Department",
+  "Home Unit",
+];
+
+const START_DATE_HEADERS = [
+  "Start Date",
+  "Hire Date",
+  "Seniority Date",
+  "Start",
+  "Date Hired",
+];
+
+const SENIORITY_HOURS_HEADERS = [
+  "Seniority Hours",
+  "Hours",
+  "SeniorityHours",
+  "Total Hours",
+  "Hours Worked",
+];
+
+const SENIORITY_RANK_HEADERS = [
+  "Seniority Rank",
+  "Rank",
+  "Seniority",
+  "Seniority Position",
+  "Order",
+  "Seniority Ranking",
+];
+
+export function mapRowToEmployee(
+  row: Record<string, unknown>,
+  index = 0,
+): Employee | null {
+  if (!row || typeof row !== "object") return null;
+
+  const parseNumber = (value: unknown): number | undefined => {
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? value : undefined;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim().replace(/,/g, "");
+      if (!trimmed) return undefined;
+      const num = Number(trimmed);
+      return Number.isFinite(num) ? num : undefined;
+    }
+    return undefined;
+  };
+
+  const idRaw = getFirst(row, EMPLOYEE_ID_HEADERS);
+  const fullNameRaw = getFirst(row, FULL_NAME_HEADERS);
+  const nameParts = splitName(fullNameRaw);
+
+  const firstNameRaw = getFirst(row, FIRST_NAME_HEADERS);
+  const lastNameRaw = getFirst(row, LAST_NAME_HEADERS);
+
+  const firstName =
+    typeof firstNameRaw === "string" && firstNameRaw.trim()
+      ? firstNameRaw.trim()
+      : nameParts.firstName;
+  const lastName =
+    typeof lastNameRaw === "string" && lastNameRaw.trim()
+      ? lastNameRaw.trim()
+      : nameParts.lastName;
+
+  const hasName = Boolean(firstName || lastName);
+  const idValue = typeof idRaw === "string" ? idRaw.trim() : idRaw;
+  const id =
+    idValue !== undefined && idValue !== null && `${idValue}`.trim()
+      ? `${idValue}`.trim()
+      : hasName
+      ? `emp_${index}`
+      : "";
+
+  if (!id && !hasName) {
+    return null;
+  }
+
+  const classificationRaw = getFirst(row, CLASSIFICATION_HEADERS);
+  const statusRaw = getFirst(row, STATUS_HEADERS);
+  const activeRaw = getFirst(row, ACTIVE_HEADERS);
+  const homeWingRaw = getFirst(row, HOME_WING_HEADERS);
+  const startDateRaw = getFirst(row, START_DATE_HEADERS);
+  const seniorityHoursRaw = getFirst(row, SENIORITY_HOURS_HEADERS);
+  const seniorityRankRaw = getFirst(row, SENIORITY_RANK_HEADERS);
+  const seniorityRankValue = parseNumber(seniorityRankRaw);
+  const seniorityHoursValue = parseNumber(seniorityHoursRaw);
+
+  const employee: Employee = {
+    id: id || `emp_${index}`,
+    firstName,
+    lastName,
+    classification: normalizeClassification(classificationRaw),
+    status: normalizeStatus(statusRaw),
+    homeWing:
+      typeof homeWingRaw === "string" && homeWingRaw.trim()
+        ? homeWingRaw.trim()
+        : undefined,
+    startDate:
+      typeof startDateRaw === "string" && startDateRaw.trim()
+        ? startDateRaw.trim()
+        : undefined,
+    seniorityHours: seniorityHoursValue,
+    seniorityRank: seniorityRankValue ?? index + 1,
+    active: normalizeActive(activeRaw ?? statusRaw),
+  };
+
+  return employee;
+}
+
 function pickWindowMinutes(v: Vacancy, settings: Settings) {
   const known = new Date(v.knownAt);
   const shiftStart = combineDateTime(v.shiftDate, v.shiftStart);
@@ -328,6 +512,9 @@ export default function App() {
   const [stagedDelete, setStagedDelete] = useState<StagedDeleteSnapshot | null>(
     null,
   );
+  const [importToast, setImportToast] = useState<
+    { message: string; timeout: ReturnType<typeof setTimeout> } | null
+  >(null);
   const [activeVacancyId, setActiveVacancyId] = useState<string | null>(null);
   const [showRangeForm, setShowRangeForm] = useState(false);
   // Modal system (confirm/prompt/alert)
@@ -382,6 +569,42 @@ export default function App() {
   };
   const showAlert = (body: string, title = "Notice"): Promise<void> =>
     new Promise((resolve) => setAlertState({ open: true, title, body, resolve }));
+
+  const showImportHeadersToast = (
+    headers: string[],
+    prefix = "Unable to import employees.",
+  ) => {
+    const unique = Array.from(
+      new Set(
+        headers
+          .map((header) =>
+            typeof header === "string" ? header.trim() : String(header ?? ""),
+          )
+          .filter((header) => header.length > 0),
+      ),
+    );
+    const base = prefix.replace(/\.*$/, "");
+    const message = unique.length
+      ? `${base}. Detected headers: ${unique.join(", ")}`
+      : `${base}. No recognizable headers detected.`;
+    setImportToast((prev) => {
+      if (prev?.timeout) clearTimeout(prev.timeout);
+      const timeout = setTimeout(() => {
+        setImportToast((current) =>
+          current?.timeout === timeout ? null : current,
+        );
+      }, 8000);
+      return { message, timeout };
+    });
+  };
+
+  useEffect(() => {
+    return () => {
+      if (importToast?.timeout) {
+        clearTimeout(importToast.timeout);
+      }
+    };
+  }, [importToast]);
 
   // expose helpers for non-App children that cannot receive props easily
   (window as any).appShowConfirm = showConfirm;
@@ -1823,7 +2046,11 @@ export default function App() {
         )}
 
         {tab === "employees" && (
-          <EmployeesPage employees={employees} setEmployees={setEmployees} />
+          <EmployeesPage
+            employees={employees}
+            setEmployees={setEmployees}
+            showImportHeadersToast={showImportHeadersToast}
+          />
         )}
 
         {tab === "archive" && (
@@ -2083,6 +2310,7 @@ export default function App() {
             </div>
           </div>
         )}
+        <Toast open={!!importToast} message={importToast?.message || ""} />
         <Toast
           open={!!stagedDelete}
           message={stagedDelete?.message || ""}
@@ -2104,9 +2332,11 @@ export default function App() {
 function EmployeesPage({
   employees,
   setEmployees,
+  showImportHeadersToast,
 }: {
   employees: Employee[];
   setEmployees: (u: any) => void;
+  showImportHeadersToast: (headers: string[], prefix?: string) => void;
 }) {
   return (
     <div className="grid">
@@ -2126,35 +2356,29 @@ function EmployeesPage({
                 rows = parseCSV(text);
               } catch (err) {
                 console.error(err);
-                await (window as any).appShowAlert?.("Failed to parse CSV");
+                showImportHeadersToast([], "Failed to parse CSV.");
                 return;
               }
-              const out: Employee[] = rows.map((r: any, i: number) => {
-                const rawClass = String(r.classification ?? "").trim();
-                const normalizedClass =
-                  CLASSIFICATIONS.find(
-                    (option) =>
-                      option.toLowerCase() === rawClass.toLowerCase(),
-                  ) ?? CLASSIFICATIONS[0];
+              const mapped = rows
+                .map((r, i) => mapRowToEmployee(r, i))
+                .filter((emp): emp is Employee => !!emp);
 
-                return {
-                  id: String(r.id ?? r.EmployeeID ?? `emp_${i}`),
-                  firstName: String(r.firstName ?? r.name ?? ""),
-                  lastName: String(r.lastName ?? ""),
-                  classification: normalizedClass as Classification,
-                  status: (["FT", "PT", "Casual"].includes(String(r.status))
-                    ? r.status
-                    : "FT") as Status,
-                  homeWing: String(r.homeWing ?? ""),
-                  startDate: String(r.startDate ?? ""),
-                  seniorityHours: Number(r.seniorityHours ?? 0),
-                  seniorityRank: Number(r.seniorityRank ?? i + 1),
-                  active: String(r.active ?? "Yes")
-                    .toLowerCase()
-                    .startsWith("y"),
-                };
-              });
-              setEmployees(out.filter((e) => !!e.id));
+              if (!mapped.length) {
+                const headers = Array.from(
+                  new Set(
+                    rows.flatMap((row) =>
+                      row && typeof row === "object"
+                        ? Object.keys(row)
+                        : [],
+                    ),
+                  ),
+                );
+                showImportHeadersToast(headers, "Unable to import employees.");
+                return;
+              }
+
+              setEmployees(mapped);
+              e.target.value = "";
             }}
           />
           <div className="subtitle">

--- a/src/__tests__/headers.test.ts
+++ b/src/__tests__/headers.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFirst,
+  normalizeActive,
+  normalizeClassification,
+  normalizeStatus,
+  splitName,
+} from "../utils/headers";
+import { CLASSIFICATIONS } from "../types";
+import { mapRowToEmployee } from "../App";
+
+describe("header utilities", () => {
+  it("gets values ignoring case, spacing, and punctuation", () => {
+    const row = { " Payroll id ": "12345", "First Name": "Anna" };
+    expect(getFirst(row, ["payroll id"])).toBe("12345");
+    expect(getFirst(row, ["first name"])).toBe("Anna");
+    expect(getFirst(row, ["missing"], "fallback")).toBe("fallback");
+  });
+
+  it("splits combined names", () => {
+    expect(splitName("Doe, John")).toEqual({ firstName: "John", lastName: "Doe" });
+    expect(splitName("Jane A Smith")).toEqual({ firstName: "Jane", lastName: "A Smith" });
+    expect(splitName("Madonna")).toEqual({ firstName: "Madonna", lastName: "" });
+  });
+
+  it("normalizes classification synonyms", () => {
+    expect(normalizeClassification("psw")).toBe("RCA");
+    expect(normalizeClassification("ADP LPN")).toBe("ADP LPN");
+    expect(normalizeClassification("unknown")).toBe(CLASSIFICATIONS[0]);
+  });
+
+  it("normalizes employment status labels", () => {
+    expect(normalizeStatus("Full Time")).toBe("FT");
+    expect(normalizeStatus("part-time")).toBe("PT");
+    expect(normalizeStatus("cas")).toBe("Casual");
+    expect(normalizeStatus(undefined)).toBe("FT");
+  });
+
+  it("normalizes activity including On Leave", () => {
+    expect(normalizeActive("Yes")).toBe(true);
+    expect(normalizeActive("no")).toBe(false);
+    expect(normalizeActive("On Leave")).toBe(false);
+    expect(normalizeActive(true)).toBe(true);
+  });
+});
+
+describe("mapRowToEmployee", () => {
+  it("maps typical spreadsheet rows to Employee objects", () => {
+    const row: Record<string, unknown> = {
+      EmployeeID: "001",
+      "Employee Name": "Jane Doe",
+      Classification: "psw",
+      "Employment Status": "Part-Time",
+      "On Leave": "On Leave",
+      "Home Wing": "Shamrock",
+      "Start Date": "2021-05-01",
+      "Seniority Hours": "1,234.5",
+      "Seniority Rank": "7",
+    };
+
+    const employee = mapRowToEmployee(row, 0);
+    expect(employee).not.toBeNull();
+    expect(employee?.id).toBe("001");
+    expect(employee?.firstName).toBe("Jane");
+    expect(employee?.lastName).toBe("Doe");
+    expect(employee?.classification).toBe("RCA");
+    expect(employee?.status).toBe("PT");
+    expect(employee?.active).toBe(false);
+    expect(employee?.homeWing).toBe("Shamrock");
+    expect(employee?.startDate).toBe("2021-05-01");
+    expect(employee?.seniorityRank).toBe(7);
+    expect(employee?.seniorityHours).toBeCloseTo(1234.5);
+  });
+
+  it("prefers payroll ids, normalizes ADP, and defaults seniority rank", () => {
+    const row: Record<string, unknown> = {
+      "Payroll ID": "777",
+      Name: "John Smith",
+      Class: "ADP",
+      Status: "Full-time",
+      Active: "Yes",
+    };
+
+    const employee = mapRowToEmployee(row, 4);
+    expect(employee).not.toBeNull();
+    expect(employee?.id).toBe("777");
+    expect(employee?.firstName).toBe("John");
+    expect(employee?.lastName).toBe("Smith");
+    expect(employee?.classification).toBe("ADP RCA");
+    expect(employee?.status).toBe("FT");
+    expect(employee?.seniorityRank).toBe(5);
+    expect(employee?.active).toBe(true);
+  });
+
+  it("returns null for rows without ids or names", () => {
+    expect(mapRowToEmployee({}, 0)).toBeNull();
+  });
+});

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,0 +1,180 @@
+import { CLASSIFICATIONS } from "../types";
+import type { Classification, Status } from "../types";
+
+const HEADER_SANITIZE_REGEX = /[^a-z0-9]/gi;
+
+const CLASSIFICATION_SYNONYMS: Record<string, Classification> = {
+  rca: "RCA",
+  psw: "RCA",
+  "personal support worker": "RCA",
+  hca: "RCA",
+  "health care aide": "RCA",
+  "healthcare aide": "RCA",
+  "care aide": "RCA",
+  lpn: "LPN",
+  rpn: "LPN",
+  "registered practical nurse": "LPN",
+  "licensed practical nurse": "LPN",
+  rn: "RN",
+  "registered nurse": "RN",
+  rec: "Recreation",
+  recreation: "Recreation",
+  "recreation aide": "Recreation",
+  "recreation assistant": "Recreation",
+  receptionist: "Receptionist",
+  "front desk": "Receptionist",
+  "front office": "Receptionist",
+  adp: "ADP RCA",
+  "adp rca": "ADP RCA",
+  "adp psw": "ADP RCA",
+  "adp lpn": "ADP LPN",
+  "adp nurse": "ADP LPN",
+};
+
+const STATUS_SYNONYMS: Record<string, Status> = {
+  ft: "FT",
+  "fulltime": "FT",
+  "full-time": "FT",
+  "full time": "FT",
+  pt: "PT",
+  "parttime": "PT",
+  "part-time": "PT",
+  "part time": "PT",
+  casual: "Casual",
+  "cas": "Casual",
+  "flex": "Casual",
+  "temporary": "Casual",
+};
+
+const NEGATIVE_ACTIVITY = new Set([
+  "no",
+  "n",
+  "false",
+  "0",
+  "inactive",
+  "terminated",
+  "retired",
+  "leave",
+  "onleave",
+  "loa",
+  "on-leave",
+  "on leave",
+  "not active",
+]);
+
+const POSITIVE_ACTIVITY = new Set([
+  "yes",
+  "y",
+  "true",
+  "1",
+  "active",
+  "current",
+]);
+
+const sanitizeHeader = (header: string): string =>
+  header.replace(HEADER_SANITIZE_REGEX, "").toLowerCase();
+
+export function getFirst<T = unknown>(
+  row: Record<string, unknown>,
+  candidates: string[],
+  fallback?: T,
+): unknown | T {
+  const normalized = new Map<string, unknown>();
+  for (const [key, value] of Object.entries(row ?? {})) {
+    normalized.set(sanitizeHeader(key), value);
+  }
+
+  for (const candidate of candidates) {
+    const value = normalized.get(sanitizeHeader(candidate));
+    if (
+      value !== undefined &&
+      value !== null &&
+      (typeof value !== "string" || value.trim() !== "")
+    ) {
+      return value;
+    }
+  }
+
+  return fallback;
+}
+
+export function splitName(name: unknown): { firstName: string; lastName: string } {
+  const text = typeof name === "string" ? name.trim() : "";
+  if (!text) {
+    return { firstName: "", lastName: "" };
+  }
+
+  if (text.includes(",")) {
+    const [last, first = ""] = text.split(",");
+    return { firstName: first.trim(), lastName: last.trim() };
+  }
+
+  const parts = text.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) {
+    return { firstName: parts[0] ?? "", lastName: "" };
+  }
+
+  return {
+    firstName: parts[0] ?? "",
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
+export function normalizeClassification(input: unknown): Classification {
+  const raw = typeof input === "string" ? input.trim() : "";
+  if (!raw) return CLASSIFICATIONS[0];
+
+  const exact = CLASSIFICATIONS.find(
+    (option) => option.toLowerCase() === raw.toLowerCase(),
+  );
+  if (exact) return exact;
+
+  const key = raw.toLowerCase();
+  if (CLASSIFICATION_SYNONYMS[key]) {
+    return CLASSIFICATION_SYNONYMS[key];
+  }
+
+  const normalizedKey = key.replace(/[^a-z0-9]/g, "");
+  if (CLASSIFICATION_SYNONYMS[normalizedKey]) {
+    return CLASSIFICATION_SYNONYMS[normalizedKey];
+  }
+
+  return CLASSIFICATIONS[0];
+}
+
+export function normalizeStatus(input: unknown): Status {
+  const raw = typeof input === "string" ? input.trim() : "";
+  if (!raw) return "FT";
+
+  const key = raw.toLowerCase();
+  if (STATUS_SYNONYMS[key]) return STATUS_SYNONYMS[key];
+
+  const compact = key.replace(/[^a-z0-9]/g, "");
+  if (STATUS_SYNONYMS[compact]) return STATUS_SYNONYMS[compact];
+
+  if (key.includes("full")) return "FT";
+  if (key.includes("part")) return "PT";
+  if (key.includes("casual")) return "Casual";
+
+  return "FT";
+}
+
+export function normalizeActive(input: unknown): boolean {
+  if (typeof input === "boolean") return input;
+  const raw = typeof input === "string" ? input.trim() : "";
+  if (!raw) return true;
+
+  const lower = raw.toLowerCase();
+  if (NEGATIVE_ACTIVITY.has(lower)) return false;
+
+  const squashed = lower.replace(/\s+/g, "");
+  if (NEGATIVE_ACTIVITY.has(squashed)) return false;
+
+  if (POSITIVE_ACTIVITY.has(lower) || POSITIVE_ACTIVITY.has(squashed)) {
+    return true;
+  }
+
+  if (lower.includes("leave")) return false;
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add header utility helpers to sanitize column names and normalize classification, status, and active flags for CSV imports
- refactor the employee import workflow to use `mapRowToEmployee`, prefer ID synonyms, and toast detected headers when parsing fails
- cover the new helpers and mapping logic with Vitest cases for noisy headers and Excel-style rows

## Testing
- npm test *(fails: `tests/searchFiltering.test.tsx` cannot find the “Red” countdown filter button in jsdom)*
- npx vitest run src/__tests__/headers.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68deca08d1e883279fe8c2ba858e8fe1