### PR TITLE
Refine search filter bar layout and styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1594,18 +1594,6 @@ export default function App() {
         .nav{display:flex;align-items:center;gap:12px;justify-content:space-between;margin-bottom:14px}
         .title{font-size:22px;font-weight:800}
         
-        .smart-filter-bar{flex-wrap:wrap;padding:4px 0;gap:8px 12px}
-        .smart-filter-bar>*{flex:0 1 auto}
-        .smart-filter-bar input:not([type="checkbox"]){width:auto}
-        .smart-filter-bar input[type="text"]{min-width:180px}
-        .smart-filter-bar .date-range{display:flex;gap:4px;flex-wrap:nowrap}
-        .smart-filter-bar .date-range input{min-width:140px}
-        .smart-filter-bar .chip-group{display:flex;gap:4px;flex-wrap:wrap}
-        .smart-filter-bar .pill-toggle{background:var(--chipBg);color:var(--chipText);border:1px solid var(--stroke);border-radius:999px;padding:6px 10px;font-size:12px;font-weight:600;cursor:pointer;white-space:nowrap;transition:background .2s,color .2s,border-color .2s}
-        .smart-filter-bar .pill-toggle[data-active="true"]{background:var(--brand);color:#fff;border-color:var(--brand)}
-        .smart-filter-bar .active-filter-chips{display:flex;gap:4px;align-items:center;flex-wrap:nowrap}
-        .smart-filter-bar .active-filter-chip{display:inline-flex;align-items:center;gap:6px;cursor:pointer;white-space:nowrap}
-        .smart-filter-bar .active-filter-chip:hover{border-color:var(--brand);color:var(--brand)}
         
         @media(max-width:900px){.nav{flex-direction:column;align-items:flex-start;gap:8px}}
         .tabs{display:flex;gap:8px;flex-wrap:wrap;margin:8px 0 16px}

--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import { ChangeEvent, useId } from "react";
 import { CLASSIFICATIONS, WINGS, SHIFT_PRESETS } from "../types";
 import type { Classification } from "../types";
 
@@ -24,6 +24,7 @@ function MultiSelectDropdown<T extends string>({
   selected,
   onChange,
 }: MultiSelectDropdownProps<T>) {
+  const dropdownId = useId();
   const toggleValue = (value: T) => {
     if (selected.includes(value)) {
       onChange(selected.filter((item) => item !== value));
@@ -44,9 +45,10 @@ function MultiSelectDropdown<T extends string>({
       </summary>
       <div role="group" aria-label={label} className="filter-dropdown__list">
         {options.map((option) => {
-          const id = `${namePrefix}-${option.value
+          const safeValue = option.value
             .toLowerCase()
-            .replace(/[^a-z0-9]+/g, "-")}`;
+            .replace(/[^a-z0-9]+/g, "-");
+          const id = `${dropdownId}-${namePrefix}-${safeValue}`;
           const checked = selected.includes(option.value);
           return (
             <label key={option.value} htmlFor={id} className="filter-dropdown__option">
@@ -105,6 +107,9 @@ export default function SearchFilterBar({
   onShiftPresetChange,
   onClear,
 }: Props) {
+  const searchInputId = useId();
+  const startDateId = useId();
+  const endDateId = useId();
   const clear = () => {
     if (onClear) {
       onClear();
@@ -189,64 +194,86 @@ export default function SearchFilterBar({
   }
 
   return (
-    <div className="toolbar smart-filter-bar search-filter-bar">
-      <div style={{ minWidth: 180, flexShrink: 0 }}>
-        <label className="sr-only" htmlFor="vacancy-search-input">
+    <section
+      className="toolbar search-filter-bar"
+      aria-label="Search and filter vacancies"
+    >
+      <div className="search-filter-bar__field">
+        <label className="sr-only" htmlFor={searchInputId}>
           Search vacancies
         </label>
         <input
-          id="vacancy-search-input"
+          id={searchInputId}
           type="text"
           placeholder="Search..."
           value={query}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onQueryChange(e.target.value)}
         />
       </div>
-      <MultiSelectDropdown
-        label="Classifications"
-        namePrefix="classification"
-        options={CLASSIFICATIONS.map((classification) => ({
-          value: classification,
-          label: classification,
-        }))}
-        selected={selectedPositions}
-        onChange={onPositionsChange}
-      />
-      <MultiSelectDropdown
-        label="Wings"
-        namePrefix="wing"
-        options={WINGS.map((wing) => ({ value: wing, label: wing }))}
-        selected={selectedWings}
-        onChange={onWingsChange}
-      />
-      <div className="date-range" aria-label="Date range filters">
-        <input
-          aria-label="Filter from date"
-          type="date"
-          value={startDate}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => onStartDateChange(e.target.value)}
-        />
-        <input
-          aria-label="Filter to date"
-          type="date"
-          value={endDate}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => onEndDateChange(e.target.value)}
+      <div className="search-filter-bar__field">
+        <MultiSelectDropdown
+          label="Classifications"
+          namePrefix="classification"
+          options={CLASSIFICATIONS.map((classification) => ({
+            value: classification,
+            label: classification,
+          }))}
+          selected={selectedPositions}
+          onChange={onPositionsChange}
         />
       </div>
+      <div className="search-filter-bar__field">
+        <MultiSelectDropdown
+          label="Wings"
+          namePrefix="wing"
+          options={WINGS.map((wing) => ({ value: wing, label: wing }))}
+          selected={selectedWings}
+          onChange={onWingsChange}
+        />
+      </div>
+      <div className="search-filter-bar__field">
+        <span className="search-filter-bar__label" aria-hidden="true">
+          Dates
+        </span>
+        <div className="search-filter-bar__date-range" aria-label="Date range filters">
+          <label className="sr-only" htmlFor={startDateId}>
+            Filter from date
+          </label>
+          <input
+            id={startDateId}
+            type="date"
+            value={startDate}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onStartDateChange(e.target.value)}
+          />
+          <label className="sr-only" htmlFor={endDateId}>
+            Filter to date
+          </label>
+          <input
+            id={endDateId}
+            type="date"
+            value={endDate}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onEndDateChange(e.target.value)}
+          />
+        </div>
+      </div>
       {onShiftPresetChange && (
-        <div className="chip-group" aria-label="Shift filters">
-          {SHIFT_PRESETS.map((preset) => (
-            <button
-              key={preset.label}
-              type="button"
-              className="pill pill-toggle"
-              data-active={shiftPreset === preset.label}
-              aria-pressed={shiftPreset === preset.label}
-              onClick={() => toggleShiftPreset(preset.label)}
-            >
-              {preset.label}
-            </button>
-          ))}
+        <div className="search-filter-bar__segmented" role="group" aria-label="Shift filters">
+          <span className="search-filter-bar__label" aria-hidden="true">
+            Shifts
+          </span>
+          <div className="search-filter-bar__segmented-buttons">
+            {SHIFT_PRESETS.map((preset) => (
+              <button
+                key={preset.label}
+                type="button"
+                data-active={shiftPreset === preset.label}
+                aria-pressed={shiftPreset === preset.label}
+                onClick={() => toggleShiftPreset(preset.label)}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
         </div>
       )}
       {onShiftPresetChange && (
@@ -276,45 +303,49 @@ export default function SearchFilterBar({
           ))}
         </select>
       )}
-      <div className="chip-group" aria-label="Bundle filters">
-        <button
-          type="button"
-          className="pill pill-toggle"
-          data-active={bundleMode === "all"}
-          aria-pressed={bundleMode === "all"}
-          onClick={() => toggleBundleMode("all")}
-        >
-          All
-        </button>
-        <button
-          type="button"
-          className="pill pill-toggle"
-          data-active={bundleMode === "bundles"}
-          aria-pressed={bundleMode === "bundles"}
-          onClick={() => toggleBundleMode("bundles")}
-        >
-          Bundles only
-        </button>
-        <button
-          type="button"
-          className="pill pill-toggle"
-          data-active={bundleMode === "singles"}
-          aria-pressed={bundleMode === "singles"}
-          onClick={() => toggleBundleMode("singles")}
-        >
-          Singles only
+      <div className="search-filter-bar__segmented" role="group" aria-label="Bundle filters">
+        <span className="search-filter-bar__label" aria-hidden="true">
+          Bundle mode
+        </span>
+        <div className="search-filter-bar__segmented-buttons">
+          <button
+            type="button"
+            data-active={bundleMode === "all"}
+            aria-pressed={bundleMode === "all"}
+            onClick={() => toggleBundleMode("all")}
+          >
+            All
+          </button>
+          <button
+            type="button"
+            data-active={bundleMode === "bundles"}
+            aria-pressed={bundleMode === "bundles"}
+            onClick={() => toggleBundleMode("bundles")}
+          >
+            Bundles only
+          </button>
+          <button
+            type="button"
+            data-active={bundleMode === "singles"}
+            aria-pressed={bundleMode === "singles"}
+            onClick={() => toggleBundleMode("singles")}
+          >
+            Singles only
+          </button>
+        </div>
+      </div>
+      <div className="search-filter-bar__field search-filter-bar__action">
+        <button className="btn" onClick={clear} type="button">
+          Clear
         </button>
       </div>
-      <button className="btn" onClick={clear} type="button">
-        Clear
-      </button>
       {activeFilters.length > 0 && (
-        <div className="active-filter-chips">
+        <div className="search-filter-bar__chips-row" aria-label="Active filters">
           {activeFilters.map((chip) => (
             <button
               key={chip.key}
               type="button"
-              className="pill active-filter-chip"
+              className="active-filter-chip"
               onClick={chip.onRemove}
               aria-label={`Remove ${chip.label}`}
             >
@@ -324,6 +355,6 @@ export default function SearchFilterBar({
           ))}
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import "./styles/ui-sanity.css";
 import "./styles/color-map.css";
 import "./styles/vacancies-redesign.css";
 import "./styles/shared-ui.css";
+import "./styles/search-filter-bar.css";
 
 const initialTheme: Theme = (() => {
   if (typeof window === "undefined") return "light";

--- a/src/styles/search-filter-bar.css
+++ b/src/styles/search-filter-bar.css
@@ -1,0 +1,252 @@
+.search-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid var(--stroke);
+  background: var(--card);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.search-filter-bar__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 200px;
+  min-width: 160px;
+}
+
+.search-filter-bar__field input[type="text"],
+.search-filter-bar__field input[type="date"],
+.search-filter-bar__field select {
+  width: 100%;
+  background: var(--cardAlt);
+  border: 1px solid var(--stroke);
+  border-radius: 12px;
+  padding: 9px 12px;
+  color: var(--text);
+  font: inherit;
+  min-height: 40px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-filter-bar__field input[type="text"]:focus,
+.search-filter-bar__field input[type="date"]:focus,
+.search-filter-bar__field select:focus {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(4, 120, 87, 0.18);
+}
+
+.search-filter-bar__label {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.search-filter-bar__date-range {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.search-filter-bar__segmented {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 240px;
+  min-width: 200px;
+}
+
+.search-filter-bar__segmented-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.search-filter-bar__segmented-buttons button {
+  border-radius: 999px;
+  border: 1px solid var(--stroke);
+  background: var(--chipBg);
+  color: var(--chipText);
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-filter-bar__segmented-buttons button[data-active="true"] {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: var(--button-text-on-brand);
+  box-shadow: 0 4px 12px rgba(4, 120, 87, 0.25);
+}
+
+.search-filter-bar__segmented-buttons button:hover,
+.search-filter-bar__segmented-buttons button:focus-visible {
+  border-color: var(--brand);
+  color: var(--brand);
+  background: rgba(4, 120, 87, 0.12);
+}
+
+.search-filter-bar__segmented-buttons button[data-active="true"]:hover,
+.search-filter-bar__segmented-buttons button[data-active="true"]:focus-visible {
+  color: var(--button-text-on-brand);
+  background: var(--brand);
+}
+
+.search-filter-bar__segmented-buttons button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(4, 120, 87, 0.2);
+}
+
+.search-filter-bar__action {
+  flex: 0 0 auto;
+}
+
+.search-filter-bar__action .btn {
+  min-height: 40px;
+  padding-inline: 16px;
+}
+
+.search-filter-bar__chips-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+  padding-top: 4px;
+}
+
+.search-filter-bar__chips-row .active-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--stroke);
+  background: var(--chipBg);
+  color: var(--chipText);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.search-filter-bar__chips-row .active-filter-chip:hover,
+.search-filter-bar__chips-row .active-filter-chip:focus-visible {
+  border-color: var(--brand);
+  color: var(--brand);
+  background: rgba(4, 120, 87, 0.1);
+  outline: none;
+}
+
+.filter-dropdown {
+  position: relative;
+  width: 100%;
+}
+
+.filter-dropdown > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--stroke);
+  border-radius: 12px;
+  background: var(--cardAlt);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 600;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  list-style: none;
+}
+
+.filter-dropdown > summary::-webkit-details-marker {
+  display: none;
+}
+
+.filter-dropdown > summary::marker {
+  display: none;
+}
+
+.filter-dropdown[open] > summary {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(4, 120, 87, 0.18);
+}
+
+.filter-dropdown__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: var(--brand);
+  color: var(--button-text-on-brand);
+  font-size: 12px;
+  font-weight: 700;
+  padding-inline: 6px;
+}
+
+.filter-dropdown__list {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 5;
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: 12px;
+  padding: 8px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.16);
+  display: grid;
+  gap: 6px;
+  max-height: 260px;
+  overflow: auto;
+}
+
+.filter-dropdown__option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.filter-dropdown__option:hover {
+  background: rgba(4, 120, 87, 0.12);
+}
+
+.filter-dropdown__option input {
+  accent-color: var(--brand);
+}
+
+.filter-dropdown__empty {
+  margin: 0;
+  padding: 6px 4px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+@media (max-width: 900px) {
+  .search-filter-bar {
+    padding: 12px;
+    gap: 10px;
+  }
+
+  .search-filter-bar__field,
+  .search-filter-bar__segmented {
+    flex: 1 1 100%;
+  }
+
+  .search-filter-bar__date-range {
+    grid-template-columns: repeat(2, minmax(120px, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- wrap the vacancy search and filter controls in a semantic section with grouped containers and stable generated ids
- add a dedicated search-filter-bar stylesheet that drives the card layout, dropdown menu presentation, segmented toggles, and active chips
- remove the legacy inline smart-filter-bar rules and import the new stylesheet through the app entry point

## Testing
- npm run build *(fails: repository already contains TypeScript errors in App.tsx and RangeBidDialog test data)*

------
https://chatgpt.com/codex/tasks/task_e_68defcc57f308327b5d96286dc34fd72