### PR TITLE
Add overtime threshold filter to analytics

### DIFF
--- a/src/Analytics.tsx
+++ b/src/Analytics.tsx
@@ -35,6 +35,7 @@ export default function Analytics() {
   const [rows, setRows] = useState<AnalyticsRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [overtimeThreshold, setOvertimeThreshold] = useState(8);
 
   const [palette, setPalette] = useState({
     brand: "#047857",
@@ -51,6 +52,10 @@ export default function Analytics() {
     return token;
   }, []);
 
+  const clampOvertimeThreshold = useCallback((value: number) => {
+    return Math.min(24, Math.max(0, Math.round(value)));
+  }, []);
+
   const loadData = useCallback(async () => {
     controllerRef.current?.abort();
     const controller = new AbortController();
@@ -61,7 +66,10 @@ export default function Analytics() {
     const maxRetries = 3;
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       try {
-        const response = await authFetch("/api/analytics", {
+        const params = new URLSearchParams({
+          overtimeThreshold: String(overtimeThreshold),
+        });
+        const response = await authFetch(`/api/analytics?${params}`, {
           signal: controller.signal,
         });
         const data = await response.json();
@@ -89,13 +97,15 @@ export default function Analytics() {
         }
       }
     }
-  }, [promptForToken]);
+  }, [overtimeThreshold, promptForToken]);
 
   const handleExport = async (format: string) => {
     try {
-      const response = await authFetch(
-        `/api/analytics/export?format=${format}`,
-      );
+      const params = new URLSearchParams({
+        format,
+        overtimeThreshold: String(overtimeThreshold),
+      });
+      const response = await authFetch(`/api/analytics/export?${params}`);
       const blob = await response.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -188,6 +198,38 @@ export default function Analytics() {
       >
         Set API Token
       </button>
+      <div style={{ marginBottom: 20 }}>
+        <label
+          htmlFor="overtime-threshold"
+          style={{ display: "block", marginBottom: 4 }}
+        >
+          Overtime threshold (hours)
+        </label>
+        <input
+          id="overtime-threshold"
+          type="number"
+          min={0}
+          max={24}
+          value={overtimeThreshold}
+          onChange={(event) => {
+            const nextValue = Number(event.target.value);
+            setOvertimeThreshold(
+              clampOvertimeThreshold(
+                Number.isNaN(nextValue) ? overtimeThreshold : nextValue,
+              ),
+            );
+          }}
+          onBlur={(event) => {
+            const nextValue = Number(event.target.value);
+            setOvertimeThreshold((current) =>
+              clampOvertimeThreshold(
+                Number.isNaN(nextValue) ? current : nextValue,
+              ),
+            );
+          }}
+          style={{ padding: "6px 8px", width: 120 }}
+        />
+      </div>
       <div style={{ width: 600 }}>
         <Bar
           data={{

--- a/tests/analyticsOvertimeThreshold.test.tsx
+++ b/tests/analyticsOvertimeThreshold.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+
+const mockAuthFetch = vi.fn();
+
+vi.mock("../src/utils/api", () => ({
+  authFetch: (...args: any[]) => mockAuthFetch(...args),
+  setToken: vi.fn(),
+}));
+
+vi.mock("react-chartjs-2", () => ({
+  Bar: () => null,
+  Line: () => null,
+}));
+
+// Import after mocks so they take effect.
+import Analytics from "../src/Analytics";
+
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+let anchorClickSpy: { mockRestore: () => void } | null = null;
+
+beforeAll(() => {
+  URL.createObjectURL = vi.fn(() => "blob:url");
+  URL.revokeObjectURL = vi.fn();
+  anchorClickSpy = vi
+    .spyOn(HTMLAnchorElement.prototype, "click")
+    .mockImplementation(() => {});
+});
+
+afterAll(() => {
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+  anchorClickSpy?.mockRestore();
+});
+
+beforeEach(() => {
+  mockAuthFetch.mockReset();
+  mockAuthFetch.mockImplementation((url: unknown) => {
+    if (typeof url === "string" && url.startsWith("/api/analytics/export")) {
+      return Promise.resolve({
+        blob: async () => new Blob([]),
+      });
+    }
+    return Promise.resolve({
+      json: async () => [],
+    });
+  });
+});
+
+test("forwards overtimeThreshold to analytics requests", async () => {
+  render(<Analytics />);
+
+  await waitFor(() => expect(mockAuthFetch).toHaveBeenCalledTimes(1));
+  expect(mockAuthFetch.mock.calls[0][0]).toContain("overtimeThreshold=8");
+
+  mockAuthFetch.mockClear();
+
+  const input = screen.getByLabelText(/overtime threshold/i);
+  fireEvent.change(input, { target: { value: "12" } });
+
+  await waitFor(() => expect(mockAuthFetch).toHaveBeenCalledTimes(1));
+  expect(mockAuthFetch.mock.calls[0][0]).toContain("overtimeThreshold=12");
+
+  mockAuthFetch.mockClear();
+
+  fireEvent.click(screen.getByText("Export CSV"));
+
+  await waitFor(() => expect(mockAuthFetch).toHaveBeenCalledTimes(1));
+  const exportUrl = mockAuthFetch.mock.calls[0][0];
+  expect(exportUrl).toContain("format=csv");
+  expect(exportUrl).toContain("overtimeThreshold=12");
+});


### PR DESCRIPTION
## Summary
- add an overtime threshold input to the analytics page and clamp the value to a sensible range
- include the overtime threshold in analytics and export requests
- add a unit test that verifies the threshold parameter is forwarded when changed

## Testing
- npm test -- analytics

------
https://chatgpt.com/codex/tasks/task_e_68def267b82c8327a7d0ad9991e51238