### PR TITLE
Escape CSV fields and cover edge cases

### DIFF
--- a/server/analyticsFormats/csv.d.ts
+++ b/server/analyticsFormats/csv.d.ts
@@ -1,3 +1,4 @@
 import type { AggregatedVacancyMetrics } from "../metrics.js";
 
+export function escapeCsv(value: unknown): string;
 export function createCsv(data: AggregatedVacancyMetrics[]): string;

--- a/server/analyticsFormats/csv.js
+++ b/server/analyticsFormats/csv.js
@@ -1,11 +1,28 @@
+function escapeCsv(value) {
+  const stringValue = value === null || value === undefined ? "" : String(value);
+  const escapedValue = stringValue.replace(/"/g, '""');
+  return `"${escapedValue}"`;
+}
+
 export function createCsv(data) {
   const header =
     "period,posted,awarded,cancelled,cancellationRate,overtime,averageHours\n";
   const rows = data
-    .map(
-      (d) =>
-        `${d.period},${d.posted},${d.awarded},${d.cancelled},${d.cancellationRate},${d.overtime},${d.averageHours}`,
+    .map((d) =>
+      [
+        d.period,
+        d.posted,
+        d.awarded,
+        d.cancelled,
+        d.cancellationRate,
+        d.overtime,
+        d.averageHours,
+      ]
+        .map(escapeCsv)
+        .join(","),
     )
     .join("\n");
   return header + rows;
 }
+
+export { escapeCsv };

--- a/tests/analyticsFormats.test.ts
+++ b/tests/analyticsFormats.test.ts
@@ -17,6 +17,51 @@ describe("createCsv", () => {
     ];
     const csv = createCsv(data);
     expect(csv).toContain("averageHours");
-    expect(csv.trim().split("\n")[1].split(",").pop()).toBe("10");
+    expect(csv.trim().split("\n")[1]).toBe(
+      '"2024-01","1","1","0","0","2","10"',
+    );
+  });
+
+  it("escapes commas, quotes, and newlines", () => {
+    const data: AggregatedVacancyMetrics[] = [
+      {
+        period: "2024-01",
+        posted: 1,
+        awarded: 1,
+        cancelled: 0,
+        cancellationRate: 0,
+        overtime: 2,
+        averageHours: 10,
+      },
+      {
+        period: '2024-02, Q1 "Special"',
+        posted: 2,
+        awarded: 1,
+        cancelled: 1,
+        cancellationRate: 0.5,
+        overtime: 3,
+        averageHours: 7,
+      },
+      {
+        period: "2024-03\nLine",
+        posted: 3,
+        awarded: 1,
+        cancelled: 2,
+        cancellationRate: 2 / 3,
+        overtime: 1,
+        averageHours: 8,
+      },
+    ];
+
+    const csv = createCsv(data);
+
+    const expected = [
+      "period,posted,awarded,cancelled,cancellationRate,overtime,averageHours",
+      '"2024-01","1","1","0","0","2","10"',
+      '"2024-02, Q1 ""Special""","2","1","1","0.5","3","7"',
+      `"2024-03\nLine","3","1","2","0.6666666666666666","1","8"`,
+    ].join("\n");
+
+    expect(csv).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary
- add an escapeCsv helper to quote, escape, and stringify CSV values
- ensure all CSV data columns use the helper while keeping the header unchanged
- extend analytics format tests to verify commas, quotes, and newline handling

## Testing
- npm test -- analyticsFormats

------
https://chatgpt.com/codex/tasks/task_e_68def07dd1008327954516172ac52aab