### PR TITLE
Support Excel employee imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.23.0",
-        "react-window": "^2.1.1"
+        "react-window": "^2.1.1",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@testing-library/react": "^16.3.0",
@@ -2388,6 +2389,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2909,6 +2919,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
@@ -3076,6 +3099,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3214,6 +3246,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -4607,6 +4651,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -7852,6 +7905,18 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -9388,6 +9453,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9525,6 +9608,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.23.0",
-    "react-window": "^2.1.1"
+    "react-window": "^2.1.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { groupVacanciesByDate } from "./lib/vacancy";
 import { matchText } from "./lib/text";
 import { reorder } from "./utils/reorder";
 import { loadState, saveState, LS_KEY } from "./utils/storage";
+import * as xlsx from "xlsx";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
 import VacancyRangeForm from "./components/VacancyRangeForm";
@@ -193,6 +194,80 @@ const SHIFT_PRESETS = [
 ] as const;
 
 const VACANT_EMPLOYEE_ID = "__vacant__";
+
+type EmployeeRow = Record<string, unknown>;
+
+const getStringValue = (row: EmployeeRow, key: string) => {
+  const value = row[key];
+  return value == null ? "" : String(value);
+};
+
+const getNumberValue = (value: unknown, fallback: number) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const mapRowToEmployee = (row: EmployeeRow, index: number): Employee => {
+  const rawClass = getStringValue(row, "classification").trim();
+  const normalizedClass =
+    CLASSIFICATIONS.find(
+      (option) => option.toLowerCase() === rawClass.toLowerCase(),
+    ) ?? CLASSIFICATIONS[0];
+
+  const statusRaw = getStringValue(row, "status");
+  const activeRaw = getStringValue(row, "active") || "Yes";
+
+  return {
+    id:
+      getStringValue(row, "id") ||
+      getStringValue(row, "EmployeeID") ||
+      `emp_${index}`,
+    firstName:
+      getStringValue(row, "firstName") || getStringValue(row, "name"),
+    lastName: getStringValue(row, "lastName"),
+    classification: normalizedClass as Classification,
+    status: (["FT", "PT", "Casual"].includes(statusRaw)
+      ? statusRaw
+      : "FT") as Status,
+    homeWing: getStringValue(row, "homeWing"),
+    startDate: getStringValue(row, "startDate"),
+    seniorityHours: getNumberValue(row["seniorityHours"], 0),
+    seniorityRank: getNumberValue(row["seniorityRank"], index + 1),
+    active: activeRaw.toLowerCase().startsWith("y"),
+  };
+};
+
+const parseFile = async (file: File): Promise<EmployeeRow[]> => {
+  const extension = file.name.split(".").pop()?.toLowerCase();
+  const mime = (file.type || "").toLowerCase();
+
+  if (extension === "csv" || mime.includes("csv")) {
+    const text = await file.text();
+    const { parseCSV } = await import("./utils/csv");
+    return parseCSV(text);
+  }
+
+  if (
+    extension === "xlsx" ||
+    extension === "xls" ||
+    mime.includes("spreadsheet") ||
+    mime.includes("excel")
+  ) {
+    const arrayBuffer = await file.arrayBuffer();
+    const workbook = xlsx.read(new Uint8Array(arrayBuffer), { type: "array" });
+    const [firstSheetName] = workbook.SheetNames;
+    if (!firstSheetName) {
+      return [];
+    }
+    const sheet = workbook.Sheets[firstSheetName];
+    if (!sheet) {
+      return [];
+    }
+    return xlsx.utils.sheet_to_json<EmployeeRow>(sheet, { defval: "" });
+  }
+
+  throw new Error("Unsupported file type");
+};
 
 type StagedDeleteSnapshot = {
   previousVacancies: Vacancy[];
@@ -2111,50 +2186,22 @@ function EmployeesPage({
   return (
     <div className="grid">
       <div className="card">
-        <div className="card-h">Import Staff (CSV)</div>
+        <div className="card-h">Import Staff (CSV/Excel)</div>
         <div className="card-c">
           <input
             type="file"
-            accept=".csv"
+            accept=".csv,.xlsx,.xls"
             onChange={async (e) => {
-              const f = e.target.files?.[0];
-              if (!f) return;
-              const text = await f.text();
-              const { parseCSV } = await import("./utils/csv");
-              let rows: Record<string, string>[] = [];
+              const file = e.target.files?.[0];
+              if (!file) return;
               try {
-                rows = parseCSV(text);
+                const rows = await parseFile(file);
+                const out = rows.map((row, i) => mapRowToEmployee(row, i));
+                setEmployees(out.filter((employee) => !!employee.id));
               } catch (err) {
                 console.error(err);
-                await (window as any).appShowAlert?.("Failed to parse CSV");
-                return;
+                await (window as any).appShowAlert?.("Failed to parse file");
               }
-              const out: Employee[] = rows.map((r: any, i: number) => {
-                const rawClass = String(r.classification ?? "").trim();
-                const normalizedClass =
-                  CLASSIFICATIONS.find(
-                    (option) =>
-                      option.toLowerCase() === rawClass.toLowerCase(),
-                  ) ?? CLASSIFICATIONS[0];
-
-                return {
-                  id: String(r.id ?? r.EmployeeID ?? `emp_${i}`),
-                  firstName: String(r.firstName ?? r.name ?? ""),
-                  lastName: String(r.lastName ?? ""),
-                  classification: normalizedClass as Classification,
-                  status: (["FT", "PT", "Casual"].includes(String(r.status))
-                    ? r.status
-                    : "FT") as Status,
-                  homeWing: String(r.homeWing ?? ""),
-                  startDate: String(r.startDate ?? ""),
-                  seniorityHours: Number(r.seniorityHours ?? 0),
-                  seniorityRank: Number(r.seniorityRank ?? i + 1),
-                  active: String(r.active ?? "Yes")
-                    .toLowerCase()
-                    .startsWith("y"),
-                };
-              });
-              setEmployees(out.filter((e) => !!e.id));
             }}
           />
           <div className="subtitle">


### PR DESCRIPTION
## Summary
- add the xlsx dependency so the client can parse Excel uploads
- add helpers in App.tsx to map parsed rows and parse CSV or Excel files
- update the employee import control to accept CSV or Excel and reuse the shared mapper

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68deca2206d48327802f44f03a8b3347