### PR TITLE
Add inline employee editing controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ import Toast from "./components/ui/Toast";
 import Button from "./components/ui/Button";
 import FilterBar from "./components/ui/FilterBar";
 import Modal from "./components/ui/Modal";
-import StatusPill from "./components/ui/StatusPill";
+import EmployeeRow from "./components/EmployeeRow";
 import useDeadlineMonitor from "./hooks/useDeadlineMonitor";
 import { useSchedulerState } from "./hooks/useSchedulerState";
 import useNotificationPrefs, {
@@ -2579,6 +2579,50 @@ function EmployeesPage({
   setEmployees: (u: any) => void;
   showImportHeadersToast: (headers: string[], prefix?: string) => void;
 }) {
+  const [saveToast, setSaveToast] = useState<
+    { message: string; timeout: ReturnType<typeof setTimeout> } | null
+  >(null);
+
+  useEffect(() => {
+    return () => {
+      if (saveToast?.timeout) {
+        clearTimeout(saveToast.timeout);
+      }
+    };
+  }, [saveToast]);
+
+  const showSaveToast = (employee: Employee) => {
+    setSaveToast((prev) => {
+      if (prev?.timeout) {
+        clearTimeout(prev.timeout);
+      }
+      const name = [employee.firstName, employee.lastName]
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0)
+        .join(" ");
+      const message = name ? `${name} saved` : "Employee updated";
+      const timeout = setTimeout(() => {
+        setSaveToast((current) =>
+          current?.timeout === timeout ? null : current,
+        );
+      }, 2500);
+      return { message, timeout };
+    });
+  };
+
+  const handleEmployeeChange = (updated: Employee) => {
+    setEmployees((prev: Employee[]) => {
+      const next = prev.map((employee) =>
+        employee.id === updated.id ? updated : employee,
+      );
+      next.sort(
+        (a, b) => (a.seniorityRank ?? 99999) - (b.seniorityRank ?? 99999),
+      );
+      return next;
+    });
+    showSaveToast(updated);
+  };
+
   return (
     <div className="grid">
       <div className="card">
@@ -2718,26 +2762,18 @@ function EmployeesPage({
               </tr>
             </thead>
             <tbody>
-              {employees.map((e) => (
-                <tr key={e.id}>
-                  <td></td>
-                  <td>
-                    {e.firstName} {e.lastName}
-                  </td>
-                  <td></td>
-                  <td></td>
-                  <td>{e.classification}</td>
-                  <td>{e.status}</td>
-                  <td>{e.seniorityRank}</td>
-                  <td>
-                    <StatusPill active={e.active} label={e.activeLabel} />
-                  </td>
-                </tr>
+              {employees.map((employee) => (
+                <EmployeeRow
+                  key={employee.id}
+                  employee={employee}
+                  onChange={handleEmployeeChange}
+                />
               ))}
             </tbody>
           </table>
         </div>
       </div>
+      <Toast open={!!saveToast} message={saveToast?.message ?? ""} />
     </div>
   );
 }

--- a/src/components/EmployeeRow.tsx
+++ b/src/components/EmployeeRow.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from "react";
+import type { Classification, Employee, Status } from "../types";
+import { CLASSIFICATIONS } from "../types";
+import EditableSelect from "./ui/EditableSelect";
+import EditableText from "./ui/EditableText";
+import EditableToggle from "./ui/EditableToggle";
+import StatusPill from "./ui/StatusPill";
+
+type EmployeeRowProps = {
+  employee: Employee;
+  onChange: (next: Employee) => void;
+};
+
+const statusOptions: { value: Status; label: string }[] = [
+  { value: "FT", label: "FT" },
+  { value: "PT", label: "PT" },
+  { value: "Casual", label: "Casual" },
+];
+
+const classificationOptions = CLASSIFICATIONS.map((classification) => ({
+  value: classification,
+  label: classification,
+}));
+
+export default function EmployeeRow({ employee, onChange }: EmployeeRowProps) {
+  const fullName = useMemo(() => {
+    return [employee.firstName, employee.lastName]
+      .map((part) => part?.trim())
+      .filter((part) => !!part)
+      .join(" ");
+  }, [employee.firstName, employee.lastName]);
+
+  const handleCommit = (updated: Employee) => {
+    if (
+      updated.firstName === employee.firstName &&
+      updated.lastName === employee.lastName &&
+      updated.classification === employee.classification &&
+      updated.status === employee.status &&
+      updated.seniorityRank === employee.seniorityRank &&
+      updated.active === employee.active &&
+      updated.activeLabel === employee.activeLabel
+    ) {
+      return;
+    }
+
+    onChange(updated);
+  };
+
+  return (
+    <tr>
+      <td></td>
+      <td>
+        <EditableText
+          value={fullName}
+          placeholder="Enter name"
+          onSave={(value) => {
+            const trimmed = value.trim();
+            const [first, ...rest] = trimmed.split(/\s+/);
+            handleCommit({
+              ...employee,
+              firstName: first ?? "",
+              lastName: rest.join(" "),
+            });
+          }}
+        />
+      </td>
+      <td></td>
+      <td></td>
+      <td>
+        <EditableSelect
+          value={employee.classification}
+          options={classificationOptions}
+          onSave={(value) => {
+            handleCommit({
+              ...employee,
+              classification: value as Classification,
+            });
+          }}
+        />
+      </td>
+      <td>
+        <EditableSelect
+          value={employee.status}
+          options={statusOptions}
+          onSave={(value) => {
+            handleCommit({
+              ...employee,
+              status: value as Status,
+            });
+          }}
+        />
+      </td>
+      <td>
+        <EditableText
+          value={String(employee.seniorityRank ?? "")}
+          placeholder="Rank"
+          onSave={(value) => {
+            const parsed = Number(value);
+            const rank = Number.isFinite(parsed) && parsed > 0
+              ? Math.round(parsed)
+              : employee.seniorityRank;
+            handleCommit({
+              ...employee,
+              seniorityRank: rank,
+            });
+          }}
+          inputProps={{ type: "number", min: 1 }}
+        />
+      </td>
+      <td>
+        <EditableToggle
+          value={employee.active}
+          labels={{ on: "Active", off: "Inactive" }}
+          renderPreview={(value) => (
+            <StatusPill
+              active={value}
+              label={value ? "Active" : "Inactive"}
+            />
+          )}
+          onSave={(value) => {
+            handleCommit({
+              ...employee,
+              active: value,
+              activeLabel: value ? "Active" : "Inactive",
+            });
+          }}
+        />
+      </td>
+    </tr>
+  );
+}

--- a/src/components/ui/EditableSelect.tsx
+++ b/src/components/ui/EditableSelect.tsx
@@ -1,0 +1,173 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+
+export type EditableSelectOption = { value: string; label: ReactNode };
+
+export type EditableSelectProps = {
+  value: string;
+  options: EditableSelectOption[];
+  onSave: (next: string) => void;
+  placeholder?: string;
+  renderPreview?: (option: EditableSelectOption | null) => ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  selectProps?: Omit<
+    React.SelectHTMLAttributes<HTMLSelectElement>,
+    "value" | "onChange" | "onBlur" | "onKeyDown"
+  >;
+  disabled?: boolean;
+};
+
+export default function EditableSelect({
+  value,
+  options,
+  onSave,
+  placeholder,
+  renderPreview,
+  className,
+  style,
+  selectProps,
+  disabled,
+}: EditableSelectProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const selectRef = useRef<HTMLSelectElement>(null);
+  const pendingActionRef = useRef<"save" | "cancel" | null>(null);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(value);
+    }
+  }, [value, isEditing]);
+
+  useEffect(() => {
+    if (isEditing) {
+      const frame = requestAnimationFrame(() => {
+        const select = selectRef.current;
+        if (select) {
+          select.focus();
+        }
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+    return undefined;
+  }, [isEditing]);
+
+  const selectedOption = useMemo(
+    () => options.find((option) => option.value === value) ?? null,
+    [options, value],
+  );
+
+  const previewContent = useMemo(() => {
+    if (renderPreview) {
+      return renderPreview(selectedOption);
+    }
+    if (!selectedOption && placeholder) {
+      return (
+        <span style={{ color: "var(--muted)", fontStyle: "italic" }}>
+          {placeholder}
+        </span>
+      );
+    }
+    return selectedOption?.label ?? "—";
+  }, [placeholder, renderPreview, selectedOption]);
+
+  const commit = (nextValue: string) => {
+    pendingActionRef.current = "save";
+    setIsEditing(false);
+    if (nextValue !== value) {
+      onSave(nextValue);
+    }
+  };
+
+  const cancel = () => {
+    pendingActionRef.current = "cancel";
+    setDraft(value);
+    setIsEditing(false);
+  };
+
+  const handleBlur = () => {
+    if (pendingActionRef.current) {
+      pendingActionRef.current = null;
+      return;
+    }
+    commit(draft);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLSelectElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commit((event.target as HTMLSelectElement).value);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      cancel();
+    }
+  };
+
+  const triggerEdit = () => {
+    if (disabled) return;
+    setDraft(value);
+    setIsEditing(true);
+  };
+
+  const buttonStyle: CSSProperties = {
+    width: "100%",
+    textAlign: "left",
+    background: "transparent",
+    border: "1px solid transparent",
+    borderRadius: 8,
+    padding: "4px 8px",
+    minHeight: 32,
+    color: "var(--text)",
+    cursor: disabled ? "not-allowed" : "pointer",
+  };
+
+  const selectStyle: CSSProperties = {
+    width: "100%",
+    background: "var(--cardAlt)",
+    border: "1px solid var(--stroke)",
+    borderRadius: 8,
+    padding: "4px 8px",
+    minHeight: 32,
+    color: "var(--text)",
+  };
+
+  return (
+    <div className={className} style={style}>
+      {isEditing ? (
+        <select
+          {...selectProps}
+          ref={selectRef}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          style={{ ...selectStyle, ...selectProps?.style }}
+          disabled={disabled}
+        >
+          {options.map((option) => (
+            <option key={String(option.value)} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <button
+          type="button"
+          onClick={triggerEdit}
+          style={buttonStyle}
+          disabled={disabled}
+        >
+          {previewContent}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/EditableText.tsx
+++ b/src/components/ui/EditableText.tsx
@@ -1,0 +1,160 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+
+export type EditableTextProps = {
+  value: string;
+  onSave: (next: string) => void;
+  placeholder?: string;
+  renderPreview?: (value: string) => ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  inputProps?: Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "value" | "onChange" | "onBlur" | "onKeyDown"
+  >;
+  disabled?: boolean;
+};
+
+export default function EditableText({
+  value,
+  onSave,
+  placeholder,
+  renderPreview,
+  className,
+  style,
+  inputProps,
+  disabled,
+}: EditableTextProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? "");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const pendingActionRef = useRef<"save" | "cancel" | null>(null);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(value ?? "");
+    }
+  }, [value, isEditing]);
+
+  useEffect(() => {
+    if (isEditing) {
+      const frame = requestAnimationFrame(() => {
+        const input = inputRef.current;
+        if (input) {
+          input.focus();
+          input.select();
+        }
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+    return undefined;
+  }, [isEditing]);
+
+  const displayValue = useMemo(() => {
+    if (renderPreview) {
+      return renderPreview(value ?? "");
+    }
+    const trimmed = (value ?? "").trim();
+    if (!trimmed && placeholder) {
+      return (
+        <span style={{ color: "var(--muted)", fontStyle: "italic" }}>
+          {placeholder}
+        </span>
+      );
+    }
+    return trimmed || "—";
+  }, [placeholder, renderPreview, value]);
+
+  const commit = (nextValue: string) => {
+    const normalized = nextValue;
+    pendingActionRef.current = "save";
+    setIsEditing(false);
+    if (normalized !== value) {
+      onSave(normalized);
+    }
+  };
+
+  const cancel = () => {
+    pendingActionRef.current = "cancel";
+    setDraft(value ?? "");
+    setIsEditing(false);
+  };
+
+  const handleBlur = () => {
+    if (pendingActionRef.current) {
+      pendingActionRef.current = null;
+      return;
+    }
+    commit(draft);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commit(draft);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      cancel();
+    }
+  };
+
+  const triggerEdit = () => {
+    if (disabled) return;
+    setDraft(value ?? "");
+    setIsEditing(true);
+  };
+
+  const baseButtonStyle: CSSProperties = {
+    width: "100%",
+    textAlign: "left",
+    background: "transparent",
+    border: "1px solid transparent",
+    borderRadius: 8,
+    padding: "4px 8px",
+    minHeight: 32,
+    color: "var(--text)",
+    cursor: disabled ? "not-allowed" : "text",
+  };
+
+  const inputStyle: CSSProperties = {
+    width: "100%",
+    background: "var(--cardAlt)",
+    border: "1px solid var(--stroke)",
+    borderRadius: 8,
+    padding: "4px 8px",
+    minHeight: 32,
+    color: "var(--text)",
+  };
+
+  return (
+    <div className={className} style={style}>
+      {isEditing ? (
+        <input
+          {...inputProps}
+          ref={inputRef}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          style={{ ...inputStyle, ...inputProps?.style }}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={triggerEdit}
+          style={baseButtonStyle}
+          disabled={disabled}
+        >
+          {displayValue}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/EditableToggle.tsx
+++ b/src/components/ui/EditableToggle.tsx
@@ -1,0 +1,56 @@
+import type { CSSProperties, ReactNode } from "react";
+import EditableSelect, {
+  type EditableSelectOption,
+} from "./EditableSelect";
+
+export type EditableToggleProps = {
+  value: boolean;
+  onSave: (next: boolean) => void;
+  labels?: { on: ReactNode; off: ReactNode };
+  placeholder?: string;
+  renderPreview?: (value: boolean) => ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  disabled?: boolean;
+};
+
+export default function EditableToggle({
+  value,
+  onSave,
+  labels,
+  placeholder,
+  renderPreview,
+  className,
+  style,
+  disabled,
+}: EditableToggleProps) {
+  const optionTrue: EditableSelectOption = {
+    value: "true",
+    label: labels?.on ?? "Yes",
+  };
+  const optionFalse: EditableSelectOption = {
+    value: "false",
+    label: labels?.off ?? "No",
+  };
+
+  const options = [optionTrue, optionFalse];
+
+  return (
+    <EditableSelect
+      value={value ? optionTrue.value : optionFalse.value}
+      options={options}
+      onSave={(next) => onSave(next === optionTrue.value)}
+      placeholder={placeholder}
+      renderPreview={(selected) => {
+        const boolValue = selected?.value === optionTrue.value;
+        if (renderPreview) {
+          return renderPreview(boolValue);
+        }
+        return boolValue ? optionTrue.label : optionFalse.label;
+      }}
+      className={className}
+      style={style}
+      disabled={disabled}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add editable text, select, and toggle primitives with keyboard and blur-save behaviour
- render employees through a dedicated EmployeeRow that splits/joins names and propagates updates
- update EmployeesPage to use the editable row, optimistically update state, and show a save toast

## Testing
- npm run test *(fails: existing suite contains known failing cases)*

------
https://chatgpt.com/codex/tasks/task_e_68deeaaabab883279b2f2781f714c189