### PR TITLE
Introduce API auth context and integrate token UX

### DIFF
--- a/src/Analytics.tsx
+++ b/src/Analytics.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { Bar, Line } from "react-chartjs-2";
-import { authFetch, setToken } from "./utils/api";
+import { authFetch } from "./utils/api";
+import { useApiAuth, useApiTokenPrompt } from "./state/apiAuth";
 import {
   Chart,
   CategoryScale,
@@ -45,12 +46,8 @@ export default function Analytics() {
   });
 
   const controllerRef = useRef<AbortController | null>(null);
-
-  const promptForToken = useCallback(() => {
-    const token = window.prompt("Enter API token");
-    if (token) setToken(token);
-    return token;
-  }, []);
+  const { waitForValidToken } = useApiAuth();
+  const promptForToken = useApiTokenPrompt();
 
   const clampOvertimeThreshold = useCallback((value: number) => {
     return Math.min(24, Math.max(0, Math.round(value)));
@@ -83,10 +80,14 @@ export default function Analytics() {
           return;
         }
         if (err.status === 401) {
-          if (promptForToken()) {
-            continue;
+          await waitForValidToken();
+          if (controller.signal.aborted) {
+            setLoading(false);
+            controllerRef.current = null;
+            return;
           }
-          err = new Error("Unauthorized");
+          attempt = -1;
+          continue;
         }
         if (attempt < maxRetries - 1) {
           const delay = 500 * 2 ** attempt;
@@ -97,35 +98,35 @@ export default function Analytics() {
         }
       }
     }
-  }, [overtimeThreshold, promptForToken]);
+  }, [overtimeThreshold, waitForValidToken]);
 
-  const handleExport = async (format: string) => {
-    try {
-      const params = new URLSearchParams({
-        format,
-        overtimeThreshold: String(overtimeThreshold),
-      });
-      const response = await authFetch(`/api/analytics/export?${params}`);
-      const blob = await response.blob();
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `analytics.${format}`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      URL.revokeObjectURL(url);
-    } catch (err: any) {
-      if (err.status === 401) {
-        if (promptForToken()) {
+  const handleExport = useCallback(
+    async (format: string) => {
+      try {
+        const params = new URLSearchParams({
+          format,
+          overtimeThreshold: String(overtimeThreshold),
+        });
+        const response = await authFetch(`/api/analytics/export?${params}`);
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `analytics.${format}`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+      } catch (err: any) {
+        if (err.status === 401) {
+          await waitForValidToken();
           return handleExport(format);
         }
-        setError("Unauthorized");
-      } else {
         setError(err.message);
       }
-    }
-  };
+    },
+    [overtimeThreshold, waitForValidToken],
+  );
 
   useEffect(() => {
     if (typeof window !== "undefined") {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,7 @@ import useNotificationPrefs, {
 import type { DeadlineNotification } from "./types/notifications";
 import RangeBidDialog from "./components/RangeBidDialog";
 import { awardVacancyRange } from "./lib/vacancy-range-award";
+import { useApiAuth, useApiTokenPrompt } from "./state/apiAuth";
 
 /**
  * Maplewood Scheduler — Coverage-first (v2.3.0)
@@ -762,6 +763,40 @@ export default function App() {
   const [activeVacancyId, setActiveVacancyId] = useState<string | null>(null);
   const [showRangeForm, setShowRangeForm] = useState(false);
   const [activeRangeBid, setActiveRangeBid] = useState<VacancyRange | null>(null);
+  const { status: apiAuthStatus, message: apiAuthMessage } = useApiAuth();
+  const promptForApiToken = useApiTokenPrompt();
+  const authBanner = useMemo(() => {
+    if (apiAuthStatus === "ready") return null;
+    const color = apiAuthStatus === "error" ? "var(--bad, #b91c1c)" : "var(--accent, #0f766e)";
+    const background = apiAuthStatus === "error" ? "rgba(185, 28, 28, 0.12)" : "rgba(16, 185, 129, 0.12)";
+    const message =
+      apiAuthStatus === "missing"
+        ? "API token required. Provide a Maplewood API token to enable syncing."
+        : apiAuthMessage || "API token rejected. Please supply a valid token to continue.";
+    return (
+      <div
+        role="alert"
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          padding: "12px 16px",
+          marginBottom: 16,
+          borderRadius: 12,
+          border: `1px solid ${color}`,
+          background,
+          color,
+        }}
+      >
+        <span style={{ fontWeight: 600 }}>{message}</span>
+        <button className="btn" onClick={promptForApiToken} style={{ flexShrink: 0 }}>
+          Set API Token
+        </button>
+      </div>
+    );
+  }, [apiAuthMessage, apiAuthStatus, promptForApiToken]);
   // Modal system (confirm/prompt/alert)
   const [confirmState, setConfirmState] = useState<
     | { open: true; title: string; body: string; resolve: (ok: boolean) => void }
@@ -1731,6 +1766,8 @@ export default function App() {
             </Button>
           </div>
         </div>
+
+        {authBanner}
 
         <div className="tabs">
           {settings.tabOrder.map((k) => (

--- a/src/__tests__/apiAuth.test.tsx
+++ b/src/__tests__/apiAuth.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { ApiAuthProvider, useApiAuth } from "../state/apiAuth";
+import { authFetch } from "../utils/api";
+
+describe("ApiAuthProvider", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it("attaches the bearer token to authenticated requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useApiAuth(), { wrapper: ApiAuthProvider });
+
+    act(() => {
+      result.current.setToken("test-token");
+    });
+
+    await authFetch("/api/example");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const fetchInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = new Headers(fetchInit?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer test-token");
+  });
+
+  it("reports unauthorized responses through context", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("Unauthorized", { status: 401, headers: { "Content-Type": "text/plain" } }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useApiAuth(), { wrapper: ApiAuthProvider });
+
+    await expect(authFetch("/api/protected")).rejects.toThrowError();
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error");
+    });
+  });
+
+  it("waits for credentials before resolving", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "Content-Type": "application/json" } }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { result } = renderHook(() => useApiAuth(), { wrapper: ApiAuthProvider });
+
+    const waiter = result.current.waitForValidToken();
+    let resolvedValue: string | null = null;
+    waiter.then((value) => {
+      resolvedValue = value;
+    });
+
+    await Promise.resolve();
+    expect(resolvedValue).toBeNull();
+
+    act(() => {
+      result.current.setToken("retry-token");
+    });
+
+    await expect(waiter).resolves.toBe("retry-token");
+    expect(resolvedValue).toBe("retry-token");
+    expect(result.current.status).toBe("ready");
+  });
+});

--- a/src/components/OpenVacanciesRedesign.tsx
+++ b/src/components/OpenVacanciesRedesign.tsx
@@ -4,9 +4,10 @@ import { SHIFT_PRESETS } from "../types";
 import type { Recommendation } from "../recommend";
 import BundleRow from "./BundleRow";
 import VacancyRow from "./VacancyRow";
-import { combineDateTime } from "../lib/dates";
+import { combineDateTime, minutesBetween } from "../lib/dates";
 import SearchFilterBar from "./SearchFilterBar";
 import { useVacancyFilters } from "../hooks/useVacancyFilters";
+import { deadlineFor, pickWindowMinutes } from "../lib/vacancy";
 
 type Props = {
   vacancies: Vacancy[];
@@ -54,6 +55,8 @@ export default function OpenVacanciesRedesign(props: Props) {
     bundleMode,
     setBundleMode,
     resetFilters,
+    countdown,
+    setCountdown,
   } = useVacancyFilters();
   const employeesById = useMemo(() => {
     const map: Record<string, Employee> = {};
@@ -96,6 +99,18 @@ export default function OpenVacanciesRedesign(props: Props) {
           (v) => v.shiftStart === preset.start && v.shiftEnd === preset.end,
         );
     }
+    if (countdown) {
+      const now = Date.now();
+      list = list.filter((v) => {
+        const deadline = deadlineFor(v, settings);
+        const msLeft = deadline.getTime() - now;
+        const winMin = pickWindowMinutes(v, settings);
+        const sinceKnownMin = minutesBetween(new Date(), new Date(v.knownAt));
+        const pct = Math.max(0, Math.min(1, (winMin - sinceKnownMin) / winMin));
+        const status = msLeft <= 0 ? "red" : pct < 0.25 ? "yellow" : "green";
+        return status === countdown;
+      });
+    }
     if (start) list = list.filter((v) => v.shiftDate >= start);
     if (end) list = list.filter((v) => v.shiftDate <= end);
     if (filters?.wing) list = list.filter((v) => (v.wing || "") === filters!.wing);
@@ -112,11 +127,13 @@ export default function OpenVacanciesRedesign(props: Props) {
     selectedPositions,
     selectedWings,
     filterShift,
+    countdown,
     start,
     end,
     filters,
     vacNameById,
     bundleMode,
+    settings,
   ]);
 
   // Cross-day bundle groups so multi-day vacancies render as ONE row
@@ -179,12 +196,14 @@ export default function OpenVacanciesRedesign(props: Props) {
         selectedPositions={selectedPositions}
         selectedWings={selectedWings}
         shiftPreset={filterShift}
+        countdownFilter={countdown}
         onQueryChange={setSearch}
         onStartDateChange={setStart}
         onEndDateChange={setEnd}
         onPositionsChange={setSelectedPositions}
         onWingsChange={setSelectedWings}
         onShiftPresetChange={setFilterShift}
+        onCountdownChange={setCountdown}
         bundleMode={bundleMode}
         onBundleModeChange={(mode) => setBundleMode(mode)}
         onClear={resetFilters}

--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -34,7 +34,7 @@ function MultiSelectDropdown<T extends string>({
 
   return (
     <details className="filter-dropdown">
-      <summary aria-haspopup="listbox">
+      <summary role="button" aria-haspopup="listbox" tabIndex={0}>
         <span>{label}</span>
         {selected.length > 0 && (
           <span className="filter-dropdown__count" aria-live="polite">
@@ -78,6 +78,7 @@ interface Props {
   bundleMode: BundleMode;
   selectedWings: string[];
   shiftPreset?: string;
+  countdownFilter?: "" | "green" | "yellow" | "red";
   onQueryChange: (value: string) => void;
   onStartDateChange: (value: string) => void;
   onEndDateChange: (value: string) => void;
@@ -85,6 +86,7 @@ interface Props {
   onBundleModeChange: (value: BundleMode) => void;
   onWingsChange: (value: string[]) => void;
   onShiftPresetChange?: (value: string) => void;
+  onCountdownChange?: (value: "" | "green" | "yellow" | "red") => void;
   onClear?: () => void;
 }
 
@@ -96,6 +98,7 @@ export default function SearchFilterBar({
   bundleMode,
   selectedWings,
   shiftPreset = "",
+  countdownFilter = "",
   onQueryChange,
   onStartDateChange,
   onEndDateChange,
@@ -103,12 +106,14 @@ export default function SearchFilterBar({
   onBundleModeChange,
   onWingsChange,
   onShiftPresetChange,
+  onCountdownChange,
   onClear,
 }: Props) {
   const clear = () => {
     if (onClear) {
       onClear();
       onShiftPresetChange?.("");
+      onCountdownChange?.("");
       return;
     }
     onQueryChange("");
@@ -118,12 +123,22 @@ export default function SearchFilterBar({
     onBundleModeChange("all");
     onWingsChange([]);
     onShiftPresetChange?.("");
+    onCountdownChange?.("");
   };
 
   const toggleShiftPreset = (value: string) => {
     if (!onShiftPresetChange) return;
     if (shiftPreset === value) onShiftPresetChange("");
     else onShiftPresetChange(value);
+  };
+
+  const toggleCountdown = (value: "" | "green" | "yellow" | "red") => {
+    if (!onCountdownChange) return;
+    if (countdownFilter === value) {
+      onCountdownChange("");
+    } else {
+      onCountdownChange(value);
+    }
   };
 
   const toggleBundleMode = (value: BundleMode) => {
@@ -185,6 +200,19 @@ export default function SearchFilterBar({
       key: "bundle",
       label: bundleMode === "bundles" ? "Bundles only" : "Singles only",
       onRemove: () => onBundleModeChange("all"),
+    });
+  }
+  if (countdownFilter && onCountdownChange) {
+    const label =
+      countdownFilter === "red"
+        ? "Countdown: Red"
+        : countdownFilter === "yellow"
+        ? "Countdown: Yellow"
+        : "Countdown: Green";
+    activeFilters.push({
+      key: "countdown",
+      label,
+      onRemove: () => onCountdownChange(""),
     });
   }
 
@@ -275,6 +303,46 @@ export default function SearchFilterBar({
             </option>
           ))}
         </select>
+      )}
+      {onCountdownChange && (
+        <div className="chip-group" aria-label="Countdown filters">
+          <button
+            type="button"
+            className="pill pill-toggle"
+            data-active={countdownFilter === ""}
+            aria-pressed={countdownFilter === ""}
+            onClick={() => toggleCountdown("")}
+          >
+            All
+          </button>
+          <button
+            type="button"
+            className="pill pill-toggle"
+            data-active={countdownFilter === "red"}
+            aria-pressed={countdownFilter === "red"}
+            onClick={() => toggleCountdown("red")}
+          >
+            Red
+          </button>
+          <button
+            type="button"
+            className="pill pill-toggle"
+            data-active={countdownFilter === "yellow"}
+            aria-pressed={countdownFilter === "yellow"}
+            onClick={() => toggleCountdown("yellow")}
+          >
+            Yellow
+          </button>
+          <button
+            type="button"
+            className="pill pill-toggle"
+            data-active={countdownFilter === "green"}
+            aria-pressed={countdownFilter === "green"}
+            onClick={() => toggleCountdown("green")}
+          >
+            Green
+          </button>
+        </div>
       )}
       <div className="chip-group" aria-label="Bundle filters">
         <button

--- a/src/hooks/useDeadlineMonitor.ts
+++ b/src/hooks/useDeadlineMonitor.ts
@@ -15,7 +15,8 @@ import type {
   DeadlineEvent,
   DeadlineNotification,
 } from "../types/notifications";
-import { authFetch, getToken, getApiBaseUrl } from "../utils/api";
+import { authFetch, getApiBaseUrl } from "../utils/api";
+import { useApiAuth } from "../state/apiAuth";
 
 const isBrowser = typeof window !== "undefined";
 const isTestEnvironment =
@@ -118,6 +119,8 @@ export function useDeadlineMonitor({
   formatVacancy,
 }: DeadlineMonitorOptions) {
   const serverSyncEnabled = isBrowser && !isTestEnvironment;
+  const { status: authStatus, token: authToken, reportError: dispatchAuthError, waitForValidToken } =
+    useApiAuth();
   const [notifications, setNotifications] = useState<DeadlineNotification[]>([]);
   const notificationsRef = useRef(new Map<string, DeadlineNotification>());
   const triggeredRef = useRef(new Map<string, string>());
@@ -205,12 +208,18 @@ export function useDeadlineMonitor({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ events }),
       });
-    } catch (error) {
+    } catch (error: any) {
       console.warn("Failed to sync deadline events", error);
       pendingRef.current.unshift(...events);
+      if (error?.status === 401) {
+        dispatchAuthError(error?.message ?? "Unauthorized");
+        await waitForValidToken();
+        if (!serverSyncEnabled) return;
+        return flushPending();
+      }
       throw error;
     }
-  }, [apiBase, serverSyncEnabled]);
+  }, [apiBase, serverSyncEnabled, dispatchAuthError, waitForValidToken]);
 
   const scheduleFlush = useCallback(
     (delayMs: number) => {
@@ -365,29 +374,46 @@ export function useDeadlineMonitor({
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let controller: AbortController | null = null;
 
-    const scheduleReconnect = () => {
-      if (cancelled) return;
-      if (retryTimer) return;
-      retryTimer = setTimeout(() => {
-        retryTimer = null;
-        if (!cancelled) connect();
-      }, 5_000);
-    };
-
     const handleEvent = (event: DeadlineEvent) => {
       const compositeKey = `${event.vacancyId}:${event.leadTimeId}`;
       triggeredRef.current.set(compositeKey, event.id);
       upsertNotification(event);
     };
 
+    function scheduleReconnect(delay = 5_000) {
+      if (cancelled || retryTimer) return;
+      retryTimer = setTimeout(async () => {
+        retryTimer = null;
+        if (cancelled) return;
+        if (authStatus !== "ready" || !authToken) {
+          await waitForValidToken();
+          if (cancelled) return;
+        }
+        connect();
+      }, delay);
+    }
+
     const connect = async () => {
       controller = new AbortController();
       try {
-        const token = getToken();
+        let tokenForRequest = authToken;
+        if (!tokenForRequest || authStatus !== "ready") {
+          tokenForRequest = await waitForValidToken();
+          if (cancelled) return;
+        }
         const response = await fetch(resolveApiUrl("/api/deadlines/stream"), {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+          headers: tokenForRequest ? { Authorization: `Bearer ${tokenForRequest}` } : undefined,
           signal: controller.signal,
         });
+        if (response.status === 401) {
+          dispatchAuthError("Unauthorized");
+          controller?.abort();
+          if (!cancelled) {
+            await waitForValidToken();
+            if (!cancelled) connect();
+          }
+          return;
+        }
         if (!response.ok) {
           throw new Error(`Stream failed with status ${response.status}`);
         }
@@ -435,7 +461,15 @@ export function useDeadlineMonitor({
         retryTimer = null;
       }
     };
-  }, [apiBase, serverSyncEnabled, upsertNotification]);
+  }, [
+    authStatus,
+    authToken,
+    serverSyncEnabled,
+    upsertNotification,
+    waitForValidToken,
+    dispatchAuthError,
+    resolveApiUrl,
+  ]);
 
   const latestNotification = useMemo(() => {
     return notifications.find((n) => !n.read) ?? null;

--- a/src/hooks/useVacancyFilters.test.ts
+++ b/src/hooks/useVacancyFilters.test.ts
@@ -65,6 +65,7 @@ describe("useVacancyFilters localStorage integration", () => {
     expect(result.current.end).toBe(snapshot.end);
     expect(result.current.search).toBe(snapshot.search);
     expect(result.current.bundleMode).toBe(snapshot.bundleMode);
+    expect(result.current.countdown).toBe(snapshot.countdown ?? "");
   });
 
   it("persists changes when filters update", async () => {
@@ -91,6 +92,7 @@ describe("useVacancyFilters localStorage integration", () => {
           end: "2024-02-14",
           search: "evening",
           bundleMode: "singles",
+          countdown: "",
         }),
       );
     });

--- a/src/hooks/useVacancyFilters.ts
+++ b/src/hooks/useVacancyFilters.ts
@@ -15,6 +15,7 @@ const DEFAULT_FILTERS: VacancyFilterSnapshot = {
   end: "",
   search: "",
   bundleMode: "all",
+  countdown: "",
 };
 
 export function useVacancyFilters() {
@@ -38,6 +39,9 @@ export function useVacancyFilters() {
   const [bundleMode, setBundleMode] = useState<"all" | "bundles" | "singles">(
     () => persistedFilters?.bundleMode ?? DEFAULT_FILTERS.bundleMode,
   );
+  const [countdown, setCountdown] = useState<VacancyFilterSnapshot["countdown"]>(
+    () => persistedFilters?.countdown ?? DEFAULT_FILTERS.countdown,
+  );
   const [filtersOpen, setFiltersOpen] = useState(false);
   const skipNextPersistRef = useRef(false);
 
@@ -54,6 +58,7 @@ export function useVacancyFilters() {
       end,
       search,
       bundleMode,
+      countdown,
     };
     saveVacancyFilters(snapshot);
   }, [
@@ -64,6 +69,7 @@ export function useVacancyFilters() {
     end,
     search,
     bundleMode,
+    countdown,
   ]);
 
   const resetFilters = () => {
@@ -75,6 +81,7 @@ export function useVacancyFilters() {
     setEnd(DEFAULT_FILTERS.end);
     setSearch(DEFAULT_FILTERS.search);
     setBundleMode(DEFAULT_FILTERS.bundleMode);
+    setCountdown(DEFAULT_FILTERS.countdown);
     clearVacancyFilters();
   };
 
@@ -93,6 +100,8 @@ export function useVacancyFilters() {
     setSearch,
     bundleMode,
     setBundleMode,
+    countdown,
+    setCountdown,
     filtersOpen,
     setFiltersOpen,
     resetFilters,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import AnalyticsPage from "./Analytics";
 import Dashboard from "./Dashboard";
 import AuditLog from "./AuditLog";
 import { ThemeProvider, Theme } from "./theme";
+import { ApiAuthProvider } from "./state/apiAuth";
 import { Analytics } from "./components/Analytics";
 import "./styles/theme.css";
 import "./styles/responsive.css";
@@ -34,16 +35,18 @@ const shouldLoadAnalytics = Boolean(isProduction && !isPreview && token);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <ThemeProvider initialTheme={initialTheme}>
-      {shouldLoadAnalytics && <Analytics token={token} />}
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<App />} />
-          <Route path="/analytics" element={<AnalyticsPage />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/audit-log" element={<AuditLog />} />
-        </Routes>
-      </BrowserRouter>
-    </ThemeProvider>
+    <ApiAuthProvider>
+      <ThemeProvider initialTheme={initialTheme}>
+        {shouldLoadAnalytics && <Analytics token={token} />}
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<App />} />
+            <Route path="/analytics" element={<AnalyticsPage />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/audit-log" element={<AuditLog />} />
+          </Routes>
+        </BrowserRouter>
+      </ThemeProvider>
+    </ApiAuthProvider>
   </React.StrictMode>,
 );

--- a/src/state/apiAuth.tsx
+++ b/src/state/apiAuth.tsx
@@ -1,0 +1,171 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export const TOKEN_STORAGE_KEY = "apiToken" as const;
+
+type ApiAuthStatus = "ready" | "missing" | "error";
+
+type ApiAuthState = {
+  token: string | null;
+  status: ApiAuthStatus;
+  message: string | null;
+};
+
+type ApiAuthContextValue = {
+  token: string | null;
+  status: ApiAuthStatus;
+  message: string | null;
+  setToken: (token: string | null) => void;
+  clearToken: () => void;
+  reportError: (message?: string | null) => void;
+  waitForValidToken: () => Promise<string>;
+};
+
+type ApiAuthExternalController = {
+  getToken: () => string | null;
+  getStatus: () => ApiAuthStatus;
+  reportAuthError: (message?: string | null) => void;
+  waitForValidToken: () => Promise<string>;
+};
+
+let externalController: ApiAuthExternalController | null = null;
+
+export function getApiAuthExternalController() {
+  return externalController;
+}
+
+function setApiAuthExternalController(controller: ApiAuthExternalController | null) {
+  externalController = controller;
+}
+
+function readInitialToken(): string | null {
+  if (typeof window !== "undefined") {
+    const stored = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (stored) return stored;
+  }
+  const metaEnv = (import.meta as unknown as { env?: Record<string, string | undefined> }).env;
+  const envToken = (metaEnv?.VITE_API_TOKEN ?? "").trim();
+  return envToken || null;
+}
+
+const ApiAuthContext = createContext<ApiAuthContextValue | null>(null);
+
+export function ApiAuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<ApiAuthState>(() => {
+    const token = readInitialToken();
+    return {
+      token,
+      status: token ? "ready" : "missing",
+      message: null,
+    };
+  });
+  const stateRef = useRef(state);
+  const waitersRef = useRef<((token: string) => void)[]>([]);
+
+  useEffect(() => {
+    stateRef.current = state;
+    if (state.status === "ready" && state.token) {
+      const resolvers = waitersRef.current.splice(0, waitersRef.current.length);
+      for (const resolve of resolvers) {
+        resolve(state.token);
+      }
+    }
+  }, [state]);
+
+  const setToken = useCallback((token: string | null) => {
+    const normalized = token?.trim() || null;
+    if (typeof window !== "undefined") {
+      if (normalized) {
+        window.localStorage.setItem(TOKEN_STORAGE_KEY, normalized);
+      } else {
+        window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+      }
+    }
+    setState({
+      token: normalized,
+      status: normalized ? "ready" : "missing",
+      message: null,
+    });
+  }, []);
+
+  const clearToken = useCallback(() => {
+    setToken(null);
+  }, [setToken]);
+
+  const reportError = useCallback((message?: string | null) => {
+    setState((prev) => ({
+      token: prev.token,
+      status: "error",
+      message: typeof message === "string" ? message : prev.message,
+    }));
+  }, []);
+
+  const waitForValidToken = useCallback(() => {
+    const snapshot = stateRef.current;
+    if (snapshot.status === "ready" && snapshot.token) {
+      return Promise.resolve(snapshot.token);
+    }
+    return new Promise<string>((resolve) => {
+      waitersRef.current.push(resolve);
+    });
+  }, []);
+
+  useEffect(() => {
+    setApiAuthExternalController({
+      getToken: () => stateRef.current.token,
+      getStatus: () => stateRef.current.status,
+      reportAuthError: (message?: string | null) => {
+        reportError(message);
+      },
+      waitForValidToken,
+    });
+    return () => setApiAuthExternalController(null);
+  }, [reportError, waitForValidToken]);
+
+  const value = useMemo<ApiAuthContextValue>(
+    () => ({
+      token: state.token,
+      status: state.status,
+      message: state.message,
+      setToken,
+      clearToken,
+      reportError,
+      waitForValidToken,
+    }),
+    [state, setToken, clearToken, reportError, waitForValidToken],
+  );
+
+  return <ApiAuthContext.Provider value={value}>{children}</ApiAuthContext.Provider>;
+}
+
+export function useApiAuth() {
+  const context = useContext(ApiAuthContext);
+  if (!context) {
+    throw new Error("useApiAuth must be used within an ApiAuthProvider");
+  }
+  return context;
+}
+
+export function useApiTokenPrompt(message = "Enter API token") {
+  const { setToken } = useApiAuth();
+  return useCallback(() => {
+    if (typeof window === "undefined") return null;
+    const input = window.prompt(message);
+    const normalized = input?.trim();
+    if (normalized) {
+      setToken(normalized);
+      return normalized;
+    }
+    return null;
+  }, [setToken, message]);
+}
+
+export type { ApiAuthStatus };

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,24 +1,4 @@
-export const TOKEN_KEY = "apiToken";
-
-export function getToken(): string | null {
-  // Prefer token from localStorage if available
-  if (typeof window !== "undefined") {
-    const stored = window.localStorage.getItem(TOKEN_KEY);
-    if (stored) return stored;
-  }
-  // Fallback to environment variable
-  const metaEnv = (import.meta as unknown as {
-    env?: Record<string, string | undefined>;
-  }).env;
-  const envToken = (metaEnv?.VITE_API_TOKEN ?? "").trim();
-  return envToken || null;
-}
-
-export function setToken(token: string) {
-  if (typeof window !== "undefined") {
-    window.localStorage.setItem(TOKEN_KEY, token);
-  }
-}
+import { getApiAuthExternalController, TOKEN_STORAGE_KEY } from "../state/apiAuth";
 
 export function getApiBaseUrl(): string {
   const metaEnv = (import.meta as unknown as {
@@ -27,6 +7,18 @@ export function getApiBaseUrl(): string {
   const raw = (metaEnv?.VITE_API_BASE_URL ?? "").trim();
   if (!raw) return "";
   return raw.replace(/\/$/, "");
+}
+
+function getFallbackToken(): string | null {
+  if (typeof window !== "undefined") {
+    const stored = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (stored) return stored;
+  }
+  const metaEnv = (import.meta as unknown as {
+    env?: Record<string, string | undefined>;
+  }).env;
+  const envToken = (metaEnv?.VITE_API_TOKEN ?? "").trim();
+  return envToken || null;
 }
 
 function resolveRequestInput(input: RequestInfo | URL): RequestInfo | URL {
@@ -51,12 +43,16 @@ function resolveRequestInput(input: RequestInfo | URL): RequestInfo | URL {
 
 export async function authFetch(input: RequestInfo, init: RequestInit = {}) {
   const resolvedInput = resolveRequestInput(input);
-  const token = getToken();
+  const authController = getApiAuthExternalController();
+  const token = authController?.getToken() ?? getFallbackToken();
   const headers = new Headers(init.headers);
   if (token) {
     headers.set("Authorization", `Bearer ${token}`);
   }
   const response = await fetch(resolvedInput, { ...init, headers });
+  if (response.status === 401) {
+    authController?.reportAuthError();
+  }
   if (!response.ok) {
     let message = `Request failed with status ${response.status}`;
     try {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -22,6 +22,7 @@ export type VacancyFilterSnapshot = {
   end: string;
   search: string;
   bundleMode: "all" | "bundles" | "singles";
+  countdown: "" | "green" | "yellow" | "red";
 };
 
 export type StoredVacancyFilters = Partial<VacancyFilterSnapshot> | null;

--- a/tests/analytics.test.tsx
+++ b/tests/analytics.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { render, screen, waitFor } from "@testing-library/react";
-import { vi, expect, test, afterEach } from "vitest";
+import { vi, expect, test, afterEach, beforeEach } from "vitest";
 import Analytics from "../src/Analytics";
+import { ApiAuthProvider } from "../src/state/apiAuth";
 import { minutesBetween } from "../src/lib/dates";
 
 // Mock chart components to avoid canvas requirement
@@ -12,8 +13,13 @@ vi.mock("react-chartjs-2", () => ({
 
 const originalFetch = global.fetch;
 
+beforeEach(() => {
+  localStorage.setItem("apiToken", "test-token");
+});
+
 afterEach(() => {
   global.fetch = originalFetch;
+  localStorage.clear();
 });
 
 test("loading indicator disappears after fetch abort", async () => {
@@ -21,7 +27,11 @@ test("loading indicator disappears after fetch abort", async () => {
     Promise.reject(Object.assign(new Error("Aborted"), { name: "AbortError" })),
   ) as any;
 
-  render(<Analytics />);
+  render(
+    <ApiAuthProvider>
+      <Analytics />
+    </ApiAuthProvider>,
+  );
 
   await waitFor(() => {
     expect(screen.queryByText("Loading...")).toBeNull();

--- a/tests/analyticsOvertimeThreshold.test.tsx
+++ b/tests/analyticsOvertimeThreshold.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterAll, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 
 const mockAuthFetch = vi.fn();
 
@@ -16,6 +16,7 @@ vi.mock("react-chartjs-2", () => ({
 
 // Import after mocks so they take effect.
 import Analytics from "../src/Analytics";
+import { ApiAuthProvider } from "../src/state/apiAuth";
 
 const originalCreateObjectURL = URL.createObjectURL;
 const originalRevokeObjectURL = URL.revokeObjectURL;
@@ -47,10 +48,19 @@ beforeEach(() => {
       json: async () => [],
     });
   });
+  localStorage.setItem("apiToken", "test-token");
+});
+
+afterEach(() => {
+  localStorage.clear();
 });
 
 test("forwards overtimeThreshold to analytics requests", async () => {
-  render(<Analytics />);
+  render(
+    <ApiAuthProvider>
+      <Analytics />
+    </ApiAuthProvider>,
+  );
 
   await waitFor(() => expect(mockAuthFetch).toHaveBeenCalledTimes(1));
   expect(mockAuthFetch.mock.calls[0][0]).toContain("overtimeThreshold=8");

--- a/tests/awardBundle.test.tsx
+++ b/tests/awardBundle.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import App from "../src/App";
+import { ApiAuthProvider } from "../src/state/apiAuth";
 
 const LS_KEY = "maplewood-scheduler-v3";
 
@@ -22,6 +23,10 @@ const baseState = {
   bids: [],
   settings: {},
 };
+
+beforeEach(() => {
+  localStorage.setItem("apiToken", "test-token");
+});
 
 afterEach(() => {
   localStorage.clear();
@@ -74,9 +79,11 @@ describe("bundle award", () => {
     );
 
     render(
-      <MemoryRouter>
-        <App />
-      </MemoryRouter>,
+      <ApiAuthProvider>
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>
+      </ApiAuthProvider>,
     );
 
     const awardBtn = await screen.findByText("Award Bundle");
@@ -167,9 +174,11 @@ describe("bundle award", () => {
     );
 
     render(
-      <MemoryRouter>
-        <App />
-      </MemoryRouter>,
+      <ApiAuthProvider>
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>
+      </ApiAuthProvider>,
     );
 
     const awardBtn = await screen.findByText("Award Bundle");

--- a/tests/awardVacancy.test.tsx
+++ b/tests/awardVacancy.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import App, { OVERRIDE_REASONS } from "../src/App";
+import { ApiAuthProvider } from "../src/state/apiAuth";
 
 const LS_KEY = "maplewood-scheduler-v3";
 
@@ -15,6 +16,10 @@ const baseState = {
   bids: [],
   settings: {},
 };
+
+beforeEach(() => {
+  localStorage.setItem("apiToken", "test-token");
+});
 
 afterEach(() => {
   localStorage.clear();
@@ -63,9 +68,11 @@ describe("award vacancy UI", () => {
     );
 
     render(
-      <MemoryRouter>
-        <App />
-      </MemoryRouter>,
+      <ApiAuthProvider>
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>
+      </ApiAuthProvider>,
     );
 
     const rows = screen
@@ -134,9 +141,11 @@ describe("award vacancy UI", () => {
     const alertMock = vi.spyOn(window, "alert").mockImplementation(() => {});
 
     render(
-      <MemoryRouter>
-        <App />
-      </MemoryRouter>,
+      <ApiAuthProvider>
+        <MemoryRouter>
+          <App />
+        </MemoryRouter>
+      </ApiAuthProvider>,
     );
 
     const row = screen

--- a/tests/multiDayCheckbox.test.tsx
+++ b/tests/multiDayCheckbox.test.tsx
@@ -1,14 +1,21 @@
 // @vitest-environment jsdom
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { expect, test } from "vitest";
+import { beforeEach, expect, test } from "vitest";
 import App from "../src/App";
+import { ApiAuthProvider } from "../src/state/apiAuth";
+
+beforeEach(() => {
+  localStorage.setItem("apiToken", "test-token");
+});
 
 test("multi-day toggle switches between single and range date fields", () => {
   render(
-    <MemoryRouter>
-      <App />
-    </MemoryRouter>,
+    <ApiAuthProvider>
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    </ApiAuthProvider>,
   );
   const dateInput = screen.getByLabelText("Date") as HTMLInputElement;
   fireEvent.change(dateInput, { target: { value: "2024-08-01" } });

--- a/tests/searchFiltering.test.tsx
+++ b/tests/searchFiltering.test.tsx
@@ -93,6 +93,7 @@ function renderComponent() {
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2024-01-01T12:00:00.000Z"));
+  localStorage.removeItem("openVacancyFilters");
 });
 
 afterEach(() => {
@@ -112,8 +113,9 @@ describe("OpenVacanciesRedesign filters", () => {
 
   it("filters by category", () => {
     renderComponent();
-    const select = screen.getByRole("combobox", { name: "Classification filter" });
-    fireEvent.change(select, { target: { value: "RN" } });
+    const dropdown = screen.getByRole("button", { name: "Classifications" });
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole("option", { name: "RN" }));
     const table = screen.getByRole("table");
     expect(within(table).getByText("Shamrock")).toBeTruthy();
     expect(within(table).getByText("Bluebell")).toBeTruthy();
@@ -135,7 +137,9 @@ describe("OpenVacanciesRedesign filters", () => {
 
   it("filters by wing", () => {
     renderComponent();
-    fireEvent.click(screen.getByRole("button", { name: "Rosewood" }));
+    const dropdown = screen.getByRole("button", { name: "Wings" });
+    fireEvent.click(dropdown);
+    fireEvent.click(screen.getByRole("option", { name: "Rosewood" }));
     const table = screen.getByRole("table");
     expect(within(table).getByText("Rosewood")).toBeTruthy();
     expect(within(table).queryByText("Shamrock")).toBeNull();


### PR DESCRIPTION
## Summary
- add a shared ApiAuthProvider with token persistence, status tracking, and prompt helpers
- wire the provider into analytics, deadline monitoring, and the app shell to surface auth errors and wait for credentials before retrying
- extend vacancy filters with countdown chips, store the selection, and refresh the affected tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68def710a2f88327acdffdabf2a0990d