### PR TITLE
Add multi-day range bid workflow and awarding logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,7 @@ import {
   normalizeStatus,
   splitName,
 } from "./utils/headers";
-import { loadState, saveState, LS_KEY } from "./utils/storage";
+import { loadState, LS_KEY } from "./utils/storage";
 import CoverageRangesPanel from "./components/CoverageRangesPanel";
 import BulkAwardDialog from "./components/BulkAwardDialog";
 import VacancyRangeForm from "./components/VacancyRangeForm";
@@ -44,12 +44,12 @@ import { appConfig } from "./config";
 import { CLASSIFICATIONS } from "./types";
 import type { VacancyRange, VacancyStatus, BundleMode } from "./types";
 export { OVERRIDE_REASONS } from "./types";
-import { createVacanciesFromRange, bundleContiguousVacanciesByRef } from "./lib/bundles";
 import Toast from "./components/ui/Toast";
 import Button from "./components/ui/Button";
 import FilterBar from "./components/ui/FilterBar";
 import Modal from "./components/ui/Modal";
 import useDeadlineMonitor from "./hooks/useDeadlineMonitor";
+import { useSchedulerState } from "./hooks/useSchedulerState";
 import useNotificationPrefs, {
   NotificationPreferences,
   NotificationChannel,
@@ -57,6 +57,8 @@ import useNotificationPrefs, {
   QuietHoursPreference,
 } from "./state/useNotificationPrefs";
 import type { DeadlineNotification } from "./types/notifications";
+import RangeBidDialog from "./components/RangeBidDialog";
+import { awardVacancyRange } from "./lib/vacancy-range-award";
 
 /**
  * Maplewood Scheduler — Coverage-first (v2.3.0)
@@ -218,6 +220,7 @@ type PersistedState = {
   archivedBids?: Record<string, Bid[]>;
   settings?: Partial<Settings>;
   notificationPrefs?: NotificationPreferences;
+  vacancyRanges?: VacancyRange[];
 };
 
 // ---------- Utils ----------
@@ -480,28 +483,23 @@ export default function App() {
   const persisted = loadState<PersistedState>() ?? null;
   const [tab, setTab] = useState<typeof TAB_KEYS[number]>("coverage");
 
-  const [employees, setEmployees] = useState<Employee[]>(
-    persisted?.employees ?? [],
-  );
-  const [vacations, setVacations] = useState<Vacation[]>(
-    persisted?.vacations ?? [],
-  );
-  const [vacancies, setVacancies] = useState<Vacancy[]>(
-    bundleContiguousVacanciesByRef(
-      (persisted?.vacancies ?? []).map((v: any) => ({
-        offeringTier: "CASUALS",
-        offeringRoundStartedAt:
-          v.offeringRoundStartedAt ?? new Date().toISOString(),
-        offeringRoundMinutes: v.offeringRoundMinutes ?? 120,
-        offeringAutoProgress: v.offeringAutoProgress ?? true,
-        ...v,
-      })),
-    ),
-  );
-  const [bids, setBids] = useState<Bid[]>(persisted?.bids ?? []);
-  const [archivedBids, setArchivedBids] = useState<Record<string, Bid[]>>(
-    persisted?.archivedBids ?? {},
-  );
+  const {
+    employees,
+    setEmployees,
+    vacations,
+    setVacations,
+    vacancies,
+    setVacancies,
+    bids,
+    setBids,
+    archivedBids,
+    setArchivedBids,
+    settings: schedulerSettings,
+    setSettings,
+    employeesById,
+    vacancyRanges,
+    setVacancyRanges,
+  } = useSchedulerState();
   const [selectedVacancyIds, setSelectedVacancyIds] = useState<string[]>([]);
   const [bulkAwardOpen, setBulkAwardOpen] = useState(false);
   const [bundleUndo, setBundleUndo] = useState<{
@@ -517,6 +515,7 @@ export default function App() {
   >(null);
   const [activeVacancyId, setActiveVacancyId] = useState<string | null>(null);
   const [showRangeForm, setShowRangeForm] = useState(false);
+  const [activeRangeBid, setActiveRangeBid] = useState<VacancyRange | null>(null);
   // Modal system (confirm/prompt/alert)
   const [confirmState, setConfirmState] = useState<
     | { open: true; title: string; body: string; resolve: (ok: boolean) => void }
@@ -610,17 +609,22 @@ export default function App() {
   (window as any).appShowConfirm = showConfirm;
   (window as any).appShowPrompt = showPrompt;
   (window as any).appShowAlert = showAlert;
-  const persistedSettings: Partial<Settings> = persisted?.settings ?? {};
-  const storedOrder: string[] = persistedSettings.tabOrder || [];
-  const mergedOrder = [
-    ...storedOrder,
-    ...TAB_KEYS.filter((k) => !storedOrder.includes(k)),
-  ];
-  const [settings, setSettings] = useState<Settings>({
-    ...defaultSettings,
-    ...persistedSettings,
-    tabOrder: mergedOrder,
-  });
+  const storedOrder = schedulerSettings.tabOrder ?? [];
+  const mergedOrder = useMemo(
+    () => [
+      ...storedOrder,
+      ...TAB_KEYS.filter((k) => !storedOrder.includes(k)),
+    ],
+    [storedOrder],
+  );
+  const settings = useMemo<Settings>(
+    () => ({
+      ...defaultSettings,
+      ...schedulerSettings,
+      tabOrder: mergedOrder,
+    }),
+    [schedulerSettings, mergedOrder],
+  );
 
   const {
     notificationPrefs,
@@ -666,34 +670,6 @@ export default function App() {
     }
   }, [tab, acknowledgeAll]);
 
-  useEffect(() => {
-    if (
-      !saveState({
-        employees,
-        vacations,
-        vacancies,
-        bids,
-        archivedBids,
-        settings,
-        notificationPrefs,
-      })
-    ) {
-      // localStorage unavailable; state persistence disabled
-    }
-  }, [
-    employees,
-    vacations,
-    vacancies,
-    bids,
-    archivedBids,
-    settings,
-    notificationPrefs,
-  ]);
-
-  const employeesById = useMemo(
-    () => Object.fromEntries(employees.map((e) => [e.id, e])),
-    [employees],
-  );
   const activeVacancy = useMemo(
     () => vacancies.find((v) => v.id === activeVacancyId) ?? null,
     [vacancies, activeVacancyId],
@@ -901,9 +877,37 @@ export default function App() {
     setMultiDay(false);
   };
 
-  const handleSaveRange = (range: VacancyRange, _awardAsBlock: boolean) => {
-    const vxs = createVacanciesFromRange(range);
-    setVacancies((prev) => [...vxs, ...prev]);
+  const handleSaveRange = (range: VacancyRange, awardAsBlock: boolean) => {
+    setVacancyRanges((prev) => [...prev, { ...range, awardAsBlock }]);
+  };
+
+  const handleSubmitRangeBid = (bid: Bid) => {
+    setBids((prev) => [...prev, bid]);
+  };
+
+  const handleAwardRange = async (rangeId: string) => {
+    const range = vacancyRanges.find((r) => r.id === rangeId);
+    if (!range) return;
+    const rangeBids = bids.filter((b) => b.vacancyId === rangeId);
+    if (!rangeBids.length) {
+      const ok = await showConfirm(
+        "No bids recorded for this range. Create vacancies anyway?",
+        "No bids on range",
+      );
+      if (!ok) return;
+    }
+    const outcome = awardVacancyRange(range, rangeBids, employees);
+    if (outcome.vacancies.length) {
+      setVacancies((prev) => [...outcome.vacancies, ...prev]);
+    }
+    setVacancyRanges((prev) => prev.filter((r) => r.id !== rangeId));
+    if (outcome.archivedBids.length) {
+      setArchivedBids((prev) => ({
+        ...prev,
+        [rangeId]: [...(prev[rangeId] ?? []), ...outcome.archivedBids],
+      }));
+      setBids((prev) => prev.filter((b) => b.vacancyId !== rangeId));
+    }
   };
 
   const archiveBids = (vacancyIds: string[]) => {
@@ -1508,10 +1512,13 @@ export default function App() {
 
         {tab === "coverage" && (
           <>
-
-          
-          <CoverageRangesPanel />
-          <div className="grid">
+            <CoverageRangesPanel
+              ranges={vacancyRanges}
+              bids={bids}
+              onBid={(range) => setActiveRangeBid(range)}
+              onAward={handleAwardRange}
+            />
+            <div className="grid">
             <div className="card">
               <div className="card-h">
                 Add Vacation (auto-creates daily vacancies)
@@ -2172,6 +2179,15 @@ export default function App() {
             onClose={() => setShowRangeForm(false)}
             onSave={handleSaveRange}
             existingVacancies={vacancies}
+          />
+        )}
+        {activeRangeBid && (
+          <RangeBidDialog
+            open
+            range={activeRangeBid}
+            onClose={() => setActiveRangeBid(null)}
+            employees={employees}
+            onSubmit={handleSubmitRangeBid}
           />
         )}
         <Modal

--- a/src/components/CoverageRangesPanel.tsx
+++ b/src/components/CoverageRangesPanel.tsx
@@ -1,3 +1,165 @@
-export default function CoverageRangesPanel() {
-  return null;
+import { useMemo } from "react";
+import type { VacancyRange, Bid } from "../types";
+import { formatDateLong, formatDowShort } from "../lib/dates";
+import { getDatesInRange } from "../utils/date";
+import Button from "./ui/Button";
+
+type Props = {
+  ranges: VacancyRange[];
+  bids: Bid[];
+  onBid: (range: VacancyRange) => void;
+  onAward: (range: VacancyRange) => void | Promise<void>;
+};
+
+type BidSummary = { total: number; partial: number };
+
+export default function CoverageRangesPanel({
+  ranges,
+  bids,
+  onBid,
+  onAward,
+}: Props) {
+  const bidSummary = useMemo(() => {
+    const summary = new Map<string, BidSummary>();
+    for (const bid of bids) {
+      const entry = summary.get(bid.vacancyId) ?? { total: 0, partial: 0 };
+      entry.total += 1;
+      if (bid.coverageType && bid.coverageType !== "full") {
+        entry.partial += 1;
+      }
+      summary.set(bid.vacancyId, entry);
+    }
+    return summary;
+  }, [bids]);
+
+  const sortedRanges = useMemo(
+    () => [...ranges].sort((a, b) => a.startDate.localeCompare(b.startDate)),
+    [ranges],
+  );
+
+  return (
+    <div className="grid">
+      <div className="card">
+        <div className="card-h">Multi-day coverage ranges</div>
+        <div className="card-c">
+          {sortedRanges.length === 0 ? (
+            <div className="subtitle">
+              No saved ranges yet. Use “New Multi-Day Vacancy” to add one.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th style={{ minWidth: 220 }}>Range</th>
+                    <th style={{ minWidth: 220 }}>Coverage days</th>
+                    <th style={{ width: 120 }}>Bids</th>
+                    <th style={{ width: 180 }}>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedRanges.map((range) => {
+                    const days = range.workingDays?.length
+                      ? range.workingDays
+                      : getDatesInRange(range.startDate, range.endDate);
+                    const summary = bidSummary.get(range.id) ?? {
+                      total: 0,
+                      partial: 0,
+                    };
+                    const daySummary = buildCoverageSummary(days);
+                    return (
+                      <tr key={range.id}>
+                        <td>
+                          <div className="font-medium">
+                            {formatDateLong(range.startDate)}
+                            {range.endDate !== range.startDate && (
+                              <>
+                                {" "}– {formatDateLong(range.endDate)}
+                              </>
+                            )}
+                          </div>
+                          <div style={{ color: "var(--muted)", fontSize: 12 }}>
+                            {range.classification}
+                            {range.wing ? ` • ${range.wing}` : ""}
+                            {range.awardAsBlock === false
+                              ? " • Split awards allowed"
+                              : ""}
+                          </div>
+                        </td>
+                        <td>
+                          <div>{daySummary.label}</div>
+                          {daySummary.extra && (
+                            <div style={{ color: "var(--muted)", fontSize: 12 }}>
+                              {daySummary.extra}
+                            </div>
+                          )}
+                        </td>
+                        <td>
+                          {summary.total === 0 ? (
+                            <span style={{ color: "var(--muted)", fontSize: 12 }}>
+                              No bids
+                            </span>
+                          ) : (
+                            <div className="flex flex-col text-sm">
+                              <span>
+                                {summary.total} bid{summary.total === 1 ? "" : "s"}
+                              </span>
+                              {summary.partial > 0 && (
+                                <span style={{ color: "var(--muted)" }}>
+                                  {summary.partial} partial
+                                </span>
+                              )}
+                            </div>
+                          )}
+                        </td>
+                        <td>
+                          <div className="flex gap-2">
+                            <Button size="sm" onClick={() => onBid(range)}>
+                              Bid
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="primary"
+                              onClick={() => onAward(range)}
+                            >
+                              Award
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type CoverageSummary = { label: string; extra?: string };
+
+function buildCoverageSummary(days: string[]): CoverageSummary {
+  if (days.length === 0) {
+    return { label: "No working days selected" };
+  }
+  if (days.length === 1) {
+    const day = days[0];
+    return {
+      label: `${formatDowShort(day)} • ${formatDateLong(day)}`,
+    };
+  }
+  const formatted = days.map(
+    (day) => `${formatDowShort(day)} ${day.slice(5)}`,
+  );
+  const label = `${days.length} days`;
+  if (formatted.length <= 4) {
+    return { label, extra: formatted.join(", ") };
+  }
+  return {
+    label,
+    extra: `${formatted.slice(0, 4).join(", ")}, …`,
+  };
 }

--- a/src/components/RangeBidDialog.tsx
+++ b/src/components/RangeBidDialog.tsx
@@ -1,6 +1,6 @@
 import BodyLock from "./BodyLock";
 import { useFocusTrap } from "../hooks/useFocusTrap";
-import React, { useRef,  useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { VacancyRange, Bid, Employee } from "../types";
 
 type Props = {
@@ -11,31 +11,66 @@ type Props = {
   onSubmit: (bid: Bid) => void;
 };
 
-export default function RangeBidDialog({ open, onClose, range, employees, onSubmit }: Props) {
+export default function RangeBidDialog({
+  open,
+  onClose,
+  range,
+  employees,
+  onSubmit,
+}: Props) {
+  const workingDays = useMemo(() => range.workingDays ?? [], [range]);
   const [employeeId, setEmployeeId] = useState<string>("");
   const [note, setNote] = useState<string>("");
-  const [coverageType, setCoverageType] = useState<"full"|"some-days"|"partial-day">("full");
-  const [selectedDays, setSelectedDays] = useState<string[]>(range.workingDays ?? []);
+  const [coverageType, setCoverageType] = useState<
+    "full" | "some-days" | "partial-day"
+  >("full");
+  const [selectedDays, setSelectedDays] = useState<string[]>(workingDays);
 
-  const empOpts = useMemo(() => employees.filter(e => e.active).sort((a,b)=>a.seniorityRank-b.seniorityRank), [employees]);
+  useEffect(() => {
+    if (!open) return;
+    setEmployeeId("");
+    setNote("");
+    setCoverageType("full");
+    setSelectedDays(workingDays);
+  }, [open, workingDays]);
+
+  const empOpts = useMemo(
+    () =>
+      employees
+        .filter((e) => e.active)
+        .sort((a, b) => a.seniorityRank - b.seniorityRank),
+    [employees],
+  );
 
   function toggleDay(d: string) {
-    setSelectedDays(prev => prev.includes(d) ? prev.filter(x=>x!==d) : [...prev, d]);
+    setSelectedDays((prev) =>
+      prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d],
+    );
   }
 
   function submit() {
     if (!employeeId) return;
-    const e = employees.find(x=>x.id===employeeId);
+    if (coverageType !== "full" && selectedDays.length === 0) return;
+    const employee = employees.find((x) => x.id === employeeId);
+    const now = new Date().toISOString();
     const bid: Bid = {
+      id: `BID-${crypto.randomUUID()}`,
       vacancyId: range.id,
       bidderEmployeeId: employeeId,
-      bidderName: (e?.firstName ?? "") + " " + (e?.lastName ?? ""),
-      bidderStatus: (e?.status)!,
-      bidderClassification: (e?.classification)!,
-      bidTimestamp: new Date().toISOString(),
+      bidderName: employee
+        ? `${employee.firstName} ${employee.lastName}`.trim()
+        : employeeId,
+      bidderStatus: employee?.status ?? "FT",
+      bidderClassification: employee?.classification ?? range.classification,
+      bidTimestamp: now,
+      createdAt: now,
+      employeeId,
       notes: note || undefined,
       coverageType,
-      selectedDays: coverageType === "full" ? [...(range.workingDays ?? [])] : [...selectedDays],
+      selectedDays:
+        coverageType === "full"
+          ? [...workingDays]
+          : [...selectedDays].sort(),
     };
     onSubmit(bid);
     onClose();
@@ -56,7 +91,9 @@ export default function RangeBidDialog({ open, onClose, range, employees, onSubm
       >
         <div className="flex items-center justify-between mb-3">
           <h2 className="text-lg font-semibold">Enter Bid for Multi‑day Vacancy</h2>
-          <button onClick={onClose} className="px-2 py-1 rounded-md border">Close</button>
+          <button onClick={onClose} className="px-2 py-1 rounded-md border">
+            Close
+          </button>
         </div>
 
         <div className="space-y-3">
@@ -64,11 +101,11 @@ export default function RangeBidDialog({ open, onClose, range, employees, onSubm
             <span className="text-sm font-medium">Bidder</span>
             <select
               value={employeeId}
-              onChange={e => setEmployeeId(e.target.value)}
+              onChange={(e) => setEmployeeId(e.target.value)}
               className="border rounded-md px-2 py-1"
             >
               <option value="">Select employee…</option>
-              {empOpts.map(e => (
+              {empOpts.map((e) => (
                 <option key={e.id} value={e.id}>
                   {e.seniorityRank}. {e.lastName}, {e.firstName} — {e.classification}
                 </option>
@@ -79,23 +116,52 @@ export default function RangeBidDialog({ open, onClose, range, employees, onSubm
           <fieldset className="border rounded-md p-2">
             <legend className="px-1 text-sm">Coverage</legend>
             <label className="flex items-center gap-2">
-              <input type="radio" checked={coverageType==="full"} onChange={()=>setCoverageType("full")} />
+              <input
+                type="radio"
+                checked={coverageType === "full"}
+                onChange={() => {
+                  setCoverageType("full");
+                  setSelectedDays(workingDays);
+                }}
+              />
               <span>Entire vacancy (all working days)</span>
             </label>
             <label className="flex items-center gap-2">
-              <input type="radio" checked={coverageType==="some-days"} onChange={()=>setCoverageType("some-days")} />
+              <input
+                type="radio"
+                checked={coverageType === "some-days"}
+                onChange={() => {
+                  setCoverageType("some-days");
+                  setSelectedDays((days) =>
+                    days.length ? days : [...workingDays],
+                  );
+                }}
+              />
               <span>Some days only</span>
             </label>
             <label className="flex items-center gap-2">
-              <input type="radio" checked={coverageType==="partial-day"} onChange={()=>setCoverageType("partial-day")} />
+              <input
+                type="radio"
+                checked={coverageType === "partial-day"}
+                onChange={() => {
+                  setCoverageType("partial-day");
+                  setSelectedDays((days) =>
+                    days.length ? days : [...workingDays],
+                  );
+                }}
+              />
               <span>Partial-day (time differs on specific day)</span>
             </label>
 
-            {(coverageType!=="full") && (
+            {coverageType !== "full" && (
               <div className="mt-2 max-h-48 overflow-auto border rounded p-2">
-                {(range.workingDays ?? []).map((d: string) => (
+                {workingDays.map((d) => (
                   <label key={d} className="flex items-center gap-2 py-0.5">
-                    <input type="checkbox" checked={selectedDays.includes(d)} onChange={()=>toggleDay(d)} />
+                    <input
+                      type="checkbox"
+                      checked={selectedDays.includes(d)}
+                      onChange={() => toggleDay(d)}
+                    />
                     <span>{d}</span>
                   </label>
                 ))}
@@ -105,13 +171,27 @@ export default function RangeBidDialog({ open, onClose, range, employees, onSubm
 
           <label className="flex flex-col gap-1">
             <span className="text-sm font-medium">Notes</span>
-            <textarea value={note} onChange={e=>setNote(e.target.value)} className="border rounded-md px-2 py-1" rows={3} placeholder="Add context (e.g., availability, restrictions)"/>
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              className="border rounded-md px-2 py-1"
+              rows={3}
+              placeholder="Add context (e.g., availability, restrictions)"
+            />
           </label>
         </div>
 
         <div className="mt-4 flex justify-end gap-2">
-          <button onClick={onClose} className="px-3 py-2 rounded-md border">Cancel</button>
-          <button onClick={submit} className="px-3 py-2 rounded-md bg-black text-white">Submit bid</button>
+          <button onClick={onClose} className="px-3 py-2 rounded-md border">
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            className="px-3 py-2 rounded-md bg-black text-white"
+            disabled={!employeeId || (coverageType !== "full" && selectedDays.length === 0)}
+          >
+            Submit bid
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/VacancyRangeForm.tsx
+++ b/src/components/VacancyRangeForm.tsx
@@ -106,6 +106,7 @@ export default function VacancyRangeForm({
       shiftEnd,
       offeringStep: "Casuals",
       status: "Open",
+      awardAsBlock,
     };
     onSave(range, awardAsBlock);
     onClose();

--- a/src/lib/bundles.ts
+++ b/src/lib/bundles.ts
@@ -58,7 +58,8 @@ export function bundleContiguousVacanciesByRef(vacs: Vacancy[]): Vacancy[] {
  * Automatically assigns a single bundleId when the range spans two or more days.
  */
 export function createVacanciesFromRange(range: VacancyRange): Vacancy[] {
-  return expandRangeToVacancies(range, true);
+  const shouldBundle = range.awardAsBlock !== false;
+  return expandRangeToVacancies(range, shouldBundle);
 }
 
 /** Award every vacancy within a bundle to the given employee. */

--- a/src/lib/vacancy-range-award.ts
+++ b/src/lib/vacancy-range-award.ts
@@ -1,17 +1,228 @@
-import type { VacancyRange, Bid, Employee } from "../types";
+import type { VacancyRange, Bid, Employee, Vacancy } from "../types";
+import { createVacanciesFromRange } from "./bundles";
+import { getDatesInRange } from "../utils/date";
+
+export type RangeAwardOutcome = {
+  vacancies: Vacancy[];
+  archivedBids: Bid[];
+};
+
+const MIN_RANK = Number.MAX_SAFE_INTEGER;
+
+type Window = { start: number; end: number };
+type Assigned = { start: number; end: number; bid: Bid };
+
+function timeToMinutes(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const [h, m] = value.split(":").map((v) => Number.parseInt(v, 10));
+  if (Number.isNaN(h) || Number.isNaN(m)) return fallback;
+  return h * 60 + m;
+}
+
+function minutesToTime(minutes: number): string {
+  const h = Math.floor(minutes / 60)
+    .toString()
+    .padStart(2, "0");
+  const m = (minutes % 60).toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+function assignCoverage(
+  windows: Window[],
+  assignments: Assigned[],
+  start: number,
+  end: number,
+  bid: Bid,
+) {
+  if (end <= start) return;
+  let idx = 0;
+  while (idx < windows.length) {
+    const window = windows[idx];
+    if (end <= window.start || start >= window.end) {
+      idx += 1;
+      continue;
+    }
+    const overlapStart = Math.max(window.start, start);
+    const overlapEnd = Math.min(window.end, end);
+    if (overlapEnd <= overlapStart) {
+      idx += 1;
+      continue;
+    }
+    assignments.push({ start: overlapStart, end: overlapEnd, bid });
+    const replacements: Window[] = [];
+    if (window.start < overlapStart) {
+      replacements.push({ start: window.start, end: overlapStart });
+    }
+    if (overlapEnd < window.end) {
+      replacements.push({ start: overlapEnd, end: window.end });
+    }
+    windows.splice(idx, 1, ...replacements);
+    if (replacements.length === 0) {
+      // window fully consumed; continue with next window at same index
+      continue;
+    }
+    idx += replacements.length;
+  }
+}
+
+function getBidDays(
+  bid: Bid,
+  range: VacancyRange,
+  defaultDays: string[],
+): string[] {
+  if (bid.coverageType === "some-days" || bid.coverageType === "partial-day") {
+    return bid.selectedDays && bid.selectedDays.length
+      ? bid.selectedDays
+      : defaultDays;
+  }
+  return defaultDays;
+}
+
+function getCoverageWindow(
+  bid: Bid,
+  day: string,
+  baseStart: number,
+  baseEnd: number,
+): Window {
+  if (bid.coverageType === "partial-day") {
+    const override = bid.timeOverrides?.[day];
+    if (override) {
+      return {
+        start: timeToMinutes(override.start, baseStart),
+        end: timeToMinutes(override.end, baseEnd),
+      };
+    }
+  }
+  return { start: baseStart, end: baseEnd };
+}
+
+function workingDaysForRange(range: VacancyRange): string[] {
+  if (range.workingDays?.length) return [...range.workingDays];
+  return getDatesInRange(range.startDate, range.endDate);
+}
 
 /**
  * Rank full-coverage bids by seniority (ascending rank = more senior).
  * Returns the winning bid or null.
  */
-export function pickWinningFullRangeBid(range: VacancyRange, bids: Bid[], employees: Employee[]): Bid | null {
-  const empById = new Map(employees.map(e => [e.id, e]));
-  const full = bids.filter(b => b.coverageType === "full" && Array.isArray(b.selectedDays));
+export function pickWinningFullRangeBid(
+  range: VacancyRange,
+  bids: Bid[],
+  employees: Employee[],
+): Bid | null {
+  if (!bids.length) return null;
+  const empById = new Map(employees.map((e) => [e.id, e]));
+  const days = workingDaysForRange(range);
+  const full = bids.filter((b) => {
+    if (b.coverageType && b.coverageType !== "full") return false;
+    if (!b.selectedDays || b.selectedDays.length === 0) return true;
+    return days.every((d) => b.selectedDays!.includes(d));
+  });
   if (!full.length) return null;
   full.sort((a, b) => {
-    const ea = empById.get(a.bidderEmployeeId)?.seniorityRank ?? Number.MAX_SAFE_INTEGER;
-    const eb = empById.get(b.bidderEmployeeId)?.seniorityRank ?? Number.MAX_SAFE_INTEGER;
-    return ea - eb;
+    const ea = empById.get(a.bidderEmployeeId)?.seniorityRank ?? MIN_RANK;
+    const eb = empById.get(b.bidderEmployeeId)?.seniorityRank ?? MIN_RANK;
+    if (ea !== eb) return ea - eb;
+    return a.bidTimestamp.localeCompare(b.bidTimestamp);
   });
   return full[0] ?? null;
+}
+
+export function awardVacancyRange(
+  range: VacancyRange,
+  bids: Bid[],
+  employees: Employee[],
+): RangeAwardOutcome {
+  const relevantBids = bids.filter((b) => b.vacancyId === range.id);
+  const baseVacancies = createVacanciesFromRange(range);
+  if (!relevantBids.length) {
+    return { vacancies: baseVacancies, archivedBids: [] };
+  }
+
+  const now = new Date().toISOString();
+  const employeesById = new Map(employees.map((e) => [e.id, e]));
+  const days = workingDaysForRange(range);
+  const fullWinner = pickWinningFullRangeBid(range, relevantBids, employees);
+  if (fullWinner) {
+    const awarded = baseVacancies.map((vac) => ({
+      ...vac,
+      status: "Awarded" as const,
+      awardedTo: fullWinner.bidderEmployeeId,
+      awardedAt: now,
+      awardReason: "Range bid award",
+    }));
+    return { vacancies: awarded, archivedBids: relevantBids };
+  }
+
+  const sortedBids = [...relevantBids].sort((a, b) => {
+    const ra = employeesById.get(a.bidderEmployeeId)?.seniorityRank ?? MIN_RANK;
+    const rb = employeesById.get(b.bidderEmployeeId)?.seniorityRank ?? MIN_RANK;
+    if (ra !== rb) return ra - rb;
+    return a.bidTimestamp.localeCompare(b.bidTimestamp);
+  });
+
+  const byDay = new Map<string, Vacancy>();
+  for (const vac of baseVacancies) {
+    byDay.set(vac.shiftDate, { ...vac, bundleId: undefined, bundleMode: undefined });
+  }
+
+  const finalVacancies: Vacancy[] = [];
+  for (const [day, template] of byDay) {
+    const baseStart = timeToMinutes(template.shiftStart ?? template.start, 390);
+    const baseEnd = timeToMinutes(template.shiftEnd ?? template.end, baseStart + 480);
+    const windows: Window[] = [{ start: baseStart, end: baseEnd }];
+    const assignments: Assigned[] = [];
+
+    for (const bid of sortedBids) {
+      const covers = getBidDays(bid, range, days);
+      if (!covers.includes(day)) continue;
+      const { start, end } = getCoverageWindow(bid, day, baseStart, baseEnd);
+      assignCoverage(windows, assignments, start, end, bid);
+    }
+
+    const segments = [
+      ...assignments.map((segment) => ({ ...segment })),
+      ...windows.map((w) => ({ start: w.start, end: w.end, bid: null as Bid | null })),
+    ]
+      .filter((segment) => segment.end > segment.start)
+      .sort((a, b) => a.start - b.start);
+
+    if (segments.length === 0) continue;
+
+    let first = true;
+    for (const segment of segments) {
+      const vac: Vacancy = {
+        ...template,
+        ...(first ? {} : { id: crypto.randomUUID() }),
+        start: minutesToTime(segment.start),
+        end: minutesToTime(segment.end),
+        shiftStart: minutesToTime(segment.start),
+        shiftEnd: minutesToTime(segment.end),
+        bundleId: undefined,
+        bundleMode: undefined,
+      };
+      if (segment.bid) {
+        vac.status = "Awarded";
+        vac.awardedTo = segment.bid.bidderEmployeeId;
+        vac.awardedAt = now;
+        vac.awardReason = "Range bid award";
+      } else {
+        vac.status = "Open";
+        vac.awardedTo = undefined;
+        vac.awardedAt = undefined;
+        vac.awardReason = undefined;
+      }
+      finalVacancies.push(vac);
+      first = false;
+    }
+  }
+
+  finalVacancies.sort((a, b) => {
+    if (a.shiftDate === b.shiftDate) {
+      return a.shiftStart.localeCompare(b.shiftStart);
+    }
+    return a.shiftDate.localeCompare(b.shiftDate);
+  });
+
+  return { vacancies: finalVacancies, archivedBids: relevantBids };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,4 +167,5 @@ export type VacancyRange = {
   status: VacancyStatus | "Pending Award";
   awardedTo?: string;
   awardedAt?: string;
+  awardAsBlock?: boolean;
 };

--- a/tests/range-coverage.test.tsx
+++ b/tests/range-coverage.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { createVacanciesFromRange } from "../src/lib/bundles";
+import { awardVacancyRange } from "../src/lib/vacancy-range-award";
+import RangeBidDialog from "../src/components/RangeBidDialog";
+import type { VacancyRange, Employee, Bid } from "../src/types";
+
+const employees: Employee[] = [
+  {
+    id: "e1",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    classification: "RN",
+    status: "FT",
+    seniorityRank: 1,
+    active: true,
+  },
+  {
+    id: "e2",
+    firstName: "Grace",
+    lastName: "Hopper",
+    classification: "RN",
+    status: "FT",
+    seniorityRank: 2,
+    active: true,
+  },
+];
+
+describe("range coverage workflow", () => {
+  it("respects awardAsBlock when creating vacancies", () => {
+    const range: VacancyRange = {
+      id: "range-1",
+      reason: "Vacation",
+      classification: "RN",
+      startDate: "2025-05-01",
+      endDate: "2025-05-03",
+      knownAt: "2025-04-01T00:00:00Z",
+      workingDays: ["2025-05-01", "2025-05-02", "2025-05-03"],
+      shiftStart: "06:30",
+      shiftEnd: "14:30",
+      offeringStep: "Casuals",
+      status: "Open",
+      awardAsBlock: false,
+    };
+    const created = createVacanciesFromRange(range);
+    expect(created).toHaveLength(3);
+    expect(created.every((vac) => vac.bundleId === undefined)).toBe(true);
+  });
+
+  it("submits a range bid with selected days", () => {
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+    const range: VacancyRange = {
+      id: "range-2",
+      reason: "Vacation",
+      classification: "RN",
+      startDate: "2025-06-01",
+      endDate: "2025-06-03",
+      knownAt: "2025-05-01T00:00:00Z",
+      workingDays: ["2025-06-01", "2025-06-02", "2025-06-03"],
+      shiftStart: "06:30",
+      shiftEnd: "14:30",
+      offeringStep: "Casuals",
+      status: "Open",
+      awardAsBlock: true,
+    };
+
+    render(
+      <RangeBidDialog
+        open
+        onClose={onClose}
+        range={range}
+        employees={employees}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "e2" } });
+    fireEvent.click(screen.getByLabelText(/some days only/i));
+    fireEvent.click(screen.getByLabelText("2025-06-01"));
+    fireEvent.click(screen.getByLabelText("2025-06-03"));
+    fireEvent.change(screen.getByPlaceholderText(/add context/i), {
+      target: { value: "Can cover mid-week" },
+    });
+    fireEvent.click(screen.getByText(/submit bid/i));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted: Bid = onSubmit.mock.calls[0][0];
+    expect(submitted.bidderEmployeeId).toBe("e2");
+    expect(submitted.coverageType).toBe("some-days");
+    expect(submitted.selectedDays).toEqual(["2025-06-02"]);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("awards full range to most senior full bid", () => {
+    const range: VacancyRange = {
+      id: "range-3",
+      reason: "Vacation",
+      classification: "RN",
+      startDate: "2025-07-01",
+      endDate: "2025-07-03",
+      knownAt: "2025-06-01T00:00:00Z",
+      workingDays: ["2025-07-01", "2025-07-02", "2025-07-03"],
+      shiftStart: "06:30",
+      shiftEnd: "14:30",
+      offeringStep: "Casuals",
+      status: "Open",
+      awardAsBlock: true,
+    };
+    const bids: Bid[] = [
+      {
+        id: "b1",
+        vacancyId: "range-3",
+        bidderEmployeeId: "e2",
+        bidderName: "Grace Hopper",
+        bidderStatus: "FT",
+        bidderClassification: "RN",
+        bidTimestamp: "2025-06-05T12:00:00Z",
+        coverageType: "full",
+      },
+      {
+        id: "b2",
+        vacancyId: "range-3",
+        bidderEmployeeId: "e1",
+        bidderName: "Ada Lovelace",
+        bidderStatus: "FT",
+        bidderClassification: "RN",
+        bidTimestamp: "2025-06-05T12:05:00Z",
+        coverageType: "full",
+      },
+    ];
+
+    const outcome = awardVacancyRange(range, bids, employees);
+    expect(outcome.vacancies).toHaveLength(3);
+    expect(outcome.vacancies.every((vac) => vac.status === "Awarded")).toBe(true);
+    expect(outcome.vacancies.every((vac) => vac.awardedTo === "e1")).toBe(true);
+    expect(outcome.archivedBids).toHaveLength(2);
+  });
+
+  it("splits partial-day coverage and leaves remainder open", () => {
+    const range: VacancyRange = {
+      id: "range-4",
+      reason: "Vacation",
+      classification: "RN",
+      startDate: "2025-08-10",
+      endDate: "2025-08-10",
+      knownAt: "2025-08-01T00:00:00Z",
+      workingDays: ["2025-08-10"],
+      shiftStart: "06:30",
+      shiftEnd: "14:30",
+      offeringStep: "Casuals",
+      status: "Open",
+      awardAsBlock: false,
+    };
+    const bids: Bid[] = [
+      {
+        id: "b3",
+        vacancyId: "range-4",
+        bidderEmployeeId: "e1",
+        bidderName: "Ada Lovelace",
+        bidderStatus: "FT",
+        bidderClassification: "RN",
+        bidTimestamp: "2025-08-01T09:00:00Z",
+        coverageType: "partial-day",
+        selectedDays: ["2025-08-10"],
+        timeOverrides: {
+          "2025-08-10": { start: "06:30", end: "10:30" },
+        },
+      },
+    ];
+
+    const outcome = awardVacancyRange(range, bids, employees);
+    expect(outcome.vacancies).toHaveLength(2);
+    const awarded = outcome.vacancies.find((vac) => vac.awardedTo === "e1");
+    const openVacancy = outcome.vacancies.find((vac) => vac.status === "Open");
+    expect(awarded?.shiftStart).toBe("06:30");
+    expect(awarded?.shiftEnd).toBe("10:30");
+    expect(openVacancy?.shiftStart).toBe("10:30");
+    expect(openVacancy?.shiftEnd).toBe("14:30");
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the coverage tab to use the scheduler state hook, persist vacancy ranges, and wire up the range bid dialog
- add a coverage ranges panel with bid and award controls plus a range bid dialog that stores coverage metadata
- extend vacancy range awarding to handle full and partial-day bids and add vitest coverage for range creation, bidding, and awarding

## Testing
- npm test *(fails: searchFiltering tests for category/date/wing/shift/countdown filters)*

------
https://chatgpt.com/codex/tasks/task_e_68dedf3a035883278813f4f0944de42a