### PR TITLE
Rename coverage modal per-day wings prop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1388,7 +1388,7 @@ function SchedulerAppContent({
   const [coverage, setCoverage] = useState<{
     selectedDates?: string[];
     perDayTimes?: Record<string, { start: string; end: string }>;
-    perDayWing?: Record<string, string>;
+    perDayWings?: Record<string, string>;
   } | null>(null);
   const [awardAsBlock, setAwardAsBlock] = useState(true);
 
@@ -1453,7 +1453,7 @@ function SchedulerAppContent({
         : {}),
       reason: "Vacation Backfill",
       classification: vac.classification,
-      wing: coverage?.perDayWing?.[d] ?? v.wing!,
+      wing: coverage?.perDayWings?.[d] ?? v.wing!,
       date: d,
       start:
         coverage?.perDayTimes?.[d]?.start ??

--- a/src/components/CoverageDaysModal.tsx
+++ b/src/components/CoverageDaysModal.tsx
@@ -11,12 +11,12 @@ type Props = {
   initial?: {
     selectedDates?: string[];
     perDayTimes?: Record<string, Times>;
-    perDayWing?: Record<string, string>;
+    perDayWings?: Record<string, string>;
   };
   onSave: (payload: {
     selectedDates: string[];
     perDayTimes: Record<string, Times>;
-    perDayWing: Record<string, string>;
+    perDayWings: Record<string, string>;
   }) => void;
   onClose: () => void;
 };
@@ -130,9 +130,9 @@ export default function CoverageDaysModal({
     return t;
   });
 
-  const [perDayWing, setPerDayWing] = useState<Record<string, string>>(() => {
+  const [perDayWings, setPerDayWings] = useState<Record<string, string>>(() => {
     const w: Record<string, string> = {};
-    inRangeDates.forEach(d => { w[d] = initial?.perDayWing?.[d] ?? ""; });
+    inRangeDates.forEach(d => { w[d] = initial?.perDayWings?.[d] ?? ""; });
     return w;
   });
 
@@ -151,11 +151,11 @@ export default function CoverageDaysModal({
     });
 
     const nextWings: Record<string, string> = {};
-    inRangeDates.forEach(d => { nextWings[d] = initial?.perDayWing?.[d] ?? ""; });
+    inRangeDates.forEach(d => { nextWings[d] = initial?.perDayWings?.[d] ?? ""; });
 
     setSelected(prev => shallowEqualBooleanMap(prev, nextSelected) ? prev : nextSelected);
     setPerDayTimes(prev => shallowEqualTimesMap(prev, nextTimes) ? prev : nextTimes);
-    setPerDayWing(prev => shallowEqualStringMap(prev, nextWings) ? prev : nextWings);
+    setPerDayWings(prev => shallowEqualStringMap(prev, nextWings) ? prev : nextWings);
   }, [open, startDate, endDate, defaultStart, defaultEnd, initial, inRangeDates]);
 
   const toggle = (d: string) => {
@@ -197,7 +197,7 @@ export default function CoverageDaysModal({
     onSave({
       selectedDates: chosen,
       perDayTimes: Object.fromEntries(chosen.map(d => [d, perDayTimes[d]])),
-      perDayWing:  Object.fromEntries(chosen.map(d => [d, perDayWing[d] ?? ""])),
+      perDayWings: Object.fromEntries(chosen.map(d => [d, perDayWings[d] ?? ""])),
     });
   };
 
@@ -243,7 +243,7 @@ export default function CoverageDaysModal({
               <div>{formatShort(d)}</div>
               <input type="time" value={perDayTimes[d].start} onChange={(e) => setPerDayTimes(t => ({ ...t, [d]: { ...t[d], start: e.target.value } }))} />
               <input type="time" value={perDayTimes[d].end}   onChange={(e) => setPerDayTimes(t => ({ ...t, [d]: { ...t[d], end: e.target.value } }))} />
-              <input placeholder="Wing (optional)" value={perDayWing[d] ?? ""} onChange={(e) => setPerDayWing(w => ({ ...w, [d]: e.target.value }))} />
+              <input placeholder="Wing (optional)" value={perDayWings[d] ?? ""} onChange={(e) => setPerDayWings(w => ({ ...w, [d]: e.target.value }))} />
             </div>
           ))}
         </div>

--- a/src/components/VacancyRangeForm.tsx
+++ b/src/components/VacancyRangeForm.tsx
@@ -219,9 +219,9 @@ export default function VacancyRangeForm({
           initial={{
             selectedDates: workingDays,
             perDayTimes,
-            perDayWing: perDayWings,
+            perDayWings,
           }}
-          onSave={({ selectedDates, perDayTimes: times, perDayWing: wings }) => {
+          onSave={({ selectedDates, perDayTimes: times, perDayWings: wings }) => {
             setWorkingDays(selectedDates);
             setPerDayTimes(times);
             setPerDayWings(wings);

--- a/tests/coverageDaysModalRangeUpdate.test.tsx
+++ b/tests/coverageDaysModalRangeUpdate.test.tsx
@@ -20,7 +20,7 @@ describe("CoverageDaysModal", () => {
           perDayTimes: {
             "2024-01-10": { start: "09:00", end: "17:00" },
           },
-          perDayWing: {
+          perDayWings: {
             "2024-01-10": "West",
           },
         }}
@@ -43,7 +43,7 @@ describe("CoverageDaysModal", () => {
           perDayTimes: {
             "2024-01-11": { start: "09:00", end: "17:00" },
           },
-          perDayWing: {
+          perDayWings: {
             "2024-01-11": "West",
           },
         }}
@@ -65,12 +65,12 @@ describe("CoverageDaysModal", () => {
       "2024-01-11": { start: "09:00", end: "17:00" },
       "2024-01-12": { start: "08:00", end: "16:00" },
     });
-    expect(payload.perDayWing).toEqual({
+    expect(payload.perDayWings).toEqual({
       "2024-01-11": "West",
       "2024-01-12": "",
     });
     expect(payload.perDayTimes).not.toHaveProperty("2024-01-10");
-    expect(payload.perDayWing).not.toHaveProperty("2024-01-10");
+    expect(payload.perDayWings).not.toHaveProperty("2024-01-10");
   });
 });
 


### PR DESCRIPTION
## Summary
- rename the coverage modal per-day wing mapping prop and payload to the plural form
- update the app, vacancy range form, and related tests to use the new `perDayWings` naming

## Testing
- `npm run typecheck` *(fails: existing zod schema typing errors in src/schemas/schedulerState.ts and downstream type mismatches in src/store/schedulerStore.ts and src/utils/persistence.ts)*
- `npm run test -- coverageDaysModalRangeUpdate`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb98724848327a69505d8d50e3b7c)