### PR TITLE
Normalize Excel date parsing to ISO strings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -575,6 +575,13 @@ const normalizeExcelRowDates = (
       }
     }
 
+    if (typeof value === "string" && value.trim()) {
+      const parsed = new Date(value);
+      if (!Number.isNaN(parsed.getTime())) {
+        return [key, formatDateValue(parsed, normalizedKey)];
+      }
+    }
+
     return [key, value];
   });
 
@@ -625,6 +632,7 @@ export async function parseFile(
     const rawRows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
       defval: "",
       cellDates: true,
+      raw: false,
     });
 
     return rawRows.map((row) => normalizeExcelRowDates(row, XLSX));

--- a/src/__tests__/parseFile.test.ts
+++ b/src/__tests__/parseFile.test.ts
@@ -18,25 +18,10 @@ describe("parseFile", () => {
       type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     });
 
-    const xlsxModule = await import("xlsx");
-    const workbook = xlsxModule.read(bytes, { type: "array" });
-    expect(workbook.SheetNames).toHaveLength(1);
-    const sheet = workbook.Sheets[workbook.SheetNames[0]];
-    expect(sheet).toBeTruthy();
-    const rawRows = xlsxModule.utils.sheet_to_json<Record<string, unknown>>(sheet!, {
-      defval: "",
-      cellDates: true,
-    });
-    expect(rawRows).toHaveLength(1);
-    expect(typeof rawRows[0]["Start Date"]).toBe("number");
-    const serial = rawRows[0]["Start Date"] as number;
-    const baseDate = new Date(Date.UTC(1899, 11, 30));
-    const debugDate = new Date(baseDate.getTime() + Math.round(serial * 86_400_000));
-    expect(debugDate.toISOString().slice(0, 10)).toBe("2024-01-15");
-
     const rows = await parseFile(file);
     expect(rows).toHaveLength(1);
     expect(rows[0]["Start Date"]).toBe("2024-01-15");
+    expect(typeof rows[0]["Start Date"]).toBe("string");
 
     const employees = rows
       .map((row, index) => mapRowToEmployee(row, index))


### PR DESCRIPTION
## Summary
- request formatted Excel parsing to normalize date-like cells into ISO strings
- convert string, date, or serial Excel values before mapping to employees
- cover the Excel startDate import path with a vitest fixture-driven test

## Testing
- npm test -- parseFile

------
https://chatgpt.com/codex/tasks/task_e_68deeda87e1c83278d4b7c5628ddcc11