### PR TITLE
Reset range bid dialog state and enforce coverage validation

### DIFF
--- a/src/components/RangeBidDialog.tsx
+++ b/src/components/RangeBidDialog.tsx
@@ -25,6 +25,7 @@ export default function RangeBidDialog({
     "full" | "some-days" | "partial-day"
   >("full");
   const [selectedDays, setSelectedDays] = useState<string[]>(workingDays);
+  const [coverageError, setCoverageError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -32,7 +33,16 @@ export default function RangeBidDialog({
     setNote("");
     setCoverageType("full");
     setSelectedDays(workingDays);
-  }, [open, workingDays]);
+    setCoverageError(null);
+  }, [open, range.id, workingDays]);
+
+  useEffect(() => {
+    if (coverageType === "full" || selectedDays.length > 0) {
+      setCoverageError(null);
+    } else if (open) {
+      setCoverageError("Select at least one working day.");
+    }
+  }, [coverageType, selectedDays, open]);
 
   const empOpts = useMemo(
     () =>
@@ -50,7 +60,10 @@ export default function RangeBidDialog({
 
   function submit() {
     if (!employeeId) return;
-    if (coverageType !== "full" && selectedDays.length === 0) return;
+    if (coverageType !== "full" && selectedDays.length === 0) {
+      setCoverageError("Select at least one working day.");
+      return;
+    }
     const employee = employees.find((x) => x.id === employeeId);
     const now = new Date().toISOString();
     const bid: Bid = {
@@ -122,6 +135,7 @@ export default function RangeBidDialog({
                 onChange={() => {
                   setCoverageType("full");
                   setSelectedDays(workingDays);
+                  setCoverageError(null);
                 }}
               />
               <span>Entire vacancy (all working days)</span>
@@ -135,6 +149,7 @@ export default function RangeBidDialog({
                   setSelectedDays((days) =>
                     days.length ? days : [...workingDays],
                   );
+                  setCoverageError(null);
                 }}
               />
               <span>Some days only</span>
@@ -148,6 +163,7 @@ export default function RangeBidDialog({
                   setSelectedDays((days) =>
                     days.length ? days : [...workingDays],
                   );
+                  setCoverageError(null);
                 }}
               />
               <span>Partial-day (time differs on specific day)</span>
@@ -166,6 +182,11 @@ export default function RangeBidDialog({
                   </label>
                 ))}
               </div>
+            )}
+            {coverageError && (
+              <p role="alert" className="mt-2 text-sm text-red-600">
+                {coverageError}
+              </p>
             )}
           </fieldset>
 
@@ -188,7 +209,7 @@ export default function RangeBidDialog({
           <button
             onClick={submit}
             className="px-3 py-2 rounded-md bg-black text-white"
-            disabled={!employeeId || (coverageType !== "full" && selectedDays.length === 0)}
+            disabled={!employeeId}
           >
             Submit bid
           </button>

--- a/src/components/__tests__/RangeBidDialog.test.tsx
+++ b/src/components/__tests__/RangeBidDialog.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import RangeBidDialog from "../RangeBidDialog";
+import type { VacancyRange, Employee } from "../../types";
+
+describe("RangeBidDialog", () => {
+  const employees: Employee[] = [
+    {
+      id: "emp-1",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      classification: "RN",
+      status: "FT",
+      seniorityRank: 1,
+      active: true,
+    },
+    {
+      id: "emp-2",
+      firstName: "Grace",
+      lastName: "Hopper",
+      classification: "RN",
+      status: "FT",
+      seniorityRank: 2,
+      active: true,
+    },
+  ];
+
+  const baseRange: VacancyRange = {
+    id: "range-1",
+    reason: "Vacation",
+    classification: "RN",
+    startDate: "2025-01-01",
+    endDate: "2025-01-03",
+    knownAt: "2024-12-01T00:00:00Z",
+    workingDays: ["2025-01-01", "2025-01-02", "2025-01-03"],
+    shiftStart: "06:30",
+    shiftEnd: "14:30",
+    offeringStep: "Casuals",
+    status: "Open",
+    awardAsBlock: true,
+  };
+
+  it("resets form values when the range id changes while open", () => {
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <RangeBidDialog
+        open
+        onClose={onClose}
+        range={baseRange}
+        employees={employees}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    let dialogs = screen.getAllByRole("dialog");
+    let dialog = dialogs[dialogs.length - 1];
+    let withinDialog = within(dialog);
+
+    fireEvent.change(withinDialog.getByRole("combobox"), {
+      target: { value: "emp-2" },
+    });
+    fireEvent.click(withinDialog.getByLabelText(/partial-day/i));
+    fireEvent.click(withinDialog.getByLabelText("2025-01-01"));
+    fireEvent.change(withinDialog.getByPlaceholderText(/add context/i), {
+      target: { value: "Original note" },
+    });
+
+    const newRange: VacancyRange = {
+      ...baseRange,
+      id: "range-2",
+      workingDays: ["2025-02-01", "2025-02-02"],
+    };
+
+    rerender(
+      <RangeBidDialog
+        open
+        onClose={onClose}
+        range={newRange}
+        employees={employees}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    dialogs = screen.getAllByRole("dialog");
+    dialog = dialogs[dialogs.length - 1];
+    withinDialog = within(dialog);
+
+    expect(
+      (withinDialog.getByRole("combobox") as HTMLSelectElement).value,
+    ).toBe("");
+    expect(
+      (withinDialog.getByLabelText(/entire vacancy/i) as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (withinDialog.getByLabelText(/some days only/i) as HTMLInputElement).checked,
+    ).toBe(false);
+    expect(
+      (withinDialog.getByLabelText(/partial-day/i) as HTMLInputElement).checked,
+    ).toBe(false);
+    expect(
+      (
+        withinDialog.getByPlaceholderText(
+          /add context/i,
+        ) as HTMLTextAreaElement
+      ).value,
+    ).toBe("");
+
+    fireEvent.click(withinDialog.getByLabelText(/some days only/i));
+    expect(
+      (withinDialog.getByLabelText("2025-02-01") as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (withinDialog.getByLabelText("2025-02-02") as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+
+  it("shows validation when partial coverage is submitted with no selected days", () => {
+    const onSubmit = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <RangeBidDialog
+        open
+        onClose={onClose}
+        range={baseRange}
+        employees={employees}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const dialogs = screen.getAllByRole("dialog");
+    const dialog = dialogs[dialogs.length - 1];
+    const withinDialog = within(dialog);
+
+    fireEvent.change(withinDialog.getByRole("combobox"), {
+      target: { value: "emp-1" },
+    });
+    fireEvent.click(withinDialog.getByLabelText(/some days only/i));
+    fireEvent.click(withinDialog.getByLabelText("2025-01-01"));
+    fireEvent.click(withinDialog.getByLabelText("2025-01-02"));
+    fireEvent.click(withinDialog.getByLabelText("2025-01-03"));
+
+    expect(
+      withinDialog.getByText(/select at least one working day/i),
+    ).toBeTruthy();
+
+    fireEvent.click(withinDialog.getByText(/submit bid/i));
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.click(withinDialog.getByLabelText("2025-01-01"));
+    expect(
+      withinDialog.queryByText(/select at least one working day/i),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- reset RangeBidDialog form state when reopened or when the vacancy range changes
- show inline validation and prevent submitting partial coverage without selected days
- add RangeBidDialog tests covering state resets and partial coverage validation

## Testing
- npm test -- RangeBidDialog

------
https://chatgpt.com/codex/tasks/task_e_68deed9b6b6c8327bd76fa89fc210364