### PR TITLE
Normalize Excel start dates before employee mapping

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -672,10 +672,11 @@ export async function parseFile(
     const sheet = workbook.Sheets[firstSheetName];
     if (!sheet) return [];
 
-    const rawRows = XLSX.utils.sheet_to_json<Record<string, unknown>>(
-      sheet,
-      EXCEL_SHEET_TO_JSON_OPTIONS,
-    );
+    const rawRows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+      ...EXCEL_SHEET_TO_JSON_OPTIONS,
+      cellDates: true,
+      raw: false,
+    });
 
     return rawRows.map((row) => normalizeExcelRowDates(row, XLSX));
   }

--- a/tests/employeeImportExcel.test.ts
+++ b/tests/employeeImportExcel.test.ts
@@ -28,6 +28,8 @@ describe("employee Excel import", () => {
     const rows = await parseFile(file);
     expect(rows).toHaveLength(1);
     expect(rows[0]["Start Date"]).toBe("2024-01-15");
+    expect(rows[0]["Start Date"]).not.toBeInstanceOf(Date);
+    expect(rows[0]["Start Date"]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 
     const employees = rows
       .map((row, index) => mapRowToEmployee(row, index))
@@ -37,6 +39,7 @@ describe("employee Excel import", () => {
 
     expect(employees).toHaveLength(1);
     expect(employees[0]?.startDate).toBe("2024-01-15");
+    expect(employees[0]?.startDate).not.toBeInstanceOf(Date);
     expect(employees[0]?.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });


### PR DESCRIPTION
## Summary
- ensure the Excel import requests date objects from `sheet_to_json` and normalizes them before mapping employees
- extend the Excel import vitest to confirm parsed rows and mapped employees expose ISO-formatted start dates

## Testing
- npm run test -- employeeImportExcel.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df1a28473483279a79ff717162e330