### PR TITLE
Refine vacancy and bundle row layout classes

### DIFF
--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -117,7 +117,7 @@ export default function BundleRow({
         />
         <CellDetails
           title={
-            <div style={{ fontWeight: 600, display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <div className="vacancy-stack bundle-row__headline">
               <span className="pill">{items.length} days</span>
               <span className="pill" title="First day">{formatDateLong(primary.shiftDate)}</span>
               <span>
@@ -127,19 +127,12 @@ export default function BundleRow({
             </div>
           }
           subtitle={
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                flexWrap: "wrap",
-              }}
-            >
+            <div className="vacancy-stack bundle-row__subtitle">
               <span className="subtitle">{rangeLabel}</span>
             </div>
           }
           rightTag={
-            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <div className="vacancy-stack bundle-row__tagline">
               {recId ? (
                 <button
                   type="button"
@@ -156,11 +149,10 @@ export default function BundleRow({
                 <span className="subtitle">—</span>
               )}
               {hasCandidates && candidates.length > 1 && (
-                <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                <div className="vacancy-row__pager">
                   <button
                     type="button"
                     className="btn btn-sm"
-                    style={{ padding: "2px 6px" }}
                     onClick={() => cycle(-1)}
                     aria-label="Previous bundle recommendation"
                   >
@@ -172,7 +164,6 @@ export default function BundleRow({
                   <button
                     type="button"
                     className="btn btn-sm"
-                    style={{ padding: "2px 6px" }}
                     onClick={() => cycle(1)}
                     aria-label="Next bundle recommendation"
                   >
@@ -259,21 +250,17 @@ export default function BundleRow({
           <td />
           <td colSpan={3}>
             <div className="bundle-expand">
-              {sorted.map((v, i) => (
-                <div
-                  key={v.id}
-                  style={{
-                    display: "flex",
-                    gap: 8,
-                    padding: "4px 0",
-                    borderTop: i === 0 ? undefined : "1px solid var(--stroke)",
-                  }}
-                >
-                  <div style={{ minWidth: 160 }}>{formatDateLong(v.shiftDate)}</div>
-                  <div style={{ minWidth: 100 }}>
+              {sorted.map((v) => (
+                <div key={v.id} className="bundle-expand__row">
+                  <div className="bundle-expand__cell bundle-expand__cell--date">
+                    {formatDateLong(v.shiftDate)}
+                  </div>
+                  <div className="bundle-expand__cell bundle-expand__cell--time">
                     {v.shiftStart}–{v.shiftEnd}
                   </div>
-                  <div style={{ minWidth: 100 }}>{v.wing ?? "-"}</div>
+                  <div className="bundle-expand__cell bundle-expand__cell--wing">
+                    {v.wing ?? "-"}
+                  </div>
                 </div>
               ))}
             </div>
@@ -314,14 +301,14 @@ function InlineEmployeePicker({
     [employees, q],
   );
   return (
-    <div className="dropdown">
+    <div className="dropdown vacancy-dropdown">
       <input
         placeholder={placeholder || "Type name…"}
         value={q}
         onChange={(e)=> setQ(e.target.value)}
         onFocus={()=>{}}
       />
-      <div className="menu" style={{ maxHeight: 240, overflow: "auto" }}>
+      <div className="menu vacancy-dropdown__menu">
         {list.map((e) => (
           <button
             type="button"
@@ -335,7 +322,9 @@ function InlineEmployeePicker({
             {e.firstName} {e.lastName}
           </button>
         ))}
-        {!list.length && <div className="item" style={{ opacity:.7 }}>No matches</div>}
+        {!list.length && (
+          <div className="item vacancy-dropdown__empty">No matches</div>
+        )}
       </div>
     </div>
   );

--- a/src/components/VacancyRow.tsx
+++ b/src/components/VacancyRow.tsx
@@ -163,9 +163,7 @@ export default function VacancyRow({
       <CellDetails
         component={cellComponent}
         title={
-          <div
-            style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
-          >
+          <div className="vacancy-stack vacancy-row__headline">
             <span>
               <span className="pill">{formatDowShort(v.shiftDate)}</span>{" "}
               {formatDateLong(v.shiftDate)} • {v.shiftStart}-{v.shiftEnd}
@@ -180,25 +178,22 @@ export default function VacancyRow({
           </div>
         }
         subtitle={
-          <div
-            style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}
-          >
+          <div className="vacancy-stack vacancy-row__meta">
             {v.wing && <span className="pill">{v.wing}</span>}
             <span className="pill">{v.classification}</span>
             <span className="pill">{v.offeringStep}</span>
           </div>
         }
         rightTag={
-          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <div className="vacancy-stack vacancy-row__tagline">
             <span className="subtitle truncate" title={recName}>
               {recName}
             </span>
             {hasCandidates && candidates.length > 1 && (
-              <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <div className="vacancy-row__pager">
                 <button
                   type="button"
                   className="btn btn-sm"
-                  style={{ padding: "2px 6px" }}
                   onClick={() => cycle(-1)}
                   aria-label="Previous recommendation"
                 >
@@ -210,7 +205,6 @@ export default function VacancyRow({
                 <button
                   type="button"
                   className="btn btn-sm"
-                  style={{ padding: "2px 6px" }}
                   onClick={() => cycle(1)}
                   aria-label="Next recommendation"
                 >
@@ -293,7 +287,7 @@ export default function VacancyRow({
                     setChoiceManual(true);
                   }}
                 />
-                <div style={{ whiteSpace: "nowrap" }}>
+                <div className="vacancy-row__toggle">
                   <input
                     id={`override-toggle-${v.id}`}
                     className="toggle-input"
@@ -369,7 +363,7 @@ function SelectEmployee({
     .slice(0, 50);
   const curr = employees.find((e) => e.id === value);
   return (
-    <div className="dropdown">
+    <div className="dropdown vacancy-dropdown">
       <input
         placeholder={curr ? `${curr.firstName} ${curr.lastName} (${curr.id})` : "Type name or ID…"}
         value={q}
@@ -380,7 +374,7 @@ function SelectEmployee({
         onFocus={() => setOpen(true)}
       />
       {open && (
-        <div className="menu" style={{ maxHeight: 320, overflow: "auto" }}>
+        <div className="menu vacancy-dropdown__menu vacancy-dropdown__menu--tall">
           {allowEmpty && (
             <div
               className="item"
@@ -404,12 +398,14 @@ function SelectEmployee({
               }}
             >
               {e.firstName} {e.lastName}{" "}
-              <span className="pill" style={{ marginLeft: 6 }}>
+              <span className="pill vacancy-dropdown__chip">
                 {e.classification} {e.status}
               </span>
             </div>
           ))}
-          {!list.length && <div className="item" style={{ opacity: 0.7 }}>No matches</div>}
+          {!list.length && (
+            <div className="item vacancy-dropdown__empty">No matches</div>
+          )}
         </div>
       )}
     </div>

--- a/src/styles/vacancies-redesign.css
+++ b/src/styles/vacancies-redesign.css
@@ -37,3 +37,27 @@ td.cell-actions { width:1%; text-align:right; padding:10px 12px; }
 .section-h { position:sticky; top:36px; z-index:1; background: var(--section-bg); padding:6px 12px; font-weight:600; color: var(--section-text); border-top:1px solid var(--table-row-border); border-bottom:1px solid var(--table-row-border); }
 .section-h__content { display:flex; align-items:center; justify-content:space-between; gap:12px; }
 .section-h__toggle { white-space:nowrap; }
+
+.vacancy-stack { display:flex; align-items:center; flex-wrap:wrap; gap:var(--space-2); }
+.vacancy-row__headline { font-weight:600; }
+.bundle-row__headline { font-weight:600; }
+.bundle-row__subtitle { gap:var(--space-2); }
+.vacancy-row__meta { gap:var(--space-2); }
+.vacancy-row__tagline, .bundle-row__tagline { gap:var(--space-2); }
+.vacancy-row__pager { display:flex; align-items:center; gap:var(--space-1); }
+.vacancy-row__pager .btn { padding:2px 6px; }
+.vacancy-row__toggle { white-space:nowrap; }
+
+.bundle-expand { display:grid; gap:var(--space-1); }
+.bundle-expand__row { display:grid; grid-template-columns:minmax(160px, 1fr) repeat(2, minmax(100px, max-content)); gap:var(--space-2); padding:var(--space-1) 0; }
+.bundle-expand__row + .bundle-expand__row { border-top:1px solid var(--stroke); }
+.bundle-expand__cell { min-width:0; }
+.bundle-expand__cell--date { min-width:160px; }
+.bundle-expand__cell--time, .bundle-expand__cell--wing { min-width:100px; }
+
+.vacancy-dropdown { width:100%; }
+.vacancy-dropdown input { width:100%; }
+.vacancy-dropdown__menu { max-height:240px; overflow:auto; }
+.vacancy-dropdown__menu--tall { max-height:320px; }
+.vacancy-dropdown__chip { margin-left:var(--space-1); }
+.vacancy-dropdown__empty { opacity:.7; cursor:default; }


### PR DESCRIPTION
## Summary
- replace inline flex styling in vacancy and bundle rows with shared utility classes
- add stack, dropdown, and bundle expansion helpers to the vacancies redesign stylesheet for consistent spacing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68defddfc0d883279b3a765e334a30c2