### PR TITLE
Add status pill component for employee activity states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import Toast from "./components/ui/Toast";
 import Button from "./components/ui/Button";
 import FilterBar from "./components/ui/FilterBar";
 import Modal from "./components/ui/Modal";
+import StatusPill from "./components/ui/StatusPill";
 import useDeadlineMonitor from "./hooks/useDeadlineMonitor";
 import { useSchedulerState } from "./hooks/useSchedulerState";
 import useNotificationPrefs, {
@@ -89,6 +90,7 @@ export type Employee = {
   seniorityHours?: number;
   seniorityRank: number; // 1 = most senior
   active: boolean;
+  activeLabel: string;
 };
 
 export type Vacation = {
@@ -214,7 +216,7 @@ type StagedDeleteSnapshot = {
 };
 
 type PersistedState = {
-  employees?: Employee[];
+  employees?: (Employee & { activeLabel?: string })[];
   vacations?: Vacation[];
   vacancies?: Vacancy[];
   bids?: Bid[];
@@ -393,6 +395,66 @@ export function mapRowToEmployee(
   const seniorityRankValue = parseNumber(seniorityRankRaw);
   const seniorityHoursValue = parseNumber(seniorityHoursRaw);
 
+  const active = normalizeActive(activeRaw ?? statusRaw);
+
+  const deriveActiveLabel = (): string => {
+    const primaryRaw =
+      typeof activeRaw === "string" && activeRaw.trim() ? activeRaw.trim() : "";
+    const fallbackRaw =
+      !primaryRaw && !active && typeof statusRaw === "string" && statusRaw.trim()
+        ? statusRaw.trim()
+        : "";
+    const source = primaryRaw || fallbackRaw;
+    if (!source) {
+      return active ? "Active" : "Inactive";
+    }
+
+    const lower = source.toLowerCase();
+    const squashed = lower.replace(/\s+/g, "");
+
+    if (lower.includes("leave") || squashed === "loa") {
+      return "On Leave";
+    }
+
+    if (["yes", "y", "true", "1", "active", "available"].includes(squashed)) {
+      return "Active";
+    }
+
+    if (
+      [
+        "no",
+        "n",
+        "false",
+        "0",
+        "inactive",
+        "notactive",
+        "terminated",
+        "retired",
+        "suspended",
+        "off",
+      ].includes(squashed)
+    ) {
+      return "Inactive";
+    }
+
+    if (lower.includes("suspend")) return "Suspended";
+    if (lower.includes("retire")) return "Retired";
+    if (lower.includes("term")) return "Terminated";
+
+    const words = source.split(/\s+/).filter(Boolean);
+    if (!words.length) {
+      return active ? "Active" : "Inactive";
+    }
+
+    return words
+      .map((word) =>
+        word.length <= 3
+          ? word.toUpperCase()
+          : `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`,
+      )
+      .join(" ");
+  };
+
   const employee: Employee = {
     id: id || `emp_${index}`,
     firstName,
@@ -409,7 +471,8 @@ export function mapRowToEmployee(
         : undefined,
     seniorityHours: seniorityHoursValue,
     seniorityRank: seniorityRankValue ?? index + 1,
-    active: normalizeActive(activeRaw ?? statusRaw),
+    active,
+    activeLabel: deriveActiveLabel(),
   };
 
   return employee;
@@ -2594,6 +2657,7 @@ function EmployeesPage({
                 status,
                 seniorityRank: rank || employees.length + 1,
                 active: true,
+                activeLabel: "Active",
               };
               const sorted = [...employees, newEmp].sort(
                 (a, b) => (a.seniorityRank ?? 99999) - (b.seniorityRank ?? 99999),
@@ -2665,7 +2729,9 @@ function EmployeesPage({
                   <td>{e.classification}</td>
                   <td>{e.status}</td>
                   <td>{e.seniorityRank}</td>
-                  <td>{e.active ? "Yes" : "No"}</td>
+                  <td>
+                    <StatusPill active={e.active} label={e.activeLabel} />
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/__tests__/headers.test.ts
+++ b/src/__tests__/headers.test.ts
@@ -66,6 +66,7 @@ describe("mapRowToEmployee", () => {
     expect(employee?.classification).toBe("RCA");
     expect(employee?.status).toBe("PT");
     expect(employee?.active).toBe(false);
+    expect(employee?.activeLabel).toBe("On Leave");
     expect(employee?.homeWing).toBe("Shamrock");
     expect(employee?.startDate).toBe("2021-05-01");
     expect(employee?.seniorityRank).toBe(7);
@@ -90,6 +91,7 @@ describe("mapRowToEmployee", () => {
     expect(employee?.status).toBe("FT");
     expect(employee?.seniorityRank).toBe(5);
     expect(employee?.active).toBe(true);
+    expect(employee?.activeLabel).toBe("Active");
   });
 
   it("returns null for rows without ids or names", () => {

--- a/src/components/EmployeePickerModal.tsx
+++ b/src/components/EmployeePickerModal.tsx
@@ -4,6 +4,7 @@ import { useFocusTrap } from "../hooks/useFocusTrap";
 import React, { useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Employee, Classification } from "../types";
+import StatusPill from "./ui/StatusPill";
 
 type Props = {
   open: boolean;
@@ -41,8 +42,35 @@ export default function EmployeePickerModal({ open, employees, classification, o
         />
         <div style={{ maxHeight: 360, overflow: "auto" }}>
           {list.map(e => (
-            <button key={e.id} className="btn row" onClick={() => onSelect(e.id)}>
-              {e.firstName} {e.lastName} • {e.classification} • Rank #{e.seniorityRank}
+            <button
+              key={e.id}
+              className="btn row"
+              onClick={() => onSelect(e.id)}
+              style={{
+                width: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+                textAlign: "left",
+              }}
+            >
+              <span
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: 6,
+                  alignItems: "baseline",
+                }}
+              >
+                <span style={{ fontWeight: 700 }}>
+                  {e.firstName} {e.lastName}
+                </span>
+                <span style={{ color: "var(--muted)", fontSize: 13 }}>
+                  • {e.classification} • Rank #{e.seniorityRank}
+                </span>
+              </span>
+              <StatusPill active={e.active} label={e.activeLabel} />
             </button>
           ))}
         </div>

--- a/src/components/ui/StatusPill.tsx
+++ b/src/components/ui/StatusPill.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+export type StatusPillProps = React.HTMLAttributes<HTMLSpanElement> & {
+  active: boolean;
+  label?: string;
+};
+
+const formatLabel = (label: string | undefined, active: boolean) => {
+  const trimmed = label?.trim();
+  if (!trimmed) {
+    return active ? "Active" : "Inactive";
+  }
+
+  return trimmed.replace(/\s+/g, " ");
+};
+
+const StatusPill = React.forwardRef<HTMLSpanElement, StatusPillProps>(
+  ({ active, label, className = "", style, ...rest }, ref) => {
+    const displayLabel = formatLabel(label, active);
+    const accentColor = active ? "var(--ok)" : "var(--bad)";
+    const backgroundTint = `color-mix(in srgb, ${accentColor} 18%, var(--card))`;
+    const borderTint = `color-mix(in srgb, ${accentColor} 45%, transparent)`;
+
+    return (
+      <span
+        ref={ref}
+        className={`status-pill${className ? ` ${className}` : ""}`}
+        data-active={active}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 6,
+          padding: "4px 10px",
+          borderRadius: 999,
+          fontSize: 12,
+          fontWeight: 700,
+          lineHeight: 1.2,
+          whiteSpace: "nowrap",
+          color: accentColor,
+          background: "var(--status-pill-bg, var(--chipBg))",
+          border: "1px solid transparent",
+          borderColor: "var(--status-pill-border, transparent)",
+          flexShrink: 0,
+          transition: "background-color .2s ease, color .2s ease, border-color .2s ease",
+          ["--status-pill-bg" as any]: backgroundTint,
+          ["--status-pill-border" as any]: borderTint,
+          ["--status-pill-indicator" as any]: accentColor,
+          ...style,
+        }}
+        {...rest}
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: "50%",
+            background: "var(--status-pill-indicator, currentColor)",
+          }}
+        />
+        <span>{displayLabel}</span>
+      </span>
+    );
+  },
+);
+
+StatusPill.displayName = "StatusPill";
+
+export default StatusPill;

--- a/src/hooks/useSchedulerState.ts
+++ b/src/hooks/useSchedulerState.ts
@@ -14,8 +14,10 @@ const defaultSettings: Settings = {
   responseWindows: { lt2h: 7, h2to4: 15, h4to24: 30, h24to72: 120, gt72: 1440 },
 };
 
+type StoredEmployee = Employee & { activeLabel?: string };
+
 type PersistedState = {
-  employees?: Employee[];
+  employees?: StoredEmployee[];
   vacations?: Vacation[];
   vacancies?: Vacancy[];
   bids?: Bid[];
@@ -27,7 +29,15 @@ type PersistedState = {
 export function useSchedulerState() {
   const persisted: PersistedState | null = loadState();
 
-  const [employees, setEmployees] = useState<Employee[]>(persisted?.employees ?? []);
+  const hydrateEmployees = (list: StoredEmployee[] | undefined): Employee[] =>
+    (list ?? []).map((emp) => ({
+      ...emp,
+      activeLabel: emp.activeLabel ?? (emp.active ? "Active" : "Inactive"),
+    }));
+
+  const [employees, setEmployees] = useState<Employee[]>(
+    hydrateEmployees(persisted?.employees),
+  );
   const [vacations, setVacations] = useState<Vacation[]>(persisted?.vacations ?? []);
   const seededVacancies = bundleContiguousVacanciesByRef(
     persisted?.vacancies

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export type Employee = {
   seniorityHours?: number;
   seniorityRank: number;
   active: boolean;
+  activeLabel: string;
 };
 
 export type Vacation = {


### PR DESCRIPTION
## Summary
- add a reusable `StatusPill` UI component that follows theme tokens for employee activity badges
- persist readable activity labels when importing, hydrating, or creating employees
- swap hard-coded "Active" text for the new pill in the employee table and picker modal

## Testing
- npm test *(fails: known suite regressions in search and archive tests unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dee81aeaf88327b32567828789eb42