### PR TITLE
Fix employeesById memo to return record map

### DIFF
--- a/src/hooks/useSchedulerState.ts
+++ b/src/hooks/useSchedulerState.ts
@@ -58,10 +58,12 @@ export function useSchedulerState() {
     persisted?.vacancyRanges ?? [],
   );
 
-  const employeesById = useMemo(() => {
-    const m = new Map<string, Employee>();
-    for (const e of employees) m.set(e.id, e);
-    return m;
+  const employeesById = useMemo<Record<string, Employee>>(() => {
+    const map: Record<string, Employee> = {};
+    for (const employee of employees) {
+      map[employee.id] = employee;
+    }
+    return map;
   }, [employees]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- convert `useSchedulerState`'s `employeesById` memo back into a plain object to match record-based lookups

## Testing
- npm run typecheck *(fails: Module '"xlsx"' has no exported member 'SSF$DateCode'; Sheet2JSONOpts errors; RangeBidDialog Employee fixture missing activeLabel)*

------
https://chatgpt.com/codex/tasks/task_e_68dff9b83aa88327819e51d32085900a