### PR TITLE
Polish picker focus states and dropdown helpers

### DIFF
--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -308,7 +308,7 @@ function InlineEmployeePicker({
         onChange={(e)=> setQ(e.target.value)}
         onFocus={()=>{}}
       />
-      <div className="menu vacancy-dropdown__menu">
+      <div className="menu vacancy-row__menu">
         {list.map((e) => (
           <button
             type="button"
@@ -323,7 +323,7 @@ function InlineEmployeePicker({
           </button>
         ))}
         {!list.length && (
-          <div className="item vacancy-dropdown__empty">No matches</div>
+          <div className="item dropdown__empty">No matches</div>
         )}
       </div>
     </div>

--- a/src/components/SearchFilterBar.tsx
+++ b/src/components/SearchFilterBar.tsx
@@ -35,7 +35,7 @@ function MultiSelectDropdown<T extends string>({
 
   return (
     <details className="filter-dropdown">
-      <summary aria-haspopup="listbox">
+      <summary className="filter-dropdown__summary" aria-haspopup="listbox">
         <span>{label}</span>
         {selected.length > 0 && (
           <span className="filter-dropdown__count" aria-live="polite">
@@ -266,6 +266,7 @@ export default function SearchFilterBar({
               <button
                 key={preset.label}
                 type="button"
+                className="segmented-option"
                 data-active={shiftPreset === preset.label}
                 aria-pressed={shiftPreset === preset.label}
                 onClick={() => toggleShiftPreset(preset.label)}
@@ -310,6 +311,7 @@ export default function SearchFilterBar({
         <div className="search-filter-bar__segmented-buttons">
           <button
             type="button"
+            className="segmented-option"
             data-active={bundleMode === "all"}
             aria-pressed={bundleMode === "all"}
             onClick={() => toggleBundleMode("all")}
@@ -318,6 +320,7 @@ export default function SearchFilterBar({
           </button>
           <button
             type="button"
+            className="segmented-option"
             data-active={bundleMode === "bundles"}
             aria-pressed={bundleMode === "bundles"}
             onClick={() => toggleBundleMode("bundles")}
@@ -326,6 +329,7 @@ export default function SearchFilterBar({
           </button>
           <button
             type="button"
+            className="segmented-option"
             data-active={bundleMode === "singles"}
             aria-pressed={bundleMode === "singles"}
             onClick={() => toggleBundleMode("singles")}

--- a/src/components/VacancyRow.tsx
+++ b/src/components/VacancyRow.tsx
@@ -374,7 +374,7 @@ function SelectEmployee({
         onFocus={() => setOpen(true)}
       />
       {open && (
-        <div className="menu vacancy-dropdown__menu vacancy-dropdown__menu--tall">
+        <div className="menu vacancy-row__menu">
           {allowEmpty && (
             <div
               className="item"
@@ -398,13 +398,13 @@ function SelectEmployee({
               }}
             >
               {e.firstName} {e.lastName}{" "}
-              <span className="pill vacancy-dropdown__chip">
+              <span className="pill vacancy-row__employee-pill">
                 {e.classification} {e.status}
               </span>
             </div>
           ))}
           {!list.length && (
-            <div className="item vacancy-dropdown__empty">No matches</div>
+            <div className="item dropdown__empty">No matches</div>
           )}
         </div>
       )}

--- a/src/styles/search-filter-bar.css
+++ b/src/styles/search-filter-bar.css
@@ -68,7 +68,7 @@
   gap: 6px;
 }
 
-.search-filter-bar__segmented-buttons button {
+.search-filter-bar__segmented-buttons .segmented-option {
   border-radius: 999px;
   border: 1px solid var(--stroke);
   background: var(--chipBg);
@@ -80,29 +80,24 @@
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.search-filter-bar__segmented-buttons button[data-active="true"] {
+.search-filter-bar__segmented-buttons .segmented-option[data-active="true"] {
   background: var(--brand);
   border-color: var(--brand);
   color: var(--button-text-on-brand);
   box-shadow: 0 4px 12px rgba(4, 120, 87, 0.25);
 }
 
-.search-filter-bar__segmented-buttons button:hover,
-.search-filter-bar__segmented-buttons button:focus-visible {
+.search-filter-bar__segmented-buttons .segmented-option:hover,
+.search-filter-bar__segmented-buttons .segmented-option:focus-visible {
   border-color: var(--brand);
   color: var(--brand);
   background: rgba(4, 120, 87, 0.12);
 }
 
-.search-filter-bar__segmented-buttons button[data-active="true"]:hover,
-.search-filter-bar__segmented-buttons button[data-active="true"]:focus-visible {
+.search-filter-bar__segmented-buttons .segmented-option[data-active="true"]:hover,
+.search-filter-bar__segmented-buttons .segmented-option[data-active="true"]:focus-visible {
   color: var(--button-text-on-brand);
   background: var(--brand);
-}
-
-.search-filter-bar__segmented-buttons button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(4, 120, 87, 0.2);
 }
 
 .search-filter-bar__action {
@@ -150,7 +145,7 @@
   width: 100%;
 }
 
-.filter-dropdown > summary {
+.filter-dropdown__summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -166,15 +161,15 @@
   list-style: none;
 }
 
-.filter-dropdown > summary::-webkit-details-marker {
+.filter-dropdown__summary::-webkit-details-marker {
   display: none;
 }
 
-.filter-dropdown > summary::marker {
+.filter-dropdown__summary::marker {
   display: none;
 }
 
-.filter-dropdown[open] > summary {
+.filter-dropdown[open] > .filter-dropdown__summary {
   border-color: var(--brand);
   box-shadow: 0 0 0 3px rgba(4, 120, 87, 0.18);
 }

--- a/src/styles/shared-ui.css
+++ b/src/styles/shared-ui.css
@@ -24,6 +24,12 @@
   transform: translateY(-1px);
 }
 
+.btn:focus-visible {
+  outline: 3px solid rgba(4, 120, 87, 0.4);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(4, 120, 87, 0.18);
+}
+
 .btn-sm {
   padding: 4px 8px;
   font-size: 12px;
@@ -42,6 +48,14 @@
   border-radius: 999px;
   font-size: 12px;
   font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.pill:focus-visible {
+  outline: 3px solid rgba(4, 120, 87, 0.4);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(4, 120, 87, 0.18);
 }
 
 .dropdown {
@@ -61,6 +75,18 @@
   overflow: auto;
 }
 
+.filter-dropdown__summary:focus-visible {
+  outline: 3px solid rgba(4, 120, 87, 0.35);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(4, 120, 87, 0.18);
+}
+
+.segmented-option:focus-visible {
+  outline: 3px solid rgba(4, 120, 87, 0.35);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(4, 120, 87, 0.18);
+}
+
 .item {
   padding: 8px 10px;
   cursor: pointer;
@@ -68,6 +94,12 @@
 
 .item:hover {
   background: rgba(4, 120, 87, 0.12);
+}
+
+.dropdown__empty {
+  color: var(--muted);
+  cursor: default;
+  pointer-events: none;
 }
 
 .btn-row {

--- a/src/styles/vacancies-redesign.css
+++ b/src/styles/vacancies-redesign.css
@@ -57,7 +57,6 @@ td.cell-actions { width:1%; text-align:right; padding:10px 12px; }
 
 .vacancy-dropdown { width:100%; }
 .vacancy-dropdown input { width:100%; }
-.vacancy-dropdown__menu { max-height:240px; overflow:auto; }
-.vacancy-dropdown__menu--tall { max-height:320px; }
-.vacancy-dropdown__chip { margin-left:var(--space-1); }
-.vacancy-dropdown__empty { opacity:.7; cursor:default; }
+.vacancy-row__menu { display:grid; gap:var(--space-1); padding:var(--space-1); max-height:320px; overflow:auto; min-width:min(360px, calc(100vw - 48px)); }
+.vacancy-row__menu .item { display:flex; align-items:center; gap:var(--space-2); border-radius:12px; width:100%; border:0; background:transparent; text-align:left; }
+.vacancy-row__employee-pill { margin-left:auto; font-size:11px; flex-shrink:0; }


### PR DESCRIPTION
## Summary
- add shared :focus-visible treatments for buttons, pills, segmented options, and filter dropdown summaries
- retheme vacancy employee dropdowns with the new vacancy-row__menu and vacancy-row__employee-pill helpers
- wire segmented controls and filter dropdowns to the new helper classes

## Testing
- npm run typecheck *(fails: existing App.tsx typing errors around SSF$DateCode and Map<Record> usage)*

------
https://chatgpt.com/codex/tasks/task_e_68deff49715c832795cb59d0fcce7fd1