### PR TITLE
Align range award handler signature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1161,9 +1161,9 @@ export default function App() {
     setBids((prev) => [...prev, bid]);
   };
 
-  const handleAwardRange = async (rangeId: string) => {
-    const range = vacancyRanges.find((r) => r.id === rangeId);
-    if (!range) return;
+  const handleAwardRange = async (range: VacancyRange) => {
+    const rangeId = range.id;
+    const currentRange = vacancyRanges.find((r) => r.id === rangeId) ?? range;
     const rangeBids = bids.filter((b) => b.vacancyId === rangeId);
     if (!rangeBids.length) {
       const ok = await showConfirm(
@@ -1172,7 +1172,7 @@ export default function App() {
       );
       if (!ok) return;
     }
-    const outcome = awardVacancyRange(range, rangeBids, employees);
+    const outcome = awardVacancyRange(currentRange, rangeBids, employees);
     if (outcome.vacancies.length) {
       setVacancies((prev) => [...outcome.vacancies, ...prev]);
     }


### PR DESCRIPTION
## Summary
- update the range award handler to accept a `VacancyRange` so it matches `CoverageRangesPanel`
- reuse the supplied range when awarding while still resolving the latest state entry when available

## Testing
- `npm run typecheck` *(fails: existing TypeScript errors in src/App.tsx and RangeBidDialog tests)*

------
https://chatgpt.com/codex/tasks/task_e_68dff9b96e2c832799e834e8b1977312