### PR TITLE
Memoize open vacancy filtering

### DIFF
--- a/src/components/OpenVacancies.tsx
+++ b/src/components/OpenVacancies.tsx
@@ -55,8 +55,12 @@ export default function OpenVacancies({
     );
   };
 
-  const openVacancies = vacancies.filter(
-    (v) => v.status !== "Filled" && v.status !== "Awarded",
+  const openVacancies = useMemo(
+    () =>
+      vacancies.filter(
+        (v) => v.status !== "Filled" && v.status !== "Awarded",
+      ),
+    [vacancies],
   );
 
   const filteredVacancies = useMemo(() => {


### PR DESCRIPTION
## Summary
- memoize the initial open vacancies filter so downstream filters reuse a stable array
- keep the filtered list memo dependent on the memoized open vacancies array

## Testing
- npm test -- tests/openVacancies.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dff713d8bc83278ffc2be26ab019dc