### PR TITLE
Add activeLabel to RangeBidDialog test employees

### DIFF
--- a/src/components/__tests__/RangeBidDialog.test.tsx
+++ b/src/components/__tests__/RangeBidDialog.test.tsx
@@ -13,6 +13,7 @@ describe("RangeBidDialog", () => {
       status: "FT",
       seniorityRank: 1,
       active: true,
+      activeLabel: "Active",
     },
     {
       id: "emp-2",
@@ -22,6 +23,7 @@ describe("RangeBidDialog", () => {
       status: "FT",
       seniorityRank: 2,
       active: true,
+      activeLabel: "Active",
     },
   ];
 


### PR DESCRIPTION
## Summary
- add the activeLabel field to each mocked Employee in the RangeBidDialog tests

## Testing
- npm run typecheck *(fails: existing errors in src/App.tsx about xlsx types and Map usage)*

------
https://chatgpt.com/codex/tasks/task_e_68dff9ba5a0c8327a88ccb7e52c11884